### PR TITLE
fix: login flow for 1Password with totp

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -456,14 +456,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		?>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
-			<input type="tel" name="authcode" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+			<input type="tel" autocomplete="off" name="authcode" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<script type="text/javascript">
 			setTimeout( function(){
 				var d;
 				try{
 					d = document.getElementById('authcode');
-					d.value = '';
 					d.focus();
 				} catch(e){}
 			}, 200);


### PR DESCRIPTION
Hey,

Thanks for the awesome work with this plugin.

I'm using 1Password to autofill totp-codes, and by setting `d.value = '';` the inserted code gets deleted and I'm not having a good time. This should fix that.