### PR TITLE
Fix the OTP secret delete button

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -200,8 +200,8 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = filter_input( INPUT_REQUEST, '_wpnonce', FILTER_SANITIZE_STRING );
-		$user_action = filter_input( INPUT_REQUEST, self::USER_SETTINGS_ACTION_PARAM, FILTER_SANITIZE_STRING );
+		$request_nonce = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+		$user_action = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_PARAM, FILTER_SANITIZE_STRING );
 
 		if ( $action !== $user_action ) {
 			return false;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -34,7 +34,14 @@ class Two_Factor_Core {
 	 *
 	 * @var string
 	 */
-	const USER_SETTINGS_ACTION_PARAM = 'action-two-factor';
+	const USER_SETTINGS_ACTION_QUERY_VAR = 'two_factor_action';
+
+	/**
+	 * Nonce key for user settings.
+	 *
+	 * @var string
+	 */
+	const USER_SETTINGS_ACTION_NONCE_QUERY_ARG = '_two_factor_action_nonce';
 
 	/**
 	 * Keep track of all the password-based authentication sessions that
@@ -74,6 +81,8 @@ class Two_Factor_Core {
 
 		// Run only after the core wp_authenticate_username_password() check.
 		add_filter( 'authenticate', array( __CLASS__, 'filter_authenticate' ), 50 );
+
+		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
 
 		$compat->init();
 	}
@@ -182,12 +191,12 @@ class Two_Factor_Core {
 		return wp_nonce_url(
 			add_query_arg(
 				array(
-					'action'                         => 'update',
-					self::USER_SETTINGS_ACTION_PARAM => $action,
+					self::USER_SETTINGS_ACTION_QUERY_VAR => $action,
 				),
 				self::get_user_settings_page_url( $user_id )
 			),
-			sprintf( '%d-%s', $user_id, $action )
+			sprintf( '%d-%s', $user_id, $action ),
+			self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG
 		);
 	}
 
@@ -200,17 +209,38 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
-		$user_action = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_PARAM, FILTER_SANITIZE_STRING );
-
-		if ( $action !== $user_action ) {
-			return false;
-		}
+		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_SANITIZE_STRING );
 
 		return wp_verify_nonce(
 			$request_nonce,
 			sprintf( '%d-%s', $user_id, $action )
 		);
+	}
+
+	/**
+	 * Trigger our custom update action if a valid
+	 * action request is detected and passes the nonce check.
+	 *
+	 * @return void
+	 */
+	public static function trigger_user_settings_action() {
+		$action = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_SANITIZE_STRING );
+		$user_id = filter_input( INPUT_GET, 'user_id', FILTER_SANITIZE_NUMBER_INT );
+
+		if ( empty( $user_id ) && is_user_logged_in() ) {
+			$user_id = get_current_user_id();
+		}
+
+		if ( ! empty( $action ) && self::is_valid_user_action( $user_id, $action ) ) {
+			/**
+			 * This action is triggered when a valid Two Factor settings
+			 * action is detected and it passes the nonce validation.
+			 *
+			 * @param integer $user_id User ID.
+			 * @param string $action Settings action.
+			 */
+			do_action( 'two_factor_user_settings_action', $user_id, $action );
+		}
 	}
 
 	/**

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -161,21 +161,19 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
 
-			$authcode = filter_input( INPUT_POST, 'two-factor-totp-authcode', FILTER_SANITIZE_NUMBER_INT );
-			$key = filter_input( INPUT_POST, 'two-factor-totp-key', FILTER_SANITIZE_STRING );
-
 			// Validate and store a new secret key.
-			if ( ! empty( $authcode ) && ! empty( $key ) ) {
-				if ( ! $this->is_valid_key( $key ) ) {
-					$errors[] = __( 'Invalid Two Factor Authentication secret key.', 'two-factor' );
-				}
-
-				if ( $this->is_valid_authcode( $key, $authcode ) ) {
-					if ( ! $this->set_user_totp_key( $user_id, $key ) ) {
-						$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
+			if ( ! empty( $_POST['two-factor-totp-authcode'] ) && ! empty( $_POST['two-factor-totp-key'] ) ) {
+				if ( $this->is_valid_key( $_POST['two-factor-totp-key'] ) ) {
+					$authcode = filter_input( INPUT_POST, 'two-factor-totp-authcode', FILTER_SANITIZE_NUMBER_INT );
+					if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $authcode ) ) {
+						if ( ! $this->set_user_totp_key( $user_id, $_POST['two-factor-totp-key'] ) ) {
+							$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
+						}
+					} else {
+						$errors[] = __( 'Invalid Two Factor Authentication code.', 'two-factor' );
 					}
 				} else {
-					$errors[] = __( 'Invalid Two Factor Authentication code.', 'two-factor' );
+					$errors[] = __( 'Invalid Two Factor Authentication secret key.', 'two-factor' );
 				}
 			}
 

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -161,19 +161,21 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
 
+			$authcode = filter_input( INPUT_POST, 'two-factor-totp-authcode', FILTER_SANITIZE_NUMBER_INT );
+			$key = filter_input( INPUT_POST, 'two-factor-totp-key', FILTER_SANITIZE_STRING );
+
 			// Validate and store a new secret key.
-			if ( ! empty( $_POST['two-factor-totp-authcode'] ) && ! empty( $_POST['two-factor-totp-key'] ) ) {
-				if ( $this->is_valid_key( $_POST['two-factor-totp-key'] ) ) {
-					$authcode = filter_input( INPUT_POST, 'two-factor-totp-authcode', FILTER_SANITIZE_NUMBER_INT );
-					if ( $this->is_valid_authcode( $_POST['two-factor-totp-key'], $authcode ) ) {
-						if ( ! $this->set_user_totp_key( $user_id, $_POST['two-factor-totp-key'] ) ) {
-							$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
-						}
-					} else {
-						$errors[] = __( 'Invalid Two Factor Authentication code.', 'two-factor' );
+			if ( ! empty( $authcode ) && ! empty( $key ) ) {
+				if ( ! $this->is_valid_key( $key ) ) {
+					$errors[] = __( 'Invalid Two Factor Authentication secret key.', 'two-factor' );
+				}
+
+				if ( $this->is_valid_authcode( $key, $authcode ) ) {
+					if ( ! $this->set_user_totp_key( $user_id, $key ) ) {
+						$errors[] = __( 'Unable to save Two Factor Authentication code. Please re-scan the QR code and enter the code provided by your application.', 'two-factor' );
 					}
 				} else {
-					$errors[] = __( 'Invalid Two Factor Authentication secret key.', 'two-factor' );
+					$errors[] = __( 'Invalid Two Factor Authentication code.', 'two-factor' );
 				}
 			}
 

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -24,6 +24,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	const NOTICES_META_KEY = '_two_factor_totp_notices';
 
+	/**
+	 * Action name for resetting the secret token.
+	 *
+	 * @var string
+	 */
+	const ACTION_SECRET_DELETE = 'totp-delete';
+
 	const DEFAULT_KEY_BIT_SIZE = 160;
 	const DEFAULT_CRYPTO = 'sha1';
 	const DEFAULT_DIGIT_COUNT = 6;
@@ -36,8 +43,10 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	protected function __construct() {
 		add_action( 'two-factor-user-options-' . __CLASS__, array( $this, 'user_two_factor_options' ) );
-		add_action( 'personal_options_update',              array( $this, 'user_two_factor_options_update' ) );
-		add_action( 'edit_user_profile_update',             array( $this, 'user_two_factor_options_update' ) );
+		add_action( 'personal_options_update', array( $this, 'user_two_factor_options_update' ) );
+		add_action( 'edit_user_profile_update', array( $this, 'user_two_factor_options_update' ) );
+		add_action( 'two_factor_user_settings_action', array( $this, 'user_settings_action' ), 10, 2 );
+
 		return parent::__construct();
 	}
 
@@ -57,6 +66,31 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	public function get_label() {
 		return _x( 'Time Based One-Time Password (Google Authenticator)', 'Provider Label', 'two-factor' );
+	}
+
+	/**
+	 * Trigger our custom user settings actions.
+	 *
+	 * @param integer $user_id User ID.
+	 * @param string  $action Action ID.
+	 *
+	 * @return void
+	 */
+	public function user_settings_action( $user_id, $action ) {
+		if ( self::ACTION_SECRET_DELETE === $action ) {
+			$this->delete_user_totp_key( $user_id );
+		}
+	}
+
+	/**
+	 * Get the URL for deleting the secret token.
+	 *
+	 * @param integer $user_id User ID.
+	 *
+	 * @return string
+	 */
+	protected function get_token_delete_url_for_user( $user_id ) {
+		return Two_Factor_Core::get_user_update_action_url( $user_id, self::ACTION_SECRET_DELETE );
 	}
 
 	/**
@@ -104,8 +138,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<?php esc_html_e( 'Secret key configured and registered.', 'two-factor' ); ?>
 			</p>
 			<p>
-				<?php // There is a button with a name "submit" so we can't do this.form.submit(). ?>
-				<input type="button" onclick="this.form.submit.click()" class="button" name="two-factor-totp-delete" value="<?php esc_attr_e( 'Reset Key', 'two-factor' ); ?>" />
+				<a class="button" href="<?php echo esc_url( self::get_token_delete_url_for_user( $user->ID ) ); ?>"><?php esc_html_e( 'Reset Key', 'two-factor' ); ?></a>
 				<em class="description">
 					<?php esc_html_e( 'You will have to re-scan the QR code on all devices as the previous codes will stop working.', 'two-factor' ); ?>
 				</em>
@@ -125,15 +158,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$notices = array();
 		$errors = array();
 
-		$current_key = $this->get_user_totp_key( $user_id );
-
 		if ( isset( $_POST['_nonce_user_two_factor_totp_options'] ) ) {
 			check_admin_referer( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options' );
-
-			// Delete the secret key.
-			if ( ! empty( $current_key ) && isset( $_POST['two-factor-totp-delete'] ) ) {
-				$this->delete_user_totp_key( $user_id );
-			}
 
 			// Validate and store a new secret key.
 			if ( ! empty( $_POST['two-factor-totp-authcode'] ) && ! empty( $_POST['two-factor-totp-key'] ) ) {

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -107,7 +107,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		wp_nonce_field( 'user_two_factor_totp_options', '_nonce_user_two_factor_totp_options', false );
 
 		$key = $this->get_user_totp_key( $user->ID );
-		$this->admin_notices();
+		$this->admin_notices( $user->ID );
 
 		?>
 		<div id="two-factor-totp-options">
@@ -240,12 +240,17 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 	/**
 	 * Display any available admin notices.
+	 *
+	 * @param integer $user_id User ID.
+	 *
+	 * @return void
 	 */
-	public function admin_notices() {
-		$notices = get_user_meta( get_current_user_id(), self::NOTICES_META_KEY, true );
+	public function admin_notices( $user_id ) {
+		$notices = get_user_meta( $user_id, self::NOTICES_META_KEY, true );
 
 		if ( ! empty( $notices ) ) {
-			delete_user_meta( get_current_user_id(), self::NOTICES_META_KEY );
+			delete_user_meta( $user_id, self::NOTICES_META_KEY );
+
 			foreach ( $notices as $class => $messages ) {
 				?>
 				<div class="<?php echo esc_attr( $class ) ?>">

--- a/providers/class.two-factor-totp.php
+++ b/providers/class.two-factor-totp.php
@@ -104,7 +104,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<?php esc_html_e( 'Secret key configured and registered.', 'two-factor' ); ?>
 			</p>
 			<p>
-				<input type="submit" class="button" name="two-factor-totp-delete" value="<?php esc_attr_e( 'Reset Key', 'two-factor' ); ?>" />
+				<?php // There is a button with a name "submit" so we can't do this.form.submit(). ?>
+				<input type="button" onclick="this.form.submit.click()" class="button" name="two-factor-totp-delete" value="<?php esc_attr_e( 'Reset Key', 'two-factor' ); ?>" />
 				<em class="description">
 					<?php esc_html_e( 'You will have to re-scan the QR code on all devices as the previous codes will stop working.', 'two-factor' ); ?>
 				</em>

--- a/tests/providers/class.two-factor-totp.php
+++ b/tests/providers/class.two-factor-totp.php
@@ -246,16 +246,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 			'Secret was stored and can be fetched'
 		);
 
-		// Configure the request and the nonce.
-		$nonce = wp_create_nonce( 'user_two_factor_totp_options' );
-		$_POST['_nonce_user_two_factor_totp_options'] = $nonce;
-		$_REQUEST['_nonce_user_two_factor_totp_options'] = $nonce; // Required for check_admin_referer().
-
-		// Set the request to delete things.
-		$_POST['two-factor-totp-delete'] = 1;
-
-		// Process the request.
-		$this->provider->user_two_factor_options_update( $user->ID );
+		$this->provider->delete_user_totp_key( $user->ID );
 
 		$this->assertEquals(
 			'',


### PR DESCRIPTION
Fixes #341.

- Introduce user action API for the plugin that takes care of generating action URLs and validating the inputs via nonces.

- Use the user action API to generate the reset link and delete the secret if the link action validation passes.

- Show OTP registration notices for the correct user -- the current or the one being edited instead of just the current one.