### PR TITLE
Filter the enabled providers for a user

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -193,7 +193,7 @@ class Two_Factor_Core {
 		/**
 		 * Filter the available two-factor authentication providers for this user.
 		 *
-		 * @param string $providers The available providers.
+		 * @param array  $providers The available providers.
 		 * @param int    $user_id   The user ID.
 		 */
 		$enabled_providers = apply_filters( 'two_factor_available_providers_for_user', $enabled_providers, $user_id );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -190,6 +190,14 @@ class Two_Factor_Core {
 		$enabled_providers    = self::get_enabled_providers_for_user( $user );
 		$configured_providers = array();
 
+		/**
+		 * Filter the available two-factor authentication providers for this user.
+		 *
+		 * @param string $providers The available providers.
+		 * @param int    $user_id   The user ID.
+		 */
+		$enabled_providers = apply_filters( 'two_factor_available_providers_for_user', $enabled_providers, $user_id );
+
 		foreach ( $providers as $classname => $provider ) {
 			if ( in_array( $classname, $enabled_providers ) && $provider->is_available_for_user( $user ) ) {
 				$configured_providers[ $classname ] = $provider;
@@ -882,4 +890,3 @@ class Two_Factor_Core {
 		return (bool) apply_filters( 'two_factor_rememberme', $rememberme );
 	}
 }
-

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -172,7 +172,13 @@ class Two_Factor_Core {
 		}
 		$enabled_providers = array_intersect( $enabled_providers, array_keys( $providers ) );
 
-		return $enabled_providers;
+		/**
+		 * Filter the enabled two-factor authentication providers for this user.
+		 *
+		 * @param array  $enabled_providers The enabled providers.
+		 * @param int    $user_id           The user ID.
+		 */
+		return apply_filters( 'two_factor_enabled_providers_for_user', $enabled_providers, $user->ID );
 	}
 
 	/**
@@ -189,14 +195,6 @@ class Two_Factor_Core {
 		$providers            = self::get_providers();
 		$enabled_providers    = self::get_enabled_providers_for_user( $user );
 		$configured_providers = array();
-
-		/**
-		 * Filter the enabled two-factor authentication providers for this user.
-		 *
-		 * @param array  $enabled_providers The enabled providers.
-		 * @param int    $user_id           The user ID.
-		 */
-		$enabled_providers = apply_filters( 'two_factor_enabled_providers_for_user', $enabled_providers, $user->ID );
 
 		foreach ( $providers as $classname => $provider ) {
 			if ( in_array( $classname, $enabled_providers ) && $provider->is_available_for_user( $user ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -193,10 +193,10 @@ class Two_Factor_Core {
 		/**
 		 * Filter the available two-factor authentication providers for this user.
 		 *
-		 * @param array  $providers The available providers.
-		 * @param int    $user_id   The user ID.
+		 * @param array  $enabled_providers The available providers.
+		 * @param int    $user_id           The user ID.
 		 */
-		$enabled_providers = apply_filters( 'two_factor_available_providers_for_user', $enabled_providers, $user_id );
+		$enabled_providers = apply_filters( 'two_factor_available_providers_for_user', $enabled_providers, $user->ID );
 
 		foreach ( $providers as $classname => $provider ) {
 			if ( in_array( $classname, $enabled_providers ) && $provider->is_available_for_user( $user ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -191,12 +191,12 @@ class Two_Factor_Core {
 		$configured_providers = array();
 
 		/**
-		 * Filter the available two-factor authentication providers for this user.
+		 * Filter the enabled two-factor authentication providers for this user.
 		 *
-		 * @param array  $enabled_providers The available providers.
+		 * @param array  $enabled_providers The enabled providers.
 		 * @param int    $user_id           The user ID.
 		 */
-		$enabled_providers = apply_filters( 'two_factor_available_providers_for_user', $enabled_providers, $user->ID );
+		$enabled_providers = apply_filters( 'two_factor_enabled_providers_for_user', $enabled_providers, $user->ID );
 
 		foreach ( $providers as $classname => $provider ) {
 			if ( in_array( $classname, $enabled_providers ) && $provider->is_available_for_user( $user ) ) {


### PR DESCRIPTION
This PR adds a filter `two_factor_enabled_providers_for_user` to allow developers to filter the the providers that are enabled for a specific user.

An example of where they may be useful is enabling the email provider for a subset of users.
````php
add_filter( 'two_factor_enabled_providers_for_user', function( $providers, $user_id ) {
    $user = get_userdata( $user_id );
    if ( in_array( 'editor', $user->roles, true ) {
        array_push( $providers, 'Two_Factor_Email' );
    }
    return array_unique( $providers );
}, 10, 2 );
````

As of right now, the only way to do this that I could find is to filter the user meta, which is fine, but less elegant.

Note: I kept the second parameter of the hook signature as `$user_id : int` as opposed to `$user : WP_User` for uniformity with a few other similar filters.