### PR TITLE
Basic local test support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,3 @@
 service_name: travis-ci
-coverage_clover: build/logs/clover.xml
-json_path: build/logs/coveralls-upload.json
+coverage_clover: tests/logs/clover.xml
+json_path: tests/logs/coveralls-upload.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.6'
+
+services:
+
+  wpdevlib:
+    build: ./tests/docker/wp-dev-lib
+    working_dir: /var/www/html
+    volumes:
+      - .:/var/www/html
+    environment:
+      CHECK_SCOPE: all

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "phpunit": "DEV_LIB_ONLY=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "preinstall": "composer install",
     "precommit": "DEV_LIB_SKIP=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
-    "prepush": "npm test",
     "docker-cli": "docker-compose run wpdevlib",
     "docker-test": "docker-compose run -e DEV_LIB_ONLY=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "docker-lint": "docker-compose run -e DEV_LIB_SKIP=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "build": "npm run readme && grunt build",
     "test": "DIFF_BASE=master ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "readme": "./vendor/xwp/wp-dev-lib/scripts/generate-markdown-readme",
-    "phpunit": "DEV_LIB_ONLY=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
+    "phpunit": "DEV_LIB_ONLY=phpunit SYNC_README_MD=0 ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "preinstall": "composer install",
     "precommit": "DEV_LIB_SKIP=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "docker-cli": "docker-compose run wpdevlib",
-    "docker-test": "docker-compose run -e DEV_LIB_ONLY=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
+    "docker-test": "docker-compose run -e DEV_LIB_ONLY=phpunit -e SYNC_README_MD=0 wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "docker-lint": "docker-compose run -e DEV_LIB_SKIP=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "phpunit": "DEV_LIB_ONLY=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
     "preinstall": "composer install",
     "precommit": "DEV_LIB_SKIP=phpunit ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
-    "prepush": "npm test"
+    "prepush": "npm test",
+    "docker-cli": "docker-compose run wpdevlib",
+    "docker-test": "docker-compose run -e DEV_LIB_ONLY=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit",
+    "docker-lint": "docker-compose run -e DEV_LIB_SKIP=phpunit wpdevlib ./vendor/xwp/wp-dev-lib/scripts/pre-commit"
   },
   "repository": {
     "type": "git",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,6 @@
 		</whitelist>
 	</filter>
 	<logging>
-		<log type="coverage-clover" target="build/logs/clover.xml" />
+		<log type="coverage-clover" target="tests/logs/clover.xml" />
 	</logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,13 +16,10 @@
 	</testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
-			<directory suffix=".php">.</directory>
-			<exclude>
-				<directory suffix=".php">includes</directory>
-				<directory suffix=".php">tests</directory>
-				<directory suffix=".php">vendor</directory>
-				<directory suffix=".php">node_modules</directory>
-			</exclude>
+			<directory suffix=".php">providers</directory>
+			<file>class-two-factor-compat.php</file>
+			<file>class-two-factor-core.php</file>
+			<file>two-factor.php</file>
 		</whitelist>
 	</filter>
 	<logging>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 		<const name="WP_TEST_ACTIVATED_PLUGINS" value="two-factor/two-factor.php" />
 	</php>
 	<testsuites>
-		<testsuite>
+		<testsuite name="All Tests">
 			<directory suffix=".php">tests</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/docker/wp-dev-lib/Dockerfile
+++ b/tests/docker/wp-dev-lib/Dockerfile
@@ -14,6 +14,10 @@ RUN apt-get update \
 	&& npm install --global npm@latest \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Setup xdebug.
+RUN	pecl install xdebug \
+	&& docker-php-ext-enable xdebug
+
 # Install Composer.
 RUN curl -s https://getcomposer.org/installer | php \
 	&& mv composer.phar /usr/local/bin/composer
@@ -21,12 +25,12 @@ RUN curl -s https://getcomposer.org/installer | php \
 # Checkout WP with tests.
 RUN svn export "$WP_SVN_URL" /tmp/wordpress
 
-VOLUME /tmp/wordpress
-
 # Copy our WP tests config.
 COPY wp-tests-config.php /tmp/wordpress/wp-tests-config.php
 
 # Setup a custom entrypoint that bootstraps the environment.
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+VOLUME /tmp/wordpress
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/tests/docker/wp-dev-lib/Dockerfile
+++ b/tests/docker/wp-dev-lib/Dockerfile
@@ -1,0 +1,32 @@
+ARG WP_PHP_VERSION=7.4
+FROM wordpress:php${WP_PHP_VERSION}-fpm
+
+# Allow custom versions of WP to be pulled in.
+ARG WP_SVN_URL=https://develop.svn.wordpress.org/trunk/
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Development tooling dependencies.
+RUN apt-get update \
+	&& apt-get install --yes --no-install-recommends \
+		bash less subversion default-mysql-server default-mysql-client libxml2-utils rsync git zip unzip \
+		nodejs npm curl \
+	&& npm install --global npm@latest \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install Composer.
+RUN curl -s https://getcomposer.org/installer | php \
+	&& mv composer.phar /usr/local/bin/composer
+
+# Checkout WP with tests.
+RUN svn export "$WP_SVN_URL" /tmp/wordpress
+
+VOLUME /tmp/wordpress
+
+# Copy our WP tests config.
+COPY wp-tests-config.php /tmp/wordpress/wp-tests-config.php
+
+# Setup a custom entrypoint that bootstraps the environment.
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/tests/docker/wp-dev-lib/entrypoint.sh
+++ b/tests/docker/wp-dev-lib/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export WP_CORE_DIR="${WP_CORE_DIR:-/tmp/wordpress}"
+export WP_TESTS_DIR="${WP_TESTS_DIR:-$WP_CORE_DIR/tests/phpunit}"
+
+# Start the MySQL server.
+service mysql start
+
+# Setup a test DB.
+mysql --user=root --password=root --execute="CREATE DATABASE wordpress_test;"
+
+# Run the command passed to this container.
+exec "$@"

--- a/tests/docker/wp-dev-lib/entrypoint.sh
+++ b/tests/docker/wp-dev-lib/entrypoint.sh
@@ -6,8 +6,14 @@ export WP_TESTS_DIR="${WP_TESTS_DIR:-$WP_CORE_DIR/tests/phpunit}"
 # Start the MySQL server.
 service mysql start
 
-# Setup a test DB.
-mysql --user=root --password=root --execute="CREATE DATABASE wordpress_test;"
+# Setup the test DB.
+mysql --user=root --password=root --execute \
+	"GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+	FLUSH PRIVILEGES;
+	DROP DATABASE IF EXISTS wordpress_test;
+	CREATE DATABASE wordpress_test"
+
+mysqladmin --user=root --password=root password root
 
 # Run the command passed to this container.
 exec "$@"

--- a/tests/docker/wp-dev-lib/entrypoint.sh
+++ b/tests/docker/wp-dev-lib/entrypoint.sh
@@ -6,14 +6,15 @@ export WP_TESTS_DIR="${WP_TESTS_DIR:-$WP_CORE_DIR/tests/phpunit}"
 # Start the MySQL server.
 service mysql start
 
-# Setup the test DB.
+# Ensure we have a password and a fresh DB.
 mysql --user=root --password=root --execute \
-	"GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
-	FLUSH PRIVILEGES;
+	"
 	DROP DATABASE IF EXISTS wordpress_test;
-	CREATE DATABASE wordpress_test"
-
-mysqladmin --user=root --password=root password root
+	CREATE DATABASE wordpress_test;
+	SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root');
+	GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+	FLUSH PRIVILEGES;
+	"
 
 # Run the command passed to this container.
 exec "$@"

--- a/tests/docker/wp-dev-lib/entrypoint.sh
+++ b/tests/docker/wp-dev-lib/entrypoint.sh
@@ -6,15 +6,15 @@ export WP_TESTS_DIR="${WP_TESTS_DIR:-$WP_CORE_DIR/tests/phpunit}"
 # Start the MySQL server.
 service mysql start
 
-# Ensure we have a password and a fresh DB.
-mysql --user=root --password=root --execute \
-	"
+# Ensure we have a password and a fresh database.
+# TODO: Figure out the ERROR 1045 (28000) error because of the password change.
+mysql --user=root --password=root << END
 	DROP DATABASE IF EXISTS wordpress_test;
 	CREATE DATABASE wordpress_test;
-	SET PASSWORD FOR 'root'@'localhost' = PASSWORD('root');
+	SET PASSWORD = PASSWORD('root');
 	GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
 	FLUSH PRIVILEGES;
-	"
+END
 
 # Run the command passed to this container.
 exec "$@"

--- a/tests/docker/wp-dev-lib/wp-tests-config.php
+++ b/tests/docker/wp-dev-lib/wp-tests-config.php
@@ -3,7 +3,7 @@
 define( 'DB_NAME', 'wordpress_test' );
 define( 'DB_USER', 'root' );
 define( 'DB_PASSWORD', 'root' );
-define( 'DB_HOST', 'localhost' );
+define( 'DB_HOST', '127.0.0.1' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 

--- a/tests/docker/wp-dev-lib/wp-tests-config.php
+++ b/tests/docker/wp-dev-lib/wp-tests-config.php
@@ -1,0 +1,20 @@
+<?php
+
+define( 'DB_NAME', 'wordpress_test' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', 'root' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wptests_';
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_DEBUG', true );
+define( 'WP_PHP_BINARY', 'php' );
+define( 'WPLANG', '' );
+
+define( 'ABSPATH', __DIR__ . '/src/' );

--- a/tests/docker/wp-dev-lib/wp-tests-config.php
+++ b/tests/docker/wp-dev-lib/wp-tests-config.php
@@ -1,5 +1,10 @@
 <?php
 
+// Ensure this is run only once.
+if ( defined( 'ABSPATH' ) ) {
+	return;
+}
+
 define( 'DB_NAME', 'wordpress_test' );
 define( 'DB_USER', 'root' );
 define( 'DB_PASSWORD', 'root' );

--- a/tests/logs/.gitignore
+++ b/tests/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Introduce a Docker based dev setup for running the PHP unit tests:

- `npm run docker-test` to run the unit tests.
- `npm run docker-lint` to run everything _but_ the unit tests.
- `npm run docker-cli` to support any command. 