### PR TITLE
Add email token expiry

### DIFF
--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -249,7 +249,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			return;
 		}
 
-		if ( ! $this->user_has_token( $user_id ) || $this->user_token_has_expired( $user_id ) ) {
+		if ( ! $this->user_has_token( $user->ID ) || $this->user_token_has_expired( $user->ID ) ) {
 			$this->generate_and_email_token( $user );
 		}
 

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -11,9 +11,16 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	/**
 	 * The user meta token key.
 	 *
-	 * @type string
+	 * @var string
 	 */
 	const TOKEN_META_KEY = '_two_factor_email_token';
+
+	/**
+	 * Store the timestamp when the token was generated.
+	 *
+	 * @var string
+	 */
+	const TOKEN_META_KEY_TIMESTAMP = '_two_factor_email_token_timestamp';
 
 	/**
 	 * Name of the input field used for code resend.
@@ -65,7 +72,10 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 */
 	public function generate_token( $user_id ) {
 		$token = $this->get_code();
+
+		update_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, time() );
 		update_user_meta( $user_id, self::TOKEN_META_KEY, wp_hash( $token ) );
+
 		return $token;
 	}
 
@@ -80,9 +90,65 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 		if ( ! empty( $hashed_token ) ) {
 			return true;
-		} else {
-			return false;
 		}
+
+		return false;
+	}
+
+	/**
+	 * Has the user token validity timestamp expired.
+	 *
+	 * @param integer $user_id User ID.
+	 *
+	 * @return boolean
+	 */
+	public function user_token_has_expired( $user_id ) {
+		$token_lifetime = $this->user_token_lifetime( $user_id );
+		$token_ttl = $this->user_token_ttl( $user_id );
+
+		// Assume that lifetime below a second is invalid.
+		if ( ! $token_lifetime ) {
+			return true;
+		}
+
+		return ( $token_lifetime >= $token_ttl );
+	}
+
+	/**
+	 * Get the lifetime of a user token in seconds.
+	 *
+	 * @param integer $user_id User ID.
+	 *
+	 * @return integer|null Return `null` if the lifetime can't be measured.
+	 */
+	public function user_token_lifetime( $user_id ) {
+		$timestamp = intval( get_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, true ) );
+
+		if ( ! empty( $timestamp ) ) {
+			return time() - $timestamp;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the token time-to-live for a user.
+	 *
+	 * @param integer $user_id User ID.
+	 *
+	 * @return integer
+	 */
+	public function user_token_ttl( $user_id ) {
+		$token_ttl = 15 * MINUTE_IN_SECONDS;
+
+		/**
+		 * Number of seconds the token is considered valid
+		 * after the generation.
+		 *
+		 * @param integer $token_ttl Token time-to-live in seconds.
+		 * @param integer $user_id User ID.
+		 */
+		return (int) apply_filters( 'two_factor_token_ttl', $token_ttl, $user_id );
 	}
 
 	/**
@@ -116,6 +182,10 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 		// Bail if token is empty or it doesn't match.
 		if ( empty( $hashed_token ) || ( wp_hash( $token ) !== $hashed_token ) ) {
+			return false;
+		}
+
+		if ( $this->user_token_has_expired( $user_id ) ) {
 			return false;
 		}
 
@@ -184,7 +254,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			return;
 		}
 
-		if ( ! $this->user_has_token( $user->ID ) ) {
+		if ( ! $this->user_has_token( $user_id ) || $this->user_token_has_expired( $user_id ) ) {
 			$this->generate_and_email_token( $user );
 		}
 

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -189,7 +189,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			return false;
 		}
 
-		// Ensure that the token can't be re-used.
+		// Ensure the token can be used only once.
 		$this->delete_token( $user_id );
 
 		return true;

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -106,12 +106,12 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$token_lifetime = $this->user_token_lifetime( $user_id );
 		$token_ttl = $this->user_token_ttl( $user_id );
 
-		// Invalid token is considered an expired token.
-		if ( ! is_int( $token_lifetime ) ) {
-			return true;
+		// Invalid token lifetime is considered an expired token.
+		if ( is_int( $token_lifetime ) && $token_lifetime <= $token_ttl ) {
+			return false;
 		}
 
-		return ( $token_lifetime >= $token_ttl );
+		return true;
 	}
 
 	/**

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -106,7 +106,12 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$token_lifetime = $this->user_token_lifetime( $user_id );
 		$token_ttl = $this->user_token_ttl( $user_id );
 
-		return ( null !== $token_lifetime && $token_lifetime >= $token_ttl );
+		// Invalid token is considered an expired token.
+		if ( ! is_int( $token_lifetime ) ) {
+			return true;
+		}
+
+		return ( $token_lifetime >= $token_ttl );
 	}
 
 	/**

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -106,11 +106,6 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$token_lifetime = $this->user_token_lifetime( $user_id );
 		$token_ttl = $this->user_token_ttl( $user_id );
 
-		// Assume that lifetime below a second is invalid.
-		if ( ! $token_lifetime ) {
-			return true;
-		}
-
 		return ( $token_lifetime >= $token_ttl );
 	}
 

--- a/providers/class.two-factor-email.php
+++ b/providers/class.two-factor-email.php
@@ -106,7 +106,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		$token_lifetime = $this->user_token_lifetime( $user_id );
 		$token_ttl = $this->user_token_ttl( $user_id );
 
-		return ( $token_lifetime >= $token_ttl );
+		return ( null !== $token_lifetime && $token_lifetime >= $token_ttl );
 	}
 
 	/**

--- a/tests/providers/class.two-factor-email.php
+++ b/tests/providers/class.two-factor-email.php
@@ -288,7 +288,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		// Update the generation time to one second before the TTL.
 		$expired_token_timestamp = time() - $this->provider->user_token_ttl( $user_id ) - 1;
-		update_user_meta( $user_id, $this->provider::TOKEN_META_KEY_TIMESTAMP, $expired_token_timestamp );
+		update_user_meta( $user_id, Two_Factor_Email::TOKEN_META_KEY_TIMESTAMP, $expired_token_timestamp );
 
 		$this->assertTrue(
 			$this->provider->user_token_has_expired( $user_id ),

--- a/tests/providers/class.two-factor-email.php
+++ b/tests/providers/class.two-factor-email.php
@@ -217,4 +217,48 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		$this->assertNotEquals( $token_original, $token_new, 'Failed to generate a new code as requested.' );
 	}
 
+	/**
+	 * Ensure that a default TTL is set.
+	 *
+	 * @covers Two_Factor_Email::user_token_ttl
+	 */
+	public function test_user_token_has_ttl() {
+		$this->assertEquals(
+			15 * 60,
+			$this->provider->user_token_ttl( 123 ),
+			'Default TTL is 15 minutes'
+		);
+	}
+
+	/**
+	 * Ensure the token generation time is stored.
+	 *
+	 * @covers Two_Factor_Email::user_token_lifetime
+	 */
+	public function test_tokens_have_generation_time() {
+		$user_id = $this->factory->user->create();
+
+		$this->assertFalse(
+			$this->provider->user_has_token( $user_id ),
+			'User does not have a valid token before requesting it'
+		);
+
+		$this->assertNull(
+			$this->provider->user_token_lifetime( $user_id ),
+			'Token lifetime is not present until a token is generated'
+		);
+
+		$this->provider->generate_token( $user_id );
+
+		$this->assertTrue(
+			$this->provider->user_has_token( $user_id ),
+			'User has a token after requesting it'
+		);
+
+		$this->assertTrue(
+			is_int( $this->provider->user_token_lifetime( $user_id ) ),
+			'Lifetime is a valid integer if present'
+		);
+	}
+
 }


### PR DESCRIPTION
Fixes #220.

- Keep track of the timestamp when the token was generated.
- Allow the token TTL to be customized via a filter.