### PR TITLE
Release 0.6.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Enable Two-Factor Authentication using time-based one-time passwords (OTP, Googl
 **Stable tag:** trunk (master)  
 **Requires PHP:** 5.6  
 
-[![Build Status](https://travis-ci.org/wordpress/two-factor.svg?branch=master)](https://travis-ci.org/wordpress/two-factor) [![Coverage Status](https://coveralls.io/repos/wordpress/two-factor/badge.svg?branch=master)](https://coveralls.io/github/wordpress/two-factor) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
+[![Build Status](https://travis-ci.org/WordPress/two-factor.svg?branch=master)](https://travis-ci.org/WordPress/two-factor) [![Coverage Status](https://coveralls.io/repos/WordPress/two-factor/badge.svg?branch=master)](https://coveralls.io/github/WordPress/two-factor) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
 
 ## Description ##
 

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,10 @@ For more history, see [this post](https://georgestephanis.wordpress.com/2013/08/
 ### Actions & Filters ###
 Here is a list of action and filter hooks provided by the plugin:
 
+- `two_factor_providers` filter overrides the available two-factor providers such as email and time-based one-time passwords. Array values are PHP classnames of the two-factor providers.
+- `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
+- `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 
 
 ## Screenshots ##

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,10 @@ For more history, see [this post](https://georgestephanis.wordpress.com/2013/08/
 
 Here is a list of action and filter hooks provided by the plugin:
 
+- `two_factor_providers` filter overrides the available two-factor providers such as email and time-based one-time passwords. Array values are PHP classnames of the two-factor providers.
+- `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
+- `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 
 == Screenshots ==
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author: Plugin Contributors
- * Version: 0.5.2
+ * Version: 0.6.0
  * Author URI: https://github.com/wordpress/two-factor/graphs/contributors
  * Network: True
  * Text Domain: two-factor


### PR DESCRIPTION
Includes #352 and #351.

- Security fix: escape the U2F key value when doing the key lookup in database during login.
- New feature: invalidate email tokens 15 minutes after they were generated. Use the `two_factor_token_ttl` filter to override this time-to-live interval.