### PR TITLE
Add filter to customize email token mail subject and message

### DIFF
--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -152,6 +152,23 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		/* translators: %s: token */
 		$message = wp_strip_all_tags( sprintf( __( 'Enter %s to log in.', 'two-factor' ), $token ) );
 
+		/**
+		 * Filter the email token subject.
+		 *
+		 * @param string $subject The email subject line.
+		 * @param int    $user_id The ID of the user.
+		 */
+		$subject = apply_filters( 'two_factor_email_token_subject', $subject, $user->ID );
+
+		/**
+		 * Filter the email token message.
+		 *
+		 * @param string $message The email message.
+		 * @param string $token   The token.
+		 * @param int    $user_id The ID of the user.
+		 */
+		$message = apply_filters( 'two_factor_email_token_message', $message, $token, $user->ID );
+
 		return wp_mail( $user->user_email, $subject, $message );
 	}
 

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -153,21 +153,21 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$message = wp_strip_all_tags( sprintf( __( 'Enter %s to log in.', 'two-factor' ), $token ) );
 
 		/**
-		 * Filter the email token subject.
+		 * Filter the token email subject.
 		 *
 		 * @param string $subject The email subject line.
 		 * @param int    $user_id The ID of the user.
 		 */
-		$subject = apply_filters( 'two_factor_email_token_subject', $subject, $user->ID );
+		$subject = apply_filters( 'two_factor_token_email_subject', $subject, $user->ID );
 
 		/**
-		 * Filter the email token message.
+		 * Filter the token email message.
 		 *
 		 * @param string $message The email message.
 		 * @param string $token   The token.
 		 * @param int    $user_id The ID of the user.
 		 */
-		$message = apply_filters( 'two_factor_email_token_message', $message, $token, $user->ID );
+		$message = apply_filters( 'two_factor_token_email_message', $message, $token, $user->ID );
 
 		return wp_mail( $user->user_email, $subject, $message );
 	}


### PR DESCRIPTION
Adds 2 filters, `two_factor_token_email_subject` and `two_factor_token_email_message`, to allow developers to filter the subject line and message of the email that gets sent to users with their access token.