### PR TITLE
Remove the submit action from the "Resend" button

### DIFF
--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -180,7 +180,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			<?php submit_button( __( 'Log In', 'two-factor' ) ); ?>
 		</p>
 		<p class="two-factor-email-resend">
-			<input type="submit" class="button" name="<?php echo esc_attr( self::INPUT_NAME_RESEND_CODE ); ?>" value="<?php esc_attr_e( 'Resend Code', 'two-factor' ); ?>" />
+			<input type="button" class="button" name="<?php echo esc_attr( self::INPUT_NAME_RESEND_CODE ); ?>" value="<?php esc_attr_e( 'Resend Code', 'two-factor' ); ?>" />
 		</p>
 		<script type="text/javascript">
 			setTimeout( function(){


### PR DESCRIPTION
When someone enters the OTP from email and hit <kbd>Return</kbd> a new OTP is generated and emailed instead of the form being submitted. This is happening because there are two `input`s in the form that are `submit`s. The _Resend_ should be a `button`.