### PR TITLE
[WIP] Two Factor User Profile Shortcode

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -47,6 +47,9 @@ class Two_Factor_Core {
 		add_filter( 'manage_users_columns', array( __CLASS__, 'filter_manage_users_columns' ) );
 		add_filter( 'wpmu_users_columns', array( __CLASS__, 'filter_manage_users_columns' ) );
 		add_filter( 'manage_users_custom_column', array( __CLASS__, 'manage_users_custom_column' ), 10, 3 );
+
+		add_shortcode( 'two-factor-user-profile', array( __CLASS__, 'user_profile_shortcode' ) );
+		add_action( 'init', array( __CLASS__, 'user_profile_shortcode_save' ) );
 	}
 
 	/**
@@ -217,6 +220,39 @@ class Two_Factor_Core {
 	public static function is_user_using_two_factor( $user_id = null ) {
 		$provider = self::get_primary_provider_for_user( $user_id );
 		return ! empty( $provider );
+	}
+
+	/**
+	 * Render the user settings via shortcode.
+	 *
+	 * @param  array $args Shortcode arguments.
+	 *
+	 * @return void
+	 */
+	public static function user_profile_shortcode( $args ) {
+		// Only logged-in users can edit things.
+		if ( ! is_user_logged_in() ) {
+			return null;
+		}
+
+		$user = wp_get_current_user();
+
+		?>
+		<form method="post" class="two-factor-user-settings two-factor-user-settings-shortcode">
+			<?php self::user_two_factor_options( $user ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * Capture the front-end shortcode profile update.
+	 *
+	 * @return void
+	 */
+	public static function user_profile_shortcode_save() {
+		if ( is_user_logged_in() ) {
+			self::user_two_factor_options_update( get_current_user_id() );
+		}
 	}
 
 	/**

--- a/providers/class.two-factor-backup-codes.php
+++ b/providers/class.two-factor-backup-codes.php
@@ -23,20 +23,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	const NUMBER_OF_CODES = 10;
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class;
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class.two-factor-dummy.php
+++ b/providers/class.two-factor-dummy.php
@@ -9,20 +9,6 @@
 class Two_Factor_Dummy extends Two_Factor_Provider {
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class;
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -23,20 +23,6 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	const INPUT_NAME_RESEND_CODE = 'two-factor-email-code-resend';
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class;
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -24,7 +24,6 @@ class Two_Factor_FIDO_U2F_Admin {
 	 * @static
 	 */
 	public static function add_hooks() {
-		add_action( 'admin_enqueue_scripts',       array( __CLASS__, 'enqueue_assets' ) );
 		add_action( 'show_user_security_settings', array( __CLASS__, 'show_user_profile' ) );
 		add_action( 'personal_options_update',     array( __CLASS__, 'catch_submission' ), 0 );
 		add_action( 'edit_user_profile_update',    array( __CLASS__, 'catch_submission' ), 0 );
@@ -34,21 +33,13 @@ class Two_Factor_FIDO_U2F_Admin {
 	}
 
 	/**
-	 * Enqueue assets.
+	 * Enqueue scripts and styles required for the key management.
 	 *
-	 * @since 0.1-dev
+	 * @param  integer $user_id Current user ID.
 	 *
-	 * @access public
-	 * @static
-	 *
-	 * @param string $hook Current page.
+	 * @return void
 	 */
-	public static function enqueue_assets( $hook ) {
-		if ( ! in_array( $hook, array( 'user-edit.php', 'profile.php' ) ) ) {
-			return;
-		}
-
-		$user_id = get_current_user_id();
+	public static function enqueue_assets( $user_id ) {
 		$security_keys = Two_Factor_FIDO_U2F::get_security_keys( $user_id );
 
 		// @todo Ensure that scripts don't fail because of missing u2fL10n
@@ -141,6 +132,8 @@ class Two_Factor_FIDO_U2F_Admin {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function show_user_profile( $user ) {
+		self::enqueue_assets( $user->ID );
+
 		wp_nonce_field( "user_security_keys-{$user->ID}", '_nonce_user_security_keys' );
 		$new_key = false;
 

--- a/providers/class.two-factor-fido-u2f-admin.php
+++ b/providers/class.two-factor-fido-u2f-admin.php
@@ -39,7 +39,7 @@ class Two_Factor_FIDO_U2F_Admin {
 	 *
 	 * @return void
 	 */
-	public static function enqueue_assets( $user_id ) {
+	protected static function enqueue_assets( $user_id ) {
 		$security_keys = Two_Factor_FIDO_U2F::get_security_keys( $user_id );
 
 		// @todo Ensure that scripts don't fail because of missing u2fL10n

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -30,19 +30,8 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	const AUTH_DATA_USER_META_KEY = '_two_factor_fido_u2f_login_request';
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
 	 *
-	 * @return \Two_Factor_FIDO_U2F
 	 */
-	static function get_instance() {
-		static $instance;
-
-		if ( ! isset( $instance ) ) {
-			$instance = new self();
-		}
-
-		return $instance;
-	}
 
 	/**
 	 * Class constructor.

--- a/providers/class.two-factor-fido-u2f.php
+++ b/providers/class.two-factor-fido-u2f.php
@@ -192,21 +192,6 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Inserts markup at the end of the user profile field for this provider.
-	 *
-	 * @since 0.1-dev
-	 *
-	 * @param WP_User $user WP_User object of the logged-in user.
-	 */
-	public function user_options( $user ) {
-		?>
-		<p>
-			<?php esc_html_e( 'Requires an HTTPS connection. Configure your security keys in the "Security Keys" section below.', 'two-factor' ); ?>
-		</p>
-		<?php
-	}
-
-	/**
 	 * Add registered security key to a user.
 	 *
 	 * @since 0.1-dev

--- a/providers/class.two-factor-provider.php
+++ b/providers/class.two-factor-provider.php
@@ -18,6 +18,21 @@ abstract class Two_Factor_Provider {
 	}
 
 	/**
+	 * Return a singleton instance of the provider.
+	 *
+	 * @return Two_Factor_Provider
+	 */
+	public static function get_instance() {
+		static $instance;
+
+		if ( ! isset( $instance ) ) {
+			$instance = new static();
+		}
+
+		return $instance;
+	}
+
+	/**
 	 * Returns the name of the provider.
 	 *
 	 * @since 0.1-dev

--- a/providers/class.two-factor-provider.php
+++ b/providers/class.two-factor-provider.php
@@ -89,6 +89,10 @@ abstract class Two_Factor_Provider {
 	 */
 	abstract function is_available_for_user( $user );
 
+	public function render_user_settings( $user ) {}
+
+	public function save_user_settings( $user ) {}
+
 	/**
 	 * Generate a random eight-digit string to send out as an auth code.
 	 *

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -42,17 +42,6 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 */
-	public static function get_instance() {
-		static $instance;
-		if ( ! isset( $instance ) ) {
-			$instance = new self();
-		}
-		return $instance;
-	}
-
-	/**
 	 * Returns the name of the provider.
 	 */
 	public function get_label() {

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -102,16 +102,11 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		<?php
 	}
 
-	/**
-	 * Save the options specified in `::user_two_factor_options()`
-	 *
-	 * @param integer $user_id The user ID whose options are being updated.
-	 * @return false
-	 */
-	public function user_two_factor_options_update( $user_id ) {
+	public function save_user_settings( $user ) {
 		$notices = array();
 		$errors = array();
 
+		$user_id = $user->ID;
 		$current_key = $this->get_user_totp_key( $user_id );
 
 		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {


### PR DESCRIPTION
Fixes #247.

## Approach

- Abstract the profile settings away from WP core user profile.

- Introduce a shortcode for rendering the two-factor user settings.


## Known Issues

- `WP_List_Table` used for FIDO U2F settings doesn't work outside WP admin. 

        Fatal error: Uncaught Error: Call to undefined function convert_to_screen() in /srv/www/wordpress-default/wp-admin/includes/class-wp-list-table.php:132 Stack trace: #0 /srv/www/projects/plugins/two-factor/providers/class.two-factor-fido-u2f-admin.php(182): WP_List_Table->__construct() #1 /srv/www/wordpress-default/wp-includes/class-wp-hook.php(286): Two_Factor_FIDO_U2F_Admin::show_user_profile(Object(WP_User)) #2 /srv/www/wordpress-default/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array) #3 /srv/www/wordpress-default/wp-includes/plugin.php(453): WP_Hook->do_action(Array) #4 /srv/www/projects/plugins/two-factor/class.two-factor-core.php(748): do_action('show_user_secur...', Object(WP_User)) #5 /srv/www/projects/plugins/two-factor/class.two-factor-core.php(235): Two_Factor_Core::user_two_factor_options(Object(WP_User)) #6 /srv/www/wordpress-default/wp-includes/shortcodes.php(319): Two_Factor_Core::user_profile_shortcode('', '', 'two-factor-user...') #7 [internal function]: do_shortcode_tag(Array) #8 /sr in /srv/www/wordpress-default/wp-admin/includes/class-wp-list-table.php on line 132