### PR TITLE
Call an action when user is authenticated

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -645,7 +645,7 @@ class Two_Factor_Core {
 		}
 
 		wp_set_auth_cookie( $user->ID, $rememberme );
-		
+
 		do_action( 'two_factor_user_authenticated', $user );
 
 		// Must be global because that's how login_header() uses it.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -645,6 +645,8 @@ class Two_Factor_Core {
 		}
 
 		wp_set_auth_cookie( $user->ID, $rememberme );
+		
+		do_action( 'two_factor_user_authenticated', $user );
 
 		// Must be global because that's how login_header() uses it.
 		global $interim_login;

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,11 @@ Use the "Two-Factor Options" section under "Users" → "Your Profile" to enable 
 
 For more history, see [this post](https://stephanis.info/2013/08/14/two-cents-on-two-factor/).
 
+= Actions & Filters =
+
+Here is a list of action and filter hooks provided by the plugin:
+
+- `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 
 == Screenshots ==
 


### PR DESCRIPTION
We cannot determine when the user has been actually authenticated after the second factor.

We cannot hook into the `wp_login` nor `set_logged_in_cookie` as this plugin is hooking into this action to remove authentication cookie and present the second factor form.