### PR TITLE
Improve Jetpack SSO and Two Factor compatibility

### DIFF
--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -806,7 +806,11 @@ class Two_Factor_Core {
 			}
 		}
 	}
-
+	/**
+	 * Determine the rememberme value
+	 *
+	 * @return int - The rememberme value
+	 */
 	public static function rememberme() {
 
 		$rememberme = 0;

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -369,10 +369,7 @@ class Two_Factor_Core {
 		$backup_providers = array_diff_key( $available_providers, array( $provider_class => null ) );
 		$interim_login = isset( $_REQUEST['interim-login'] ); // WPCS: CSRF ok.
 
-		$rememberme = 0;
-		if ( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] ) {
-			$rememberme = 1;
-		}
+		$rememberme = self::rememberme();
 
 		if ( ! function_exists( 'login_header' ) ) {
 			// We really should migrate login_header() out of `wp-login.php` so it can be called from an includes file.
@@ -809,4 +806,25 @@ class Two_Factor_Core {
 			}
 		}
 	}
+
+	public static function rememberme() {
+
+		$rememberme = 0;
+
+		if (
+			( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] )
+			|| ( 
+				isset( $_GET['action'] )
+				&& 'jetpack-sso' === $_GET['action']
+				&& method_exists( 'Jetpack', 'is_module_active' ) 
+				&& Jetpack::is_module_active( 'sso' )
+			)
+		) {
+			$rememberme = 1;
+		}
+
+		return (int) apply_filters( 'two_factor_rememberme', $rememberme );
+
+	}
 }
+

--- a/class.two-factor-core.php
+++ b/class.two-factor-core.php
@@ -817,10 +817,10 @@ class Two_Factor_Core {
 
 		if (
 			( isset( $_REQUEST['rememberme'] ) && $_REQUEST['rememberme'] )
-			|| ( 
+			|| (
 				isset( $_GET['action'] )
 				&& 'jetpack-sso' === $_GET['action']
-				&& method_exists( 'Jetpack', 'is_module_active' ) 
+				&& method_exists( 'Jetpack', 'is_module_active' )
 				&& Jetpack::is_module_active( 'sso' )
 			)
 		) {


### PR DESCRIPTION
When a user clicks “Login with WordPress.com”, they’re [logged in with Jetpack](https://github.com/Automattic/jetpack/blob/792b26b5539d07cc35fdd93567942f2ad481eef2/modules/sso/class.jetpack-sso-helpers.php#L246-L257), and then [immediately logged out](https://github.com/WordPress/two-factor/blob/1354d5a5f77ee3d9ebad2266920f01920bde7cbe/class.two-factor-core.php#L238) for the 2FA authentication.

The issue is that Jetpack logs in using [`wp_set_auth_cookie`](https://github.com/Automattic/jetpack/blob/e783446cabd8214aaea261fa5176018b32d9476f/modules/sso.php#L769-L771) and sets the [cookie timeout to a year](https://github.com/Automattic/jetpack/blob/792b26b5539d07cc35fdd93567942f2ad481eef2/modules/sso/class.jetpack-sso-helpers.php#L246-L257), but Two-Factor does this all over again, the second time around - based on the `rememberme` value, which is 0 in the case of a WordPress.com authentication, so when an user provides the 2FA key, they’re logged in only for a day.

Users are logged out when the session cookie expires (differs based on browser, but usually when the browser is closed) because `rememberme` is set to 0 .

This patch makes sure that Jetpack is installed and the SSO module is active, if `jetpack-sso` is set as the login action, it's going to set the `rememberme` value to `1`.

In addition, I've added a filter `two_factor_rememberme` so that the rememberme value can be modified externally, potentially for other SSO Plugins.