### PR TITLE
Version 0.7.0

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author: Plugin Contributors
- * Version: 0.6.0
+ * Version: 0.7.0-rc.1
  * Author URI: https://github.com/wordpress/two-factor/graphs/contributors
  * Network: True
  * Text Domain: two-factor
@@ -26,7 +26,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.5.1' );
+define( 'TWO_FACTOR_VERSION', '0.7.0-rc.1' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author: Plugin Contributors
- * Version: 0.7.0-rc.1
+ * Version: 0.7.0
  * Author URI: https://github.com/wordpress/two-factor/graphs/contributors
  * Network: True
  * Text Domain: two-factor
@@ -26,7 +26,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.7.0-rc.1' );
+define( 'TWO_FACTOR_VERSION', '0.7.0' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
## Changelog 

- Fix: improve time-based one-time (TOTP) autofill when using password managers like 1Password, see #373. Props @omelhus.
- Fix: register FIDO U2F related scripts during the suggested action hooks to avoid PHP noticed, see #356 and #368. Props @cojennin.
- Rename and deprecate action and filter names `two-factor-user-options-` and `two-factor-totp-time-step-allowance` that don't following the WP coding standards. Use `two_factor_user_options_` and `two_factor_totp_time_step_allowance` now. See #363. Props @paulschreiber.
- Update codebase to match the WordPress coding standards, see #340. Props @paulschreiber.
- Add tooling to run PHPUnit tests locally during development, see #355. Props @kasparsd.