### PR TITLE
Only show "Security Keys" section if "FIDO U2F Security Keys" is enabled

### DIFF
--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -182,7 +182,7 @@ class Two_Factor_FIDO_U2F_Admin {
 		}
 
 		?>
-		<div class="security-keys" id="security-keys-section">
+		<div class="security-keys no-js" id="security-keys-section">
 			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
 
 			<?php if ( ! is_ssl() ) : ?>

--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -182,7 +182,7 @@ class Two_Factor_FIDO_U2F_Admin {
 		}
 
 		?>
-		<div class="security-keys no-js" id="security-keys-section">
+		<div class="security-keys" id="security-keys-section">
 			<h3><?php esc_html_e( 'Security Keys', 'two-factor' ); ?></h3>
 
 			<?php if ( ! is_ssl() ) : ?>

--- a/providers/css/fido-u2f-admin.css
+++ b/providers/css/fido-u2f-admin.css
@@ -8,3 +8,6 @@
 	vertical-align: middle;
 	font-style: italic;
 }
+#security-keys-section.no-js {
+	display: none;
+}

--- a/providers/css/fido-u2f-admin.css
+++ b/providers/css/fido-u2f-admin.css
@@ -8,6 +8,9 @@
 	vertical-align: middle;
 	font-style: italic;
 }
-#security-keys-section.no-js {
+#security-keys-section {
 	display: none;
+}
+body.no-js #security-keys-section {
+	display: block;
 }

--- a/providers/js/fido-u2f-admin.js
+++ b/providers/js/fido-u2f-admin.js
@@ -3,6 +3,20 @@
 	var $button = $( '#register_security_key' );
 	var $statusNotice = $( '#security-keys-section .security-key-status' );
 	var u2fSupported = ( window.u2f && 'register' in window.u2f );
+	var $securityKeys = $( '#security-keys-section' );
+	var $u2fCheckbox = $( '#two-factor-options input[value="Two_Factor_FIDO_U2F"]' );
+
+	if ( $u2fCheckbox.prop( 'checked' ) ) {
+		$securityKeys.show();
+	}
+
+	$u2fCheckbox.on( 'change', function() {
+		if ( $(this).prop( 'checked' ) ) {
+			$securityKeys.show();
+		} else {
+			$securityKeys.hide();
+		}
+	} );
 
 	if ( ! u2fSupported ) {
 		$statusNotice.text( u2fL10n.text.u2f_not_supported );


### PR DESCRIPTION
Hi,

This PR only shows the "Security Keys" section if the "FIDO U2F Security Keys" provider is enabled.

Here's a GIF of the PR:

![GIF](https://user-images.githubusercontent.com/505921/94980459-762e5000-0519-11eb-8b38-8277d3b42bd8.gif)

If JS is disabled, the "Security Keys" section gets displayed as expected.

----

I created this PR for better UX. If the "Security Keys" section is shown, but the "FIDO U2F Security Keys" provider is not enabled, this might confuse people thinking that this might be something that needs to be filled in.

I would also recommend changing the `Requires an HTTPS connection. Configure your security keys in the "Security Keys" section below.` string. I don't think it is necessary to mention `Requires an HTTPS connection`. Either the server supports HTTPS or it doesn't. The end user doesn't care about this.

Let me know what you think.