### PR TITLE
Fix U2F browser support check

### DIFF
--- a/includes/Google/u2f-api.js
+++ b/includes/Google/u2f-api.js
@@ -20,7 +20,7 @@ var u2f = u2f || {};
  * Check if browser supports U2F API before this wrapper was added.
  * @type {int}
  */
-u2f.HasNativeApiSupport = ( ( u2f && u2f.register ) || ( chrome && chrome.runtime ) );
+u2f.HasNativeApiSupport = ( ( u2f && u2f.register ) || ( typeof chrome !== 'undefined' && chrome.runtime ) );
 
 /**
  * FIDO U2F Javascript API Version


### PR DESCRIPTION
On certain browsers that don't support U2F, it'll throw an error when trying to load the U2F js lib if `chrome` is not strictly undefined. I tried this on Epiphany, an open source browser, for example. I implemented a browser support check in my application based on this.

Additionally, but not covered by this PR, there is a Safari browser extension and helper app to implement U2F, but it won't work with this Wordpress plugin because it replaces the `u2f` object with its own. I suggest either moving the browser support check out of this file and into a different namespace, or waiting for a change to be made on the Safari extension to not replace the `u2f` object. I mentioned that here: https://github.com/Safari-FIDO-U2F/Safari-FIDO-U2F/issues/17

I don't actually use this plugin or Wordpress, so do with this what you will. 😄 