### PR TITLE
Generate QR codes internally

### DIFF
--- a/includes/BaconQrCode/Common/AbstractEnum.php
+++ b/includes/BaconQrCode/Common/AbstractEnum.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use BaconQrCode\Exception;
+use ReflectionClass;
+
+/**
+ * A general enum implementation until we got SplEnum.
+ */
+abstract class AbstractEnum
+{
+    /**
+     * Default value.
+     */
+    const __default = null;
+
+    /**
+     * Current value.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * Cache of constants.
+     *
+     * @var array
+     */
+    protected $constants;
+
+    /**
+     * Whether to handle values strict or not.
+     *
+     * @var boolean
+     */
+    protected $strict;
+
+    /**
+     * Creates a new enum.
+     *
+     * @param mixed   $initialValue
+     * @param boolean $strict
+     */
+    public function __construct($initialValue = null, $strict = false)
+    {
+        $this->strict = $strict;
+        $this->change($initialValue);
+    }
+
+    /**
+     * Changes the value of the enum.
+     *
+     * @param  mixed $value
+     * @return void
+     */
+    public function change($value)
+    {
+        if (!in_array($value, $this->getConstList(), $this->strict)) {
+            throw new Exception\UnexpectedValueException('Value not a const in enum ' . get_class($this));
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * Gets current value.
+     *
+     * @return mixed
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Gets all constants (possible values) as an array.
+     *
+     * @param  boolean $includeDefault
+     * @return array
+     */
+    public function getConstList($includeDefault = true)
+    {
+        if ($this->constants === null) {
+            $reflection      = new ReflectionClass($this);
+            $this->constants = $reflection->getConstants();
+        }
+
+        if ($includeDefault) {
+            return $this->constants;
+        }
+
+        $constants = $this->constants;
+        unset($constants['__default']);
+
+        return $constants;
+    }
+
+    /**
+     * Gets the name of the enum.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return array_search($this->value, $this->getConstList());
+    }
+}

--- a/includes/BaconQrCode/Common/AbstractEnum.php
+++ b/includes/BaconQrCode/Common/AbstractEnum.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Exception;
 use ReflectionClass;
 
 /**

--- a/includes/BaconQrCode/Common/BitArray.php
+++ b/includes/BaconQrCode/Common/BitArray.php
@@ -1,0 +1,435 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use SplFixedArray;
+
+/**
+ * A simple, fast array of bits.
+ */
+class BitArray
+{
+    /**
+     * Bits represented as an array of integers.
+     *
+     * @var SplFixedArray
+     */
+    protected $bits;
+
+    /**
+     * Size of the bit array in bits.
+     *
+     * @var integer
+     */
+    protected $size;
+
+    /**
+     * Creates a new bit array with a given size.
+     *
+     * @param integer $size
+     */
+    public function __construct($size = 0)
+    {
+        $this->size = $size;
+        $this->bits = new SplFixedArray(($this->size + 31) >> 3);
+    }
+
+    /**
+     * Gets the size in bits.
+     *
+     * @return integer
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * Gets the size in bytes.
+     *
+     * @return integer
+     */
+    public function getSizeInBytes()
+    {
+        return ($this->size + 7) >> 3;
+    }
+
+    /**
+     * Ensures that the array has a minimum capacity.
+     *
+     * @param  integer $size
+     * @return void
+     */
+    public function ensureCapacity($size)
+    {
+        if ($size > count($this->bits) << 5) {
+            $this->bits->setSize(($size + 31) >> 5);
+        }
+    }
+
+    /**
+     * Gets a specific bit.
+     *
+     * @param  integer $i
+     * @return boolean
+     */
+    public function get($i)
+    {
+        return ($this->bits[$i >> 5] & (1 << ($i & 0x1f))) !== 0;
+    }
+
+    /**
+     * Sets a specific bit.
+     *
+     * @param  integer $i
+     * @return void
+     */
+    public function set($i)
+    {
+        $this->bits[$i >> 5] = $this->bits[$i >> 5] | 1 << ($i & 0x1f);
+    }
+
+    /**
+     * Flips a specific bit.
+     *
+     * @param  integer $i
+     * @return void
+     */
+    public function flip($i)
+    {
+        $this->bits[$i >> 5] ^= 1 << ($i & 0x1f);
+    }
+
+    /**
+     * Gets the next set bit position from a given position.
+     *
+     * @param  integer $from
+     * @return integer
+     */
+    public function getNextSet($from)
+    {
+        if ($from >= $this->size) {
+            return $this->size;
+        }
+
+        $bitsOffset  = $from >> 5;
+        $currentBits = $this->bits[$bitsOffset];
+        $bitsLength  = count($this->bits);
+
+        $currentBits &= ~((1 << ($from & 0x1f)) - 1);
+
+        while ($currentBits === 0) {
+            if (++$bitsOffset === $bitsLength) {
+                return $this->size;
+            }
+
+            $currentBits = $this->bits[$bitsOffset];
+        }
+
+        $result = ($bitsOffset << 5) + BitUtils::numberOfTrailingZeros($currentBits);
+
+        return $result > $this->size ? $this->size : $result;
+    }
+
+    /**
+     * Gets the next unset bit position from a given position.
+     *
+     * @param  integer $from
+     * @return integer
+     */
+    public function getNextUnset($from)
+    {
+        if ($from >= $this->size) {
+            return $this->size;
+        }
+
+        $bitsOffset  = $from >> 5;
+        $currentBits = ~$this->bits[$bitsOffset];
+        $bitsLength  = count($this->bits);
+
+        $currentBits &= ~((1 << ($from & 0x1f)) - 1);
+
+        while ($currentBits === 0) {
+            if (++$bitsOffset === $bitsLength) {
+                return $this->size;
+            }
+
+            $currentBits = ~$this->bits[$bitsOffset];
+        }
+
+        $result = ($bitsOffset << 5) + BitUtils::numberOfTrailingZeros($currentBits);
+
+        return $result > $this->size ? $this->size : $result;
+    }
+
+    /**
+     * Sets a bulk of bits.
+     *
+     * @param  integer $i
+     * @param  integer $newBits
+     * @return void
+     */
+    public function setBulk($i, $newBits)
+    {
+        $this->bits[$i >> 5] = $newBits;
+    }
+
+    /**
+     * Sets a range of bits.
+     *
+     * @param  integer $start
+     * @param  integer $end
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setRange($start, $end)
+    {
+        if ($end < $start) {
+            throw new Exception\InvalidArgumentException('End must be greater or equal to start');
+        }
+
+        if ($end === $start) {
+            return;
+        }
+
+        $end--;
+
+        $firstInt = $start >> 5;
+        $lastInt  = $end >> 5;
+
+        for ($i = $firstInt; $i <= $lastInt; $i++) {
+            $firstBit = $i > $firstInt ?  0 : $start & 0x1f;
+            $lastBit  = $i < $lastInt ? 31 : $end & 0x1f;
+
+            if ($firstBit === 0 && $lastBit === 31) {
+                $mask = 0x7fffffff;
+            } else {
+                $mask = 0;
+
+                for ($j = $firstBit; $j < $lastBit; $j++) {
+                    $mask |= 1 << $j;
+                }
+            }
+
+            $this->bits[$i] = $this->bits[$i] | $mask;
+        }
+    }
+
+    /**
+     * Clears the bit array, unsetting every bit.
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $bitsLength = count($this->bits);
+
+        for ($i = 0; $i < $bitsLength; $i++) {
+            $this->bits[$i] = 0;
+        }
+    }
+
+    /**
+     * Checks if a range of bits is set or not set.
+     *
+     * @param  integer $start
+     * @param  integer $end
+     * @param  integer $value
+     * @return boolean
+     * @throws Exception\InvalidArgumentException
+     */
+    public function isRange($start, $end, $value)
+    {
+        if ($end < $start) {
+            throw new Exception\InvalidArgumentException('End must be greater or equal to start');
+        }
+
+        if ($end === $start) {
+            return;
+        }
+
+        $end--;
+
+        $firstInt = $start >> 5;
+        $lastInt  = $end >> 5;
+
+        for ($i = $firstInt; $i <= $lastInt; $i++) {
+            $firstBit = $i > $firstInt ?  0 : $start & 0x1f;
+            $lastBit  = $i < $lastInt ? 31 : $end & 0x1f;
+
+            if ($firstBit === 0 && $lastBit === 31) {
+                $mask = 0x7fffffff;
+            } else {
+                $mask = 0;
+
+                for ($j = $firstBit; $j <= $lastBit; $j++) {
+                    $mask |= 1 << $j;
+                }
+            }
+
+            if (($this->bits[$i] & $mask) !== ($value ? $mask : 0)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Appends a bit to the array.
+     *
+     * @param  boolean $bit
+     * @return void
+     */
+    public function appendBit($bit)
+    {
+        $this->ensureCapacity($this->size + 1);
+
+        if ($bit) {
+            $this->bits[$this->size >> 5] = $this->bits[$this->size >> 5] | (1 << ($this->size & 0x1f));
+        }
+
+        $this->size++;
+    }
+
+    /**
+     * Appends a number of bits (up to 32) to the array.
+     *
+     * @param  integer $value
+     * @param  integer $numBits
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function appendBits($value, $numBits)
+    {
+        if ($numBits < 0 || $numBits > 32) {
+            throw new Exception\InvalidArgumentException('Num bits must be between 0 and 32');
+        }
+
+        $this->ensureCapacity($this->size + $numBits);
+
+        for ($numBitsLeft = $numBits; $numBitsLeft > 0; $numBitsLeft--) {
+            $this->appendBit((($value >> ($numBitsLeft - 1)) & 0x01) === 1);
+        }
+    }
+
+    /**
+     * Appends another bit array to this array.
+     *
+     * @param  BitArray $other
+     * @return void
+     */
+    public function appendBitArray(self $other)
+    {
+        $otherSize = $other->getSize();
+        $this->ensureCapacity($this->size + $other->getSize());
+
+        for ($i = 0; $i < $otherSize; $i++) {
+            $this->appendBit($other->get($i));
+        }
+    }
+
+    /**
+     * Makes an exclusive-or comparision on the current bit array.
+     *
+     * @param  BitArray $other
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function xorBits(self $other)
+    {
+        $bitsLength = count($this->bits);
+        $otherBits  = $other->getBitArray();
+
+        if ($bitsLength !== count($otherBits)) {
+            throw new Exception\InvalidArgumentException('Sizes don\'t match');
+        }
+
+        for ($i = 0; $i < $bitsLength; $i++) {
+            $this->bits[$i] = $this->bits[$i] ^ $otherBits[$i];
+        }
+    }
+
+    /**
+     * Converts the bit array to a byte array.
+     *
+     * @param  integer $bitOffset
+     * @param  integer $numBytes
+     * @return SplFixedArray
+     */
+    public function toBytes($bitOffset, $numBytes)
+    {
+        $bytes = new SplFixedArray($numBytes);
+
+        for ($i = 0; $i < $numBytes; $i++) {
+            $byte = 0;
+
+            for ($j = 0; $j < 8; $j++) {
+                if ($this->get($bitOffset)) {
+                    $byte |= 1 << (7 - $j);
+                }
+
+                $bitOffset++;
+            }
+
+            $bytes[$i] = $byte;
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * Gets the internal bit array.
+     *
+     * @return SplFixedArray
+     */
+    public function getBitArray()
+    {
+        return $this->bits;
+    }
+
+    /**
+     * Reverses the array.
+     *
+     * @return void
+     */
+    public function reverse()
+    {
+        $newBits = new SplFixedArray(count($this->bits));
+
+        for ($i = 0; $i < $this->size; $i++) {
+            if ($this->get($this->size - $i - 1)) {
+                $newBits[$i >> 5] = $newBits[$i >> 5] | (1 << ($i & 0x1f));
+            }
+        }
+
+        $this->bits = newBits;
+    }
+
+    /**
+     * Returns a string representation of the bit array.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = '';
+
+        for ($i = 0; $i < $this->size; $i++) {
+            if (($i & 0x07) === 0) {
+                $result .= ' ';
+            }
+
+            $result .= $this->get($i) ? 'X' : '.';
+        }
+
+        return $result;
+    }
+}

--- a/includes/BaconQrCode/Common/BitArray.php
+++ b/includes/BaconQrCode/Common/BitArray.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Common/BitMatrix.php
+++ b/includes/BaconQrCode/Common/BitMatrix.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use SplFixedArray;
+
+/**
+ * Bit matrix.
+ *
+ * Represents a 2D matrix of bits. In function arguments below, and throughout
+ * the common module, x is the column position, and y is the row position. The
+ * ordering is always x, y. The origin is at the top-left.
+ */
+class BitMatrix
+{
+    /**
+     * Width of the bit matrix.
+     *
+     * @var integer
+     */
+    protected $width;
+
+    /**
+     * Height of the bit matrix.
+     *
+     * @var integer
+     */
+    protected $height;
+
+    /**
+     * Size in bits of each individual row.
+     *
+     * @var integer
+     */
+    protected $rowSize;
+
+    /**
+     * Bits representation.
+     *
+     * @var SplFixedArray
+     */
+    protected $bits;
+
+    /**
+     * Creates a new bit matrix with given dimensions.
+     *
+     * @param  integer      $width
+     * @param  integer|null $height
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($width, $height = null)
+    {
+        if ($height === null) {
+            $height = $width;
+        }
+
+        if ($width < 1 || $height < 1) {
+            throw new Exception\InvalidArgumentException('Both dimensions must be greater than zero');
+        }
+
+        $this->width   = $width;
+        $this->height  = $height;
+        $this->rowSize = ($width + 31) >> 5;
+        $this->bits    = new SplFixedArray($this->rowSize * $height);
+    }
+
+    /**
+     * Gets the requested bit, where true means black.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @return boolean
+     */
+    public function get($x, $y)
+    {
+        $offset = $y * $this->rowSize + ($x >> 5);
+        return (BitUtils::unsignedRightShift($this->bits[$offset], ($x & 0x1f)) & 1) !== 0;
+    }
+
+    /**
+     * Sets the given bit to true.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @return void
+     */
+    public function set($x, $y)
+    {
+        $offset = $y * $this->rowSize + ($x >> 5);
+        $this->bits[$offset] = $this->bits[$offset] | (1 << ($x & 0x1f));
+    }
+
+    /**
+     * Flips the given bit.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @return void
+     */
+    public function flip($x, $y)
+    {
+        $offset = $y * $this->rowSize + ($x >> 5);
+        $this->bits[$offset] = $this->bits[$offset] ^ (1 << ($x & 0x1f));
+    }
+
+    /**
+     * Clears all bits (set to false).
+     *
+     * @return void
+     */
+    public function clear()
+    {
+        $max = count($this->bits);
+
+        for ($i = 0; $i < $max; $i++) {
+            $this->bits[$i] = 0;
+        }
+    }
+
+    /**
+     * Sets a square region of the bit matrix to true.
+     *
+     * @param  integer $left
+     * @param  integer $top
+     * @param  integer $width
+     * @param  integer $height
+     * @return void
+     */
+    public function setRegion($left, $top, $width, $height)
+    {
+        if ($top < 0 || $left < 0) {
+            throw new Exception\InvalidArgumentException('Left and top must be non-negative');
+        }
+
+        if ($height < 1 || $width < 1) {
+            throw new Exception\InvalidArgumentException('Width and height must be at least 1');
+        }
+
+        $right  = $left + $width;
+        $bottom = $top + $height;
+
+        if ($bottom > $this->height || $right > $this->width) {
+            throw new Exception\InvalidArgumentException('The region must fit inside the matrix');
+        }
+
+        for ($y = $top; $y < $bottom; $y++) {
+            $offset = $y * $this->rowSize;
+
+            for ($x = $left; $x < $right; $x++) {
+                $index = $offset + ($x >> 5);
+                $this->bits[$index] = $this->bits[$index] | (1 << ($x & 0x1f));
+            }
+        }
+    }
+
+    /**
+     * A fast method to retrieve one row of data from the matrix as a BitArray.
+     *
+     * @param  integer  $y
+     * @param  BitArray $row
+     * @return BitArray
+     */
+    public function getRow($y, BitArray $row = null)
+    {
+        if ($row === null || $row->getSize() < $this->width) {
+            $row = new BitArray($this->width);
+        }
+
+        $offset = $y * $this->rowSize;
+
+        for ($x = 0; $x < $this->rowSize; $x++) {
+            $row->setBulk($x << 5, $this->bits[$offset + $x]);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Sets a row of data from a BitArray.
+     *
+     * @param  integer  $y
+     * @param  BitArray $row
+     * @return void
+     */
+    public function setRow($y, BitArray $row)
+    {
+        $bits = $row->getBitArray();
+
+        for ($i = 0; $i < $this->rowSize; $i++) {
+            $this->bits[$y * $this->rowSize + $i] = $bits[$i];
+        }
+    }
+
+    /**
+     * This is useful in detecting the enclosing rectangle of a 'pure' barcode.
+     *
+     * @return SplFixedArray
+     */
+    public function getEnclosingRectangle()
+    {
+        $left   = $this->width;
+        $top    = $this->height;
+        $right  = -1;
+        $bottom = -1;
+
+        for ($y = 0; $y < $this->height; $y++) {
+            for ($x32 = 0; $x32 < $this->rowSize; $x32++) {
+                $bits = $this->bits[$y * $this->rowSize + $x32];
+
+                if ($bits !== 0) {
+                    if ($y < $top) {
+                        $top = $y;
+                    }
+
+                    if ($y > $bottom) {
+                        $bottom = $y;
+                    }
+
+                    if ($x32 * 32 < $left) {
+                        $bit = 0;
+
+                        while (($bits << (31 - $bit)) === 0) {
+                            $bit++;
+                        }
+
+                        if (($x32 * 32 + $bit) < $left) {
+                            $left = $x32 * 32 + $bit;
+                        }
+                    }
+                }
+
+                if ($x32 * 32 + 31 > $right) {
+                    $bit = 31;
+
+                    while (BitUtils::unsignedRightShift($bits, $bit) === 0) {
+                        $bit--;
+                    }
+
+                    if (($x32 * 32 + $bit) > $right) {
+                        $right = $x32 * 32 + $bit;
+                    }
+                }
+            }
+        }
+
+        $width  = $right - $left;
+        $height = $bottom - $top;
+
+        if ($width < 0 || $height < 0) {
+            return null;
+        }
+
+        return SplFixedArray::fromArray(array($left, $top, $width, $height), false);
+    }
+
+    /**
+     * Gets the most top left set bit.
+     *
+     * This is useful in detecting a corner of a 'pure' barcode.
+     *
+     * @return SplFixedArray
+     */
+    public function getTopLeftOnBit()
+    {
+        $bitsOffset = 0;
+
+        while ($bitsOffset < count($this->bits) && $this->bits[$bitsOffset] === 0) {
+            $bitsOffset++;
+        }
+
+        if ($bitsOffset === count($this->bits)) {
+            return null;
+        }
+
+        $x = intval($bitsOffset / $this->rowSize);
+        $y = ($bitsOffset % $this->rowSize) << 5;
+
+        $bits = $this->bits[$bitsOffset];
+        $bit  = 0;
+
+        while (($bits << (31 - $bit)) === 0) {
+            $bit++;
+        }
+
+        $x += $bit;
+
+        return SplFixedArray::fromArray(array($x, $y), false);
+    }
+
+    /**
+     * Gets the most bottom right set bit.
+     *
+     * This is useful in detecting a corner of a 'pure' barcode.
+     *
+     * @return SplFixedArray
+     */
+    public function getBottomRightOnBit()
+    {
+        $bitsOffset = count($this->bits) - 1;
+
+        while ($bitsOffset >= 0 && $this->bits[$bitsOffset] === 0) {
+            $bitsOffset--;
+        }
+
+        if ($bitsOffset < 0) {
+            return null;
+        }
+
+        $x = intval($bitsOffset / $this->rowSize);
+        $y = ($bitsOffset % $this->rowSize) << 5;
+
+        $bits = $this->bits[$bitsOffset];
+        $bit  = 0;
+
+        while (BitUtils::unsignedRightShift($bits, $bit) === 0) {
+            $bit--;
+        }
+
+        $x += $bit;
+
+        return SplFixedArray::fromArray(array($x, $y), false);
+    }
+
+    /**
+     * Gets the width of the matrix,
+     *
+     * @return integer
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * Gets the height of the matrix.
+     *
+     * @return integer
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+}

--- a/includes/BaconQrCode/Common/BitMatrix.php
+++ b/includes/BaconQrCode/Common/BitMatrix.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Common/BitUtils.php
+++ b/includes/BaconQrCode/Common/BitUtils.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * General bit utilities.
+ *
+ * All utility methods are based on 32-bit integers and also work on 64-bit
+ * systems.
+ */
+class BitUtils
+{
+    /**
+     * Performs an unsigned right shift.
+     *
+     * This is the same as the unsigned right shift operator ">>>" in other
+     * languages.
+     *
+     * @param  integer $a
+     * @param  integer $b
+     * @return integer
+     */
+    public static function unsignedRightShift($a, $b)
+    {
+        return (
+            $a >= 0
+            ? $a >> $b
+            : (($a & 0x7fffffff) >> $b) | (0x40000000 >> ($b - 1))
+        );
+    }
+
+    /**
+     * Gets the number of trailing zeros.
+     *
+     * @param  integer $i
+     * @return integer
+     */
+    public static function numberOfTrailingZeros($i)
+    {
+        $lastPos = strrpos(str_pad(decbin($i), 32, '0', STR_PAD_LEFT), '1');
+
+        return $lastPos === false ? 32 : 31 - $lastPos;
+    }
+}

--- a/includes/BaconQrCode/Common/BitUtils.php
+++ b/includes/BaconQrCode/Common/BitUtils.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * General bit utilities.

--- a/includes/BaconQrCode/Common/CharacterSetEci.php
+++ b/includes/BaconQrCode/Common/CharacterSetEci.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * Encapsulates a Character Set ECI, according to "Extended Channel
+ * Interpretations" 5.3.1.1 of ISO 18004.
+ */
+class CharacterSetEci extends AbstractEnum
+{
+    /**#@+
+     * Character set constants.
+     */
+    const CP437                = 0;
+    const ISO8859_1            = 1;
+    const ISO8859_2            = 4;
+    const ISO8859_3            = 5;
+    const ISO8859_4            = 6;
+    const ISO8859_5            = 7;
+    const ISO8859_6            = 8;
+    const ISO8859_7            = 9;
+    const ISO8859_8            = 10;
+    const ISO8859_9            = 11;
+    const ISO8859_10           = 12;
+    const ISO8859_11           = 13;
+    const ISO8859_12           = 14;
+    const ISO8859_13           = 15;
+    const ISO8859_14           = 16;
+    const ISO8859_15           = 17;
+    const ISO8859_16           = 18;
+    const SJIS                 = 20;
+    const CP1250               = 21;
+    const CP1251               = 22;
+    const CP1252               = 23;
+    const CP1256               = 24;
+    const UNICODE_BIG_UNMARKED = 25;
+    const UTF8                 = 26;
+    const ASCII                = 27;
+    const BIG5                 = 28;
+    const GB18030              = 29;
+    const EUC_KR               = 30;
+    /**#@-*/
+
+    /**
+     * Map between character names and their ECI values.
+     *
+     * @var array
+     */
+    protected static $nameToEci = array(
+        'ISO-8859-1'   => self::ISO8859_1,
+        'ISO-8859-2'   => self::ISO8859_2,
+        'ISO-8859-3'   => self::ISO8859_3,
+        'ISO-8859-4'   => self::ISO8859_4,
+        'ISO-8859-5'   => self::ISO8859_5,
+        'ISO-8859-6'   => self::ISO8859_6,
+        'ISO-8859-7'   => self::ISO8859_7,
+        'ISO-8859-8'   => self::ISO8859_8,
+        'ISO-8859-9'   => self::ISO8859_9,
+        'ISO-8859-10'  => self::ISO8859_10,
+        'ISO-8859-11'  => self::ISO8859_11,
+        'ISO-8859-12'  => self::ISO8859_12,
+        'ISO-8859-13'  => self::ISO8859_13,
+        'ISO-8859-14'  => self::ISO8859_14,
+        'ISO-8859-15'  => self::ISO8859_15,
+        'ISO-8859-16'  => self::ISO8859_16,
+        'SHIFT-JIS'    => self::SJIS,
+        'WINDOWS-1250' => self::CP1250,
+        'WINDOWS-1251' => self::CP1251,
+        'WINDOWS-1252' => self::CP1252,
+        'WINDOWS-1256' => self::CP1256,
+        'UTF-16BE'     => self::UNICODE_BIG_UNMARKED,
+        'UTF-8'        => self::UTF8,
+        'ASCII'        => self::ASCII,
+        'GBK'          => self::GB18030,
+        'EUC-KR'       => self::EUC_KR,
+    );
+
+    /**
+     * Additional possible values for character sets.
+     *
+     * @var array
+     */
+    protected $additionalValues = array(
+        self::CP437 => 2,
+        self::ASCII => 170,
+    );
+
+    /**
+     * Gets character set ECI by value.
+     *
+     * @param  string $name
+     * @return CharacterSetEci|null
+     */
+    public static function getCharacterSetECIByValue($value)
+    {
+        if ($value < 0 || $value >= 900) {
+            throw new Exception\InvalidArgumentException('Value must be between 0 and 900');
+        }
+
+        if (false !== ($key = array_search($value, self::$additionalValues))) {
+            $value = $key;
+        }
+
+        try {
+            return new self($value);
+        } catch (Exception\UnexpectedValueException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets character set ECI by name.
+     *
+     * @param  string $name
+     * @return CharacterSetEci|null
+     */
+    public static function getCharacterSetECIByName($name)
+    {
+        $name = strtoupper($name);
+
+        if (isset(self::$nameToEci[$name])) {
+            return new self(self::$nameToEci[$name]);
+        }
+
+        return null;
+    }
+}

--- a/includes/BaconQrCode/Common/CharacterSetEci.php
+++ b/includes/BaconQrCode/Common/CharacterSetEci.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * Encapsulates a Character Set ECI, according to "Extended Channel

--- a/includes/BaconQrCode/Common/EcBlock.php
+++ b/includes/BaconQrCode/Common/EcBlock.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * Encapsualtes the parameters for one error-correction block in one symbol
+ * version. This includes the number of data codewords, and the number of times
+ * a block with these parameters is used consecutively in the QR code version's
+ * format.
+ */
+class EcBlock
+{
+    /**
+     * How many times the block is used.
+     *
+     * @var integer
+     */
+    protected $count;
+
+    /**
+     * Number of data codewords.
+     *
+     * @var integer
+     */
+    protected $dataCodewords;
+
+    /**
+     * Creates a new EC block.
+     *
+     * @param integer $count
+     * @param integer $dataCodewords
+     */
+    public function __construct($count, $dataCodewords)
+    {
+        $this->count         = $count;
+        $this->dataCodewords = $dataCodewords;
+    }
+
+    /**
+     * Returns how many times the block is used.
+     *
+     * @return integer
+     */
+    public function getCount()
+    {
+        return $this->count;
+    }
+
+    /**
+     * Returns the number of data codewords.
+     *
+     * @return integer
+     */
+    public function getDataCodewords()
+    {
+        return $this->dataCodewords;
+    }
+}

--- a/includes/BaconQrCode/Common/EcBlock.php
+++ b/includes/BaconQrCode/Common/EcBlock.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * Encapsualtes the parameters for one error-correction block in one symbol

--- a/includes/BaconQrCode/Common/EcBlocks.php
+++ b/includes/BaconQrCode/Common/EcBlocks.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use SplFixedArray;
+
+/**
+ * Encapsulates a set of error-correction blocks in one symbol version. Most
+ * versions will use blocks of differing sizes within one version, so, this
+ * encapsulates the parameters for each set of blocks. It also holds the number
+ * of error-correction codewords per block since it will be the same across all
+ * blocks within one version.
+ */
+class EcBlocks
+{
+    /**
+     * Number of EC codewords per block.
+     *
+     * @var integer
+     */
+    protected $ecCodewordsPerBlock;
+
+    /**
+     * List of EC blocks.
+     *
+     * @var SplFixedArray
+     */
+    protected $ecBlocks;
+
+    /**
+     * Creates a new EC blocks instance.
+     *
+     * @param integer      $ecCodewordsPerBlock
+     * @param EcBlock      $ecb1
+     * @param EcBlock|null $ecb2
+     */
+    public function __construct($ecCodewordsPerBlock, EcBlock $ecb1, EcBlock $ecb2 = null)
+    {
+        $this->ecCodewordsPerBlock = $ecCodewordsPerBlock;
+
+        $this->ecBlocks = new SplFixedArray($ecb2 === null ? 1 : 2);
+        $this->ecBlocks[0] = $ecb1;
+
+        if ($ecb2 !== null) {
+            $this->ecBlocks[1] = $ecb2;
+        }
+    }
+
+    /**
+     * Gets the number of EC codewords per block.
+     *
+     * @return integer
+     */
+    public function getEcCodewordsPerBlock()
+    {
+        return $this->ecCodewordsPerBlock;
+    }
+
+    /**
+     * Gets the total number of EC block appearances.
+     *
+     * @return integer
+     */
+    public function getNumBlocks()
+    {
+        $total = 0;
+
+        foreach ($this->ecBlocks as $ecBlock) {
+            $total += $ecBlock->getCount();
+        }
+
+        return $total;
+    }
+
+    /**
+     * Gets the total count of EC codewords.
+     *
+     * @return integer
+     */
+    public function getTotalEcCodewords()
+    {
+        return $this->ecCodewordsPerBlock * $this->getNumBlocks();
+    }
+
+    /**
+     * Gets the EC blocks included in this collection.
+     *
+     * @return SplFixedArray
+     */
+    public function getEcBlocks()
+    {
+        return $this->ecBlocks;
+    }
+}

--- a/includes/BaconQrCode/Common/EcBlocks.php
+++ b/includes/BaconQrCode/Common/EcBlocks.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Common/ErrorCorrectionLevel.php
+++ b/includes/BaconQrCode/Common/ErrorCorrectionLevel.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * Enum representing the four error correction levels.
+ */
+class ErrorCorrectionLevel extends AbstractEnum
+{
+    /**
+     * Level L, ~7% correction.
+     */
+    const L = 0x1;
+
+    /**
+     * Level M, ~15% correction.
+     */
+    const M = 0x0;
+
+    /**
+     * Level Q, ~25% correction.
+     */
+    const Q = 0x3;
+
+    /**
+     * Level H, ~30% correction.
+     */
+    const H = 0x2;
+
+    /**
+     * Gets the ordinal of this enumeration constant.
+     *
+     * @return integer
+     */
+    public function getOrdinal()
+    {
+        switch ($this->value) {
+            case self::L:
+                return 0;
+                break;
+
+            case self::M:
+                return 1;
+                break;
+
+            case self::Q:
+                return 2;
+                break;
+
+            case self::H:
+                return 3;
+                break;
+        }
+    }
+}

--- a/includes/BaconQrCode/Common/ErrorCorrectionLevel.php
+++ b/includes/BaconQrCode/Common/ErrorCorrectionLevel.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * Enum representing the four error correction levels.

--- a/includes/BaconQrCode/Common/FormatInformation.php
+++ b/includes/BaconQrCode/Common/FormatInformation.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * Encapsulates a QR Code's format information, including the data mask used and
+ * error correction level.
+ */
+class FormatInformation
+{
+    /**
+     * Mask for format information.
+     */
+    const FORMAT_INFO_MASK_QR = 0x5412;
+
+    /**
+     * Lookup table for decoding format information.
+     *
+     * See ISO 18004:2006, Annex C, Table C.1
+     *
+     * @var array
+     */
+    protected static $formatInfoDecodeLookup = array(
+        array(0x5412, 0x00),
+        array(0x5125, 0x01),
+        array(0x5e7c, 0x02),
+        array(0x5b4b, 0x03),
+        array(0x45f9, 0x04),
+        array(0x40ce, 0x05),
+        array(0x4f97, 0x06),
+        array(0x4aa0, 0x07),
+        array(0x77c4, 0x08),
+        array(0x72f3, 0x09),
+        array(0x7daa, 0x0a),
+        array(0x789d, 0x0b),
+        array(0x662f, 0x0c),
+        array(0x6318, 0x0d),
+        array(0x6c41, 0x0e),
+        array(0x6976, 0x0f),
+        array(0x1689, 0x10),
+        array(0x13be, 0x11),
+        array(0x1ce7, 0x12),
+        array(0x19d0, 0x13),
+        array(0x0762, 0x14),
+        array(0x0255, 0x15),
+        array(0x0d0c, 0x16),
+        array(0x083b, 0x17),
+        array(0x355f, 0x18),
+        array(0x3068, 0x19),
+        array(0x3f31, 0x1a),
+        array(0x3a06, 0x1b),
+        array(0x24b4, 0x1c),
+        array(0x2183, 0x1d),
+        array(0x2eda, 0x1e),
+        array(0x2bed, 0x1f),
+    );
+
+    /**
+     * Offset i holds the number of 1 bits in the binary representation of i.
+     *
+     * @var array
+     */
+    protected static $bitsSetInHalfByte = array(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
+
+    /**
+     * Error correction level.
+     *
+     * @var ErrorCorrectionLevel
+     */
+    protected $ecLevel;
+
+    /**
+     * Data mask.
+     *
+     * @var integer
+     */
+    protected $dataMask;
+
+    /**
+     * Creates a new format information instance.
+     *
+     * @param integer $formatInfo
+     */
+    protected function __construct($formatInfo)
+    {
+        $this->ecLevel  = new ErrorCorrectionLevel(($formatInfo >> 3) & 0x3);
+        $this->dataMask = $formatInfo & 0x7;
+    }
+
+    /**
+     * Checks how many bits are different between two integers.
+     *
+     * @param  integer $a
+     * @param  integer $b
+     * @return integer
+     */
+    public static function numBitsDiffering($a, $b)
+    {
+        $a ^= $b;
+
+        return (
+            self::$bitsSetInHalfByte[$a & 0xf]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 4) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 8) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 12) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 16) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 20) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 24) & 0xf)]
+            + self::$bitsSetInHalfByte[(BitUtils::unsignedRightShift($a, 28) & 0xf)]
+        );
+    }
+
+    /**
+     * Decodes format information.
+     *
+     * @param  integer $maskedFormatInfo1
+     * @param  integer $maskedFormatInfo2
+     * @return FormatInformation|null
+     */
+    public static function decodeFormatInformation($maskedFormatInfo1, $maskedFormatInfo2)
+    {
+        $formatInfo = self::doDecodeFormatInformation($maskedFormatInfo1, $maskedFormatInfo2);
+
+        if ($formatInfo !== null) {
+            return $formatInfo;
+        }
+
+        // Should return null, but, some QR codes apparently do not mask this
+        // info. Try again by actually masking the pattern first.
+        return self::doDecodeFormatInformation(
+            $maskedFormatInfo1 ^ self::FORMAT_INFO_MASK_QR,
+            $maskedFormatInfo2 ^ self::FORMAT_INFO_MASK_QR
+        );
+    }
+
+    /**
+     * Internal method for decoding format information.
+     *
+     * @param  integer $maskedFormatInfo1
+     * @param  integer $maskedFormatInfo2
+     * @return FormatInformation|null
+     */
+    protected static function doDecodeFormatInformation($maskedFormatInfo1, $maskedFormatInfo2)
+    {
+        $bestDifference = PHP_INT_MAX;
+        $bestFormatInfo = 0;
+
+        foreach (self::$formatInfoDecodeLookup as $decodeInfo) {
+            $targetInfo = $decodeInfo[0];
+
+            if ($targetInfo === $maskedFormatInfo1 || $targetInfo === $maskedFormatInfo2) {
+                // Found an exact match
+                return new self($decodeInfo[1]);
+            }
+
+            $bitsDifference = self::numBitsDiffering($maskedFormatInfo1, $targetInfo);
+
+            if ($bitsDifference < $bestDifference) {
+                $bestFormatInfo = $decodeInfo[1];
+                $bestDifference = $bitsDifference;
+            }
+
+            if ($maskedFormatInfo1 !== $maskedFormatInfo2) {
+                // Also try the other option
+                $bitsDifference = self::numBitsDiffering($maskedFormatInfo2, $targetInfo);
+
+                if ($bitsDifference < $bestDifference) {
+                    $bestFormatInfo = $decodeInfo[1];
+                    $bestDifference = $bitsDifference;
+                }
+            }
+        }
+
+        // Hamming distance of the 32 masked codes is 7, by construction, so
+        // <= 3 bits differing means we found a match.
+        if ($bestDifference <= 3) {
+            return new self($bestFormatInfo);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the error correction level.
+     *
+     * @return ErrorCorrectionLevel
+     */
+    public function getErrorCorrectionLevel()
+    {
+        return $this->ecLevel;
+    }
+
+    /**
+     * Gets the data mask.
+     *
+     * @return integer
+     */
+    public function getDataMask()
+    {
+        return $this->dataMask;
+    }
+
+    /**
+     * Hashes the code of the EC level.
+     *
+     * @return integer
+     */
+    public function hashCode()
+    {
+        return ($this->ecLevel->get() << 3) | $this->dataMask;
+    }
+
+    /**
+     * Verifies if this instance equals another one.
+     *
+     * @param  mixed $other
+     * @return boolean
+     */
+    public function equals($other) {
+        if (!$other instanceof self) {
+            return false;
+        }
+
+        return (
+            $this->ecLevel->get() === $other->getErrorCorrectionLevel()->get()
+            && $this->dataMask === $other->getDataMask()
+        );
+    }
+}

--- a/includes/BaconQrCode/Common/FormatInformation.php
+++ b/includes/BaconQrCode/Common/FormatInformation.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * Encapsulates a QR Code's format information, including the data mask used and

--- a/includes/BaconQrCode/Common/Mode.php
+++ b/includes/BaconQrCode/Common/Mode.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+/**
+ * Enum representing various modes in which data can be encoded to bits.
+ */
+class Mode extends AbstractEnum
+{
+    /**#@+
+     * Mode constants.
+     */
+    const TERMINATOR           = 0x0;
+    const NUMERIC              = 0x1;
+    const ALPHANUMERIC         = 0x2;
+    const STRUCTURED_APPEND    = 0x3;
+    const BYTE                 = 0x4;
+    const ECI                  = 0x7;
+    const KANJI                = 0x8;
+    const FNC1_FIRST_POSITION  = 0x5;
+    const FNC1_SECOND_POSITION = 0x9;
+    const HANZI                = 0xd;
+    /**#@-*/
+
+    /**
+     * Character count bits for each version.
+     *
+     * @var array
+     */
+    protected static $characterCountBitsForVersions = array(
+        self::TERMINATOR           => array(0, 0, 0),
+        self::NUMERIC              => array(10, 12, 14),
+        self::ALPHANUMERIC         => array(9, 11, 13),
+        self::STRUCTURED_APPEND    => array(0, 0, 0),
+        self::BYTE                 => array(8, 16, 16),
+        self::ECI                  => array(0, 0, 0),
+        self::KANJI                => array(8, 10, 12),
+        self::FNC1_FIRST_POSITION  => array(0, 0, 0),
+        self::FNC1_SECOND_POSITION => array(0, 0, 0),
+        self::HANZI                => array(8, 10, 12),
+    );
+
+    /**
+     * Gets the number of bits used in a specific QR code version.
+     *
+     * @param  Version $version
+     * @return integer
+     */
+    public function getCharacterCountBits(Version $version)
+    {
+        $number = $version->getVersionNumber();
+
+        if ($number <= 9) {
+            $offset = 0;
+        } elseif ($number <= 26) {
+            $offset = 1;
+        } else {
+            $offset = 2;
+        }
+
+        return self::$characterCountBitsForVersions[$this->value][$offset];
+    }
+}

--- a/includes/BaconQrCode/Common/Mode.php
+++ b/includes/BaconQrCode/Common/Mode.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 /**
  * Enum representing various modes in which data can be encoded to bits.

--- a/includes/BaconQrCode/Common/ReedSolomonCodec.php
+++ b/includes/BaconQrCode/Common/ReedSolomonCodec.php
@@ -1,0 +1,476 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use BaconQrCode\Exception;
+use SplFixedArray;
+
+/**
+ * Reed-Solomon codec for 8-bit characters.
+ *
+ * Based on libfec by Phil Karn, KA9Q.
+ */
+class ReedSolomonCodec
+{
+    /**
+     * Symbol size in bits.
+     *
+     * @var integer
+     */
+    protected $symbolSize;
+
+    /**
+     * Block size in symbols.
+     *
+     * @var integer
+     */
+    protected $blockSize;
+
+    /**
+     * First root of RS code generator polynomial, index form.
+     *
+     * @var integer
+     */
+    protected $firstRoot;
+
+    /**
+     * Primitive element to generate polynomial roots, index form.
+     *
+     * @var integer
+     */
+    protected $primitive;
+
+    /**
+     * Prim-th root of 1, index form.
+     *
+     * @var integer
+     */
+    protected $iPrimitive;
+
+    /**
+     * RS code generator polynomial degree (number of roots).
+     *
+     * @var integer
+     */
+    protected $numRoots;
+
+    /**
+     * Padding bytes at front of shortened block.
+     *
+     * @var integer
+     */
+    protected $padding;
+
+    /**
+     * Log lookup table.
+     *
+     * @var SplFixedArray
+     */
+    protected $alphaTo;
+
+    /**
+     * Anti-Log lookup table.
+     *
+     * @var SplFixedArray
+     */
+    protected $indexOf;
+
+    /**
+     * Generator polynomial.
+     *
+     * @var SplFixedArray
+     */
+    protected $generatorPoly;
+
+    /**
+     * Creates a new reed solomon instance.
+     *
+     * @param  integer $symbolSize
+     * @param  integer $gfPoly
+     * @param  integer $firstRoot
+     * @param  integer $primitive
+     * @param  integer $numRoots
+     * @param  integer $padding
+     * @throws Exception\InvalidArgumentException
+     * @throws Exception\RuntimeException
+     */
+    public function __construct($symbolSize, $gfPoly, $firstRoot, $primitive, $numRoots, $padding)
+    {
+        if ($symbolSize < 0 || $symbolSize > 8) {
+            throw new Exception\InvalidArgumentException('Symbol size must be between 0 and 8');
+        }
+
+        if ($firstRoot < 0 || $firstRoot >= (1 << $symbolSize)) {
+            throw new Exception\InvalidArgumentException('First root must be between 0 and ' . (1 << $symbolSize));
+        }
+
+        if ($numRoots < 0 || $numRoots >= (1 << $symbolSize)) {
+            throw new Exception\InvalidArgumentException('Num roots must be between 0 and ' . (1 << $symbolSize));
+        }
+
+        if ($padding < 0 || $padding >= ((1 << $symbolSize) - 1 - $numRoots)) {
+            throw new Exception\InvalidArgumentException('Padding must be between 0 and ' . ((1 << $symbolSize) - 1 - $numRoots));
+        }
+
+        $this->symbolSize = $symbolSize;
+        $this->blockSize  = (1 << $symbolSize) - 1;
+        $this->padding    = $padding;
+        $this->alphaTo    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0), false);
+        $this->indexOf    = SplFixedArray::fromArray(array_fill(0, $this->blockSize + 1, 0), false);
+
+        // Generate galous field lookup table
+        $this->indexOf[0]                = $this->blockSize;
+        $this->alphaTo[$this->blockSize] = 0;
+
+        $sr = 1;
+
+        for ($i = 0; $i < $this->blockSize; $i++) {
+            $this->indexOf[$sr] = $i;
+            $this->alphaTo[$i]  = $sr;
+
+            $sr <<= 1;
+
+            if ($sr & (1 << $symbolSize)) {
+                $sr ^= $gfPoly;
+            }
+
+            $sr &= $this->blockSize;
+        }
+
+        if ($sr !== 1) {
+            throw new Exception\RuntimeException('Field generator polynomial is not primitive');
+        }
+
+        // Form RS code generator polynomial from its roots
+        $this->generatorPoly = SplFixedArray::fromArray(array_fill(0, $numRoots + 1, 0), false);
+        $this->firstRoot     = $firstRoot;
+        $this->primitive     = $primitive;
+        $this->numRoots      = $numRoots;
+
+        // Find prim-th root of 1, used in decoding
+        for ($iPrimitive = 1; ($iPrimitive % $primitive) !== 0; $iPrimitive += $this->blockSize);
+        $this->iPrimitive = intval($iPrimitive / $primitive);
+
+        $this->generatorPoly[0] = 1;
+
+        for ($i = 0, $root = $firstRoot * $primitive; $i < $numRoots; $i++, $root += $primitive) {
+            $this->generatorPoly[$i + 1] = 1;
+
+            for ($j = $i; $j > 0; $j--) {
+                if ($this->generatorPoly[$j] !== 0) {
+                    $this->generatorPoly[$j] = $this->generatorPoly[$j - 1] ^ $this->alphaTo[$this->modNn($this->indexOf[$this->generatorPoly[$j]] + $root)];
+                } else {
+                    $this->generatorPoly[$j] = $this->generatorPoly[$j - 1];
+                }
+            }
+
+            $this->generatorPoly[$j] = $this->alphaTo[$this->modNn($this->indexOf[$this->generatorPoly[0]] + $root)];
+        }
+
+        // Convert generator poly to index form for quicker encoding
+        for ($i = 0; $i <= $numRoots; $i++) {
+            $this->generatorPoly[$i] = $this->indexOf[$this->generatorPoly[$i]];
+        }
+    }
+
+    /**
+     * Encodes data and writes result back into parity array.
+     *
+     * @param  SplFixedArray $data
+     * @param  SplFixedArray $parity
+     * @return void
+     */
+    public function encode(SplFixedArray $data, SplFixedArray $parity)
+    {
+        for ($i = 0; $i < $this->numRoots; $i++) {
+            $parity[$i] = 0;
+        }
+
+        $iterations = $this->blockSize - $this->numRoots - $this->padding;
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $feedback = $this->indexOf[$data[$i] ^ $parity[0]];
+
+            if ($feedback !== $this->blockSize) {
+                // Feedback term is non-zero
+                $feedback = $this->modNn($this->blockSize - $this->generatorPoly[$this->numRoots] + $feedback);
+
+                for ($j = 1; $j < $this->numRoots; $j++) {
+                    $parity[$j] = $parity[$j] ^ $this->alphaTo[$this->modNn($feedback + $this->generatorPoly[$this->numRoots - $j])];
+                }
+            }
+
+            for ($j = 0; $j < $this->numRoots - 1; $j++) {
+                $parity[$j] = $parity[$j + 1];
+            }
+
+            if ($feedback !== $this->blockSize) {
+                $parity[$this->numRoots - 1] = $this->alphaTo[$this->modNn($feedback + $this->generatorPoly[0])];
+            } else {
+                $parity[$this->numRoots - 1] = 0;
+            }
+        }
+    }
+
+    /**
+     * Decodes received data.
+     *
+     * @param  SplFixedArray      $data
+     * @param  SplFixedArray|null $erasures
+     * @return null|integer
+     */
+    public function decode(SplFixedArray $data, SplFixedArray $erasures = null)
+    {
+        // This speeds up the initialization a bit.
+        $numRootsPlusOne = SplFixedArray::fromArray(array_fill(0, $this->numRoots + 1, 0), false);
+        $numRoots        = SplFixedArray::fromArray(array_fill(0, $this->numRoots, 0), false);
+
+        $lambda    = clone $numRootsPlusOne;
+        $b         = clone $numRootsPlusOne;
+        $t         = clone $numRootsPlusOne;
+        $omega     = clone $numRootsPlusOne;
+        $root      = clone $numRoots;
+        $loc       = clone $numRoots;
+
+        $numErasures = ($erasures !== null ? count($erasures) : 0);
+
+        // Form the Syndromes; i.e., evaluate data(x) at roots of g(x)
+        $syndromes = SplFixedArray::fromArray(array_fill(0, $this->numRoots, $data[0]), false);
+
+        for ($i = 1; $i < $this->blockSize - $this->padding; $i++) {
+            for ($j = 0; $j < $this->numRoots; $j++) {
+                if ($syndromes[$j] === 0) {
+                    $syndromes[$j] = $data[$i];
+                } else {
+                    $syndromes[$j] = $data[$i] ^ $this->alphaTo[
+                        $this->modNn($this->indexOf[$syndromes[$j]] + ($this->firstRoot + $j) * $this->primitive)
+                    ];
+                }
+            }
+        }
+
+        // Convert syndromes to index form, checking for nonzero conditions
+        $syndromeError = 0;
+
+        for ($i = 0; $i < $this->numRoots; $i++) {
+            $syndromeError |= $syndromes[$i];
+            $syndromes[$i]  = $this->indexOf[$syndromes[$i]];
+        }
+
+        if (!$syndromeError) {
+            // If syndrome is zero, data[] is a codeword and there are no errors
+            // to correct, so return data[] unmodified.
+            return 0;
+        }
+
+        $lambda[0] = 1;
+
+        if ($numErasures > 0) {
+            // Init lambda to be the erasure locator polynomial
+            $lambda[1] = $this->alphaTo[$this->modNn($this->primitive * ($this->blockSize - 1 - $erasures[0]))];
+
+            for ($i = 1; $i < $numErasures; $i++) {
+                $u = $this->modNn($this->primitive * ($this->blockSize - 1 - $erasures[$i]));
+
+                for ($j = $i + 1; $j > 0; $j--) {
+                    $tmp = $this->indexOf[$lambda[$j - 1]];
+
+                    if ($tmp !== $this->blockSize) {
+                        $lambda[$j] = $lambda[$j] ^ $this->alphaTo[$this->modNn($u + $tmp)];
+                    }
+                }
+            }
+        }
+
+        for ($i = 0; $i <= $this->numRoots; $i++) {
+            $b[$i] = $this->indexOf[$lambda[$i]];
+        }
+
+        // Begin Berlekamp-Massey algorithm to determine error+erasure locator
+        // polynomial
+        $r  = $numErasures;
+        $el = $numErasures;
+
+        while (++$r <= $this->numRoots) {
+            // Compute discrepancy at the r-th step in poly form
+            $discrepancyR = 0;
+
+            for ($i = 0; $i < $r; $i++) {
+                if ($lambda[$i] !== 0 && $syndromes[$r - $i - 1] !== $this->blockSize) {
+                    $discrepancyR ^= $this->alphaTo[$this->modNn($this->indexOf[$lambda[$i]] + $syndromes[$r - $i - 1])];
+                }
+            }
+
+            $discrepancyR = $this->indexOf[$discrepancyR];
+
+            if ($discrepancyR === $this->blockSize) {
+                $tmp = $b->toArray();
+                array_unshift($tmp, $this->blockSize);
+                array_pop($tmp);
+                $b = SplFixedArray::fromArray($tmp, false);
+            } else {
+                $t[0] = $lambda[0];
+
+                for ($i = 0; $i < $this->numRoots; $i++) {
+                    if ($b[$i] !== $this->blockSize) {
+                        $t[$i + 1] = $lambda[$i + 1] ^ $this->alphaTo[$this->modNn($discrepancyR + $b[$i])];
+                    } else {
+                        $t[$i + 1] = $lambda[$i + 1];
+                    }
+                }
+
+                if (2 * $el <= $r + $numErasures - 1) {
+                    $el = $r + $numErasures - $el;
+
+                    for ($i = 0; $i <= $this->numRoots; $i++) {
+                        $b[$i] = (
+                            $lambda[$i] === 0
+                            ? $this->blockSize
+                            : $this->modNn($this->indexOf[$lambda[$i]] - $discrepancyR + $this->blockSize)
+                        );
+                    }
+                } else {
+                    $tmp = $b->toArray();
+                    array_unshift($tmp, $this->blockSize);
+                    array_pop($tmp);
+                    $b = SplFixedArray::fromArray($tmp, false);
+                }
+
+                $lambda = clone $t;
+            }
+        }
+
+        // Convert lambda to index form and compute deg(lambda(x))
+        $degLambda = 0;
+
+        for ($i = 0; $i <= $this->numRoots; $i++) {
+            $lambda[$i] = $this->indexOf[$lambda[$i]];
+
+            if ($lambda[$i] !== $this->blockSize) {
+                $degLambda = $i;
+            }
+        }
+
+        // Find roots of the error+erasure locator polynomial by Chien search.
+        $reg    = clone $lambda;
+        $reg[0] = 0;
+        $count  = 0;
+
+        for ($i = 1, $k = $this->iPrimitive - 1; $i <= $this->blockSize; $i++, $k = $this->modNn($k + $this->iPrimitive)) {
+            $q = 1;
+
+            for ($j = $degLambda; $j > 0; $j--) {
+                if ($reg[$j] !== $this->blockSize) {
+                    $reg[$j]  = $this->modNn($reg[$j] + $j);
+                    $q       ^= $this->alphaTo[$reg[$j]];
+                }
+            }
+
+            if ($q !== 0) {
+                // Not a root
+                continue;
+            }
+
+            // Store root (index-form) and error location number
+            $root[$count] = $i;
+            $loc[$count]  = $k;
+
+            if (++$count === $degLambda) {
+                break;
+            }
+        }
+
+        if ($degLambda !== $count) {
+            // deg(lambda) unequal to number of roots: uncorreactable error
+            // detected
+            return null;
+        }
+
+        // Compute err+eras evaluate poly omega(x) = s(x)*lambda(x) (modulo
+        // x**numRoots). In index form. Also find deg(omega).
+        $degOmega = $degLambda - 1;
+
+        for ($i = 0; $i <= $degOmega; $i++) {
+            $tmp = 0;
+
+            for ($j = $i; $j >= 0; $j--) {
+                if ($syndromes[$i - $j] !== $this->blockSize && $lambda[$j] !== $this->blockSize) {
+                    $tmp ^= $this->alphaTo[$this->modNn($syndromes[$i - $j] + $lambda[$j])];
+                }
+            }
+
+            $omega[$i] = $this->indexOf[$tmp];
+        }
+
+        // Compute error values in poly-form. num1 = omega(inv(X(l))), num2 =
+        // inv(X(l))**(firstRoot-1) and den = lambda_pr(inv(X(l))) all in poly
+        // form.
+        for ($j = $count - 1; $j >= 0; $j--) {
+            $num1 = 0;
+
+            for ($i = $degOmega; $i >= 0; $i--) {
+                if ($omega[$i] !== $this->blockSize) {
+                    $num1 ^= $this->alphaTo[$this->modNn($omega[$i] + $i * $root[$j])];
+                }
+            }
+
+            $num2 = $this->alphaTo[$this->modNn($root[$j] * ($this->firstRoot - 1) + $this->blockSize)];
+            $den  = 0;
+
+            // lambda[i+1] for i even is the formal derivativelambda_pr of
+            // lambda[i]
+            for ($i = min($degLambda, $this->numRoots - 1) & ~1; $i >= 0; $i -= 2) {
+                if ($lambda[$i + 1] !== $this->blockSize) {
+                    $den ^= $this->alphaTo[$this->modNn($lambda[$i + 1] + $i * $root[$j])];
+                }
+            }
+
+            // Apply error to data
+            if ($num1 !== 0 && $loc[$j] >= $this->padding) {
+                $data[$loc[$j] - $this->padding] = $data[$loc[$j] - $this->padding] ^ (
+                    $this->alphaTo[
+                        $this->modNn(
+                            $this->indexOf[$num1] + $this->indexOf[$num2] + $this->blockSize - $this->indexOf[$den]
+                        )
+                    ]
+                );
+            }
+        }
+
+        if ($erasures !== null) {
+            if (count($erasures) < $count) {
+                $erasures->setSize($count);
+            }
+
+            for ($i = 0; $i < $count; $i++) {
+                $erasures[$i] = $loc[$i];
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Computes $x % GF_SIZE, where GF_SIZE is 2**GF_BITS - 1, without a slow
+     * divide.
+     *
+     * @param  itneger $x
+     * @return integer
+     */
+    protected function modNn($x)
+    {
+        while ($x >= $this->blockSize) {
+            $x -= $this->blockSize;
+            $x  = ($x >> $this->symbolSize) + ($x & $this->blockSize);
+        }
+
+        return $x;
+    }
+}

--- a/includes/BaconQrCode/Common/ReedSolomonCodec.php
+++ b/includes/BaconQrCode/Common/ReedSolomonCodec.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Exception;
 use SplFixedArray;
 
 /**

--- a/includes/BaconQrCode/Common/Version.php
+++ b/includes/BaconQrCode/Common/Version.php
@@ -1,0 +1,687 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Common;
+
+use SplFixedArray;
+
+/**
+ * Version representation.
+ */
+class Version
+{
+    /**
+     * Version decode information.
+     *
+     * @var array
+     */
+    protected static $versionDecodeInfo = array(
+        0x07c94, 0x085bc, 0x09a99, 0x0a4d3, 0x0bbf6, 0x0c762, 0x0d847, 0x0e60d,
+        0x0f928, 0x10b78, 0x1145d, 0x12a17, 0x13532, 0x149a6, 0x15683, 0x168c9,
+        0x177ec, 0x18ec4, 0x191e1, 0x1afab, 0x1b08e, 0x1cc1a, 0x1d33f, 0x1ed75,
+        0x1f250, 0x209d5, 0x216f0, 0x228ba, 0x2379f, 0x24b0b, 0x2542e, 0x26a64,
+        0x27541, 0x28c69
+    );
+
+    /**
+     * Cached version instances.
+     *
+     * @var array
+     */
+    protected static $versions = array();
+
+    /**
+     * Version number of this version.
+     *
+     * @var integer
+     */
+    protected $versionNumber;
+
+    /**
+     * Alignment pattern centers.
+     *
+     * @var SplFixedArray
+     */
+    protected $alignmentPatternCenters;
+
+    /**
+     * Error correction blocks.
+     *
+     * @var SplFixedArray
+     */
+    protected $errorCorrectionBlocks;
+
+    /**
+     * Total number of codewords.
+     *
+     * @var integer
+     */
+    protected $totalCodewords;
+
+    /**
+     * Creates a new version.
+     *
+     * @param integer       $versionNumber
+     * @param SplFixedArray $alignmentPatternCenters
+     * @param SplFixedArray $ecBlocks
+     */
+    protected function __construct(
+        $versionNumber,
+        SplFixedArray $alignmentPatternCenters,
+        SplFixedArray $ecBlocks
+    ) {
+        $this->versionNumber           = $versionNumber;
+        $this->alignmentPatternCenters = $alignmentPatternCenters;
+        $this->errorCorrectionBlocks   = $ecBlocks;
+
+        $totalCodewords = 0;
+        $ecCodewords    = $ecBlocks[0]->getEcCodewordsPerBlock();
+
+        foreach ($ecBlocks[0]->getEcBlocks() as $ecBlock) {
+            $totalCodewords += $ecBlock->getCount() * ($ecBlock->getDataCodewords() + $ecCodewords);
+        }
+
+        $this->totalCodewords = $totalCodewords;
+    }
+
+    /**
+     * Gets the version number.
+     *
+     * @return integer
+     */
+    public function getVersionNumber()
+    {
+        return $this->versionNumber;
+    }
+
+    /**
+     * Gets the alignment pattern centers.
+     *
+     * @return SplFixedArray
+     */
+    public function getAlignmentPatternCenters()
+    {
+        return $this->alignmentPatternCenters;
+    }
+
+    /**
+     * Gets the total number of codewords.
+     *
+     * @return integer
+     */
+    public function getTotalCodewords()
+    {
+        return $this->totalCodewords;
+    }
+
+    /**
+     * Gets the dimension for the current version.
+     *
+     * @return integer
+     */
+    public function getDimensionForVersion()
+    {
+        return 17 + 4 * $this->versionNumber;
+    }
+
+    /**
+     * Gets the number of EC blocks for a specific EC level.
+     *
+     * @param  ErrorCorrectionLevel $ecLevel
+     * @return integer
+     */
+    public function getEcBlocksForLevel(ErrorCorrectionLevel $ecLevel)
+    {
+        return $this->errorCorrectionBlocks[$ecLevel->getOrdinal()];
+    }
+
+    /**
+     * Gets a provisional version number for a specific dimension.
+     *
+     * @param  integer $dimension
+     * @return Version
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function getProvisionalVersionForDimension($dimension)
+    {
+        if ($dimension % 4 !== 1) {
+            throw new Exception\InvalidArgumentException('Dimension is not 1 mod 4');
+        }
+
+        return self::getVersionForNumber(($dimension - 17) >> 2);
+    }
+
+    /**
+     * Gets a version instance for a specific version number.
+     *
+     * @param  integer $versionNumber
+     * @return Version
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function getVersionForNumber($versionNumber)
+    {
+        if ($versionNumber < 1 || $versionNumber > 40) {
+            throw new Exception\InvalidArgumentException('Version number must be between 1 and 40');
+        }
+
+        if (!isset(self::$versions[$versionNumber])) {
+            self::buildVersion($versionNumber);
+        }
+
+        return self::$versions[$versionNumber - 1];
+    }
+
+    /**
+     * Decodes version information from an integer and returns the version.
+     *
+     * @param  integer $versionBits
+     * @return Version|null
+     */
+    public static function decodeVersionInformation($versionBits)
+    {
+        $bestDifference = PHP_INT_MAX;
+        $bestVersion    = 0;
+
+        foreach (self::$versionDecodeInfo as $i => $targetVersion) {
+            if ($targetVersion === $versionBits) {
+                return self::getVersionForNumber($i + 7);
+            }
+
+            $bitsDifference = FormatInformation::numBitsDiffering($versionBits, $targetVersion);
+
+            if ($bitsDifference < $bestDifference) {
+                $bestVersion    = $i + 7;
+                $bestDifference = $bitsDifference;
+            }
+        }
+
+        if ($bestDifference <= 3) {
+            return self::getVersionForNumber($bestVersion);
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds the function pattern for the current version.
+     *
+     * @return BitMatrix
+     */
+    public function buildFunctionPattern()
+    {
+        $dimension = $this->getDimensionForVersion();
+        $bitMatrix = new BitMatrix($dimension);
+
+        // Top left finder pattern + separator + format
+        $bitMatrix->setRegion(0, 0, 9, 9);
+        // Top right finder pattern + separator + format
+        $bitMatrix->setRegion($dimension - 8, 0, 8, 9);
+        // Bottom left finder pattern + separator + format
+        $bitMatrix->setRegion(0, $dimension - 8, 9, 8);
+
+        // Alignment patterns
+        $max = count($this->alignmentPatternCenters);
+
+        for ($x = 0; $x < $max; $x++) {
+            $i = $this->alignmentPatternCenters[$x] - 2;
+
+            for ($y = 0; $y < $max; $y++) {
+                if (($x === 0 && ($y === 0 || $y === $max - 1)) || ($x === $max - 1 && $y === 0)) {
+                    // No alignment patterns near the three finder paterns
+                    continue;
+                }
+
+                $bitMatrix->setRegion($this->alignmentPatternCenters[$y] - 2, $i, 5, 5);
+            }
+        }
+
+        // Vertical timing pattern
+        $bitMatrix->setRegion(6, 9, 1, $dimension - 17);
+        // Horizontal timing pattern
+        $bitMatrix->setRegion(9, 6, $dimension - 17, 1);
+
+        if ($this->versionNumber > 6) {
+            // Version info, top right
+            $bitMatrix->setRegion($dimension - 11, 0, 3, 6);
+            // Version info, bottom left
+            $bitMatrix->setRegion(0, $dimension - 11, 6, 3);
+        }
+
+        return $bitMatrix;
+    }
+
+    /**
+     * Returns a string representation for the version.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->versionNumber;
+    }
+
+    /**
+     * Build and cache a specific version.
+     *
+     * See ISO 18004:2006 6.5.1 Table 9.
+     *
+     * @param  integer $versionNumber
+     * @return void
+     */
+    protected static function buildVersion($versionNumber)
+    {
+        switch ($versionNumber) {
+            case 1:
+                $patterns = array();
+                $ecBlocks = array(
+                    new EcBlocks(7, new EcBlock(1, 19)),
+                    new EcBlocks(10, new EcBlock(1, 16)),
+                    new EcBlocks(13, new EcBlock(1, 13)),
+                    new EcBlocks(17, new EcBlock(1, 9)),
+                );
+                break;
+
+            case 2:
+                $patterns = array(6, 18);
+                $ecBlocks = array(
+                    new EcBlocks(10, new EcBlock(1, 34)),
+                    new EcBlocks(16, new EcBlock(1, 28)),
+                    new EcBlocks(22, new EcBlock(1, 22)),
+                    new EcBlocks(28, new EcBlock(1, 16)),
+                );
+                break;
+
+            case 3:
+                $patterns = array(6, 22);
+                $ecBlocks = array(
+                    new EcBlocks(15, new EcBlock(1, 55)),
+                    new EcBlocks(26, new EcBlock(1, 44)),
+                    new EcBlocks(18, new EcBlock(2, 17)),
+                    new EcBlocks(22, new EcBlock(2, 13)),
+                );
+                break;
+
+            case 4:
+                $patterns = array(6, 26);
+                $ecBlocks = array(
+                    new EcBlocks(20, new EcBlock(1, 80)),
+                    new EcBlocks(18, new EcBlock(2, 32)),
+                    new EcBlocks(26, new EcBlock(3, 24)),
+                    new EcBlocks(16, new EcBlock(4, 9)),
+                );
+                break;
+
+            case 5:
+                $patterns = array(6, 30);
+                $ecBlocks = array(
+                    new EcBlocks(26, new EcBlock(1, 108)),
+                    new EcBlocks(24, new EcBlock(2, 43)),
+                    new EcBlocks(18, new EcBlock(2, 15), new EcBlock(2, 16)),
+                    new EcBlocks(22, new EcBlock(2, 11), new EcBlock(2, 12)),
+                );
+                break;
+
+            case 6:
+                $patterns = array(6, 34);
+                $ecBlocks = array(
+                    new EcBlocks(18, new EcBlock(2, 68)),
+                    new EcBlocks(16, new EcBlock(4, 27)),
+                    new EcBlocks(24, new EcBlock(4, 19)),
+                    new EcBlocks(28, new EcBlock(4, 15)),
+                );
+                break;
+
+            case 7:
+                $patterns = array(6, 22, 38);
+                $ecBlocks = array(
+                    new EcBlocks(20, new EcBlock(2, 78)),
+                    new EcBlocks(18, new EcBlock(4, 31)),
+                    new EcBlocks(18, new EcBlock(2, 14), new EcBlock(4, 15)),
+                    new EcBlocks(26, new EcBlock(4, 13), new EcBlock(1, 14)),
+                );
+                break;
+
+            case 8:
+                $patterns = array(6, 24, 42);
+                $ecBlocks = array(
+                    new EcBlocks(24, new EcBlock(2, 97)),
+                    new EcBlocks(22, new EcBlock(2, 38), new EcBlock(2, 39)),
+                    new EcBlocks(22, new EcBlock(4, 18), new EcBlock(2, 19)),
+                    new EcBlocks(26, new EcBlock(4, 14), new EcBlock(2, 15)),
+                );
+                break;
+
+            case 9:
+                $patterns = array(6, 26, 46);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(2, 116)),
+                    new EcBlocks(22, new EcBlock(3, 36), new EcBlock(2, 37)),
+                    new EcBlocks(20, new EcBlock(4, 16), new EcBlock(4, 17)),
+                    new EcBlocks(24, new EcBlock(4, 12), new EcBlock(4, 13)),
+                );
+                break;
+
+            case 10:
+                $patterns = array(6, 28, 50);
+                $ecBlocks = array(
+                    new EcBlocks(18, new EcBlock(2, 68), new EcBlock(2, 69)),
+                    new EcBlocks(26, new EcBlock(4, 43), new EcBlock(1, 44)),
+                    new EcBlocks(24, new EcBlock(6, 19), new EcBlock(2, 20)),
+                    new EcBlocks(28, new EcBlock(6, 15), new EcBlock(2, 16)),
+                );
+                break;
+
+            case 11:
+                $patterns = array(6, 30, 54);
+                $ecBlocks = array(
+                    new EcBlocks(20, new EcBlock(4, 81)),
+                    new EcBlocks(30, new EcBlock(1, 50), new EcBlock(4, 51)),
+                    new EcBlocks(28, new EcBlock(4, 22), new EcBlock(4, 23)),
+                    new EcBlocks(24, new EcBlock(3, 12), new EcBlock(8, 13)),
+                );
+                break;
+
+            case 12:
+                $patterns = array(6, 32, 58);
+                $ecBlocks = array(
+                    new EcBlocks(24, new EcBlock(2, 92), new EcBlock(2, 93)),
+                    new EcBlocks(22, new EcBlock(6, 36), new EcBlock(2, 37)),
+                    new EcBlocks(26, new EcBlock(4, 20), new EcBlock(6, 21)),
+                    new EcBlocks(28, new EcBlock(7, 14), new EcBlock(4, 15)),
+                );
+                break;
+
+            case 13:
+                $patterns = array(6, 34, 62);
+                $ecBlocks = array(
+                    new EcBlocks(26, new EcBlock(4, 107)),
+                    new EcBlocks(22, new EcBlock(8, 37), new EcBlock(1, 38)),
+                    new EcBlocks(24, new EcBlock(8, 20), new EcBlock(4, 21)),
+                    new EcBlocks(22, new EcBlock(12, 11), new EcBlock(4, 12)),
+                );
+                break;
+
+            case 14:
+                $patterns = array(6, 26, 46, 66);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(3, 115), new EcBlock(1, 116)),
+                    new EcBlocks(24, new EcBlock(4, 40), new EcBlock(5, 41)),
+                    new EcBlocks(20, new EcBlock(11, 16), new EcBlock(5, 17)),
+                    new EcBlocks(24, new EcBlock(11, 12), new EcBlock(5, 13)),
+                );
+                break;
+
+            case 15:
+                $patterns = array(6, 26, 48, 70);
+                $ecBlocks = array(
+                    new EcBlocks(22, new EcBlock(5, 87), new EcBlock(1, 88)),
+                    new EcBlocks(24, new EcBlock(5, 41), new EcBlock(5, 42)),
+                    new EcBlocks(30, new EcBlock(5, 24), new EcBlock(7, 25)),
+                    new EcBlocks(24, new EcBlock(11, 12), new EcBlock(7, 13)),
+                );
+                break;
+
+            case 16:
+                $patterns = array(6, 26, 50, 74);
+                $ecBlocks = array(
+                    new EcBlocks(24, new EcBlock(5, 98), new EcBlock(1, 99)),
+                    new EcBlocks(28, new EcBlock(7, 45), new EcBlock(3, 46)),
+                    new EcBlocks(24, new EcBlock(15, 19), new EcBlock(2, 20)),
+                    new EcBlocks(30, new EcBlock(3, 15), new EcBlock(13, 16)),
+                );
+                break;
+
+            case 17:
+                $patterns = array(6, 30, 54, 78);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(1, 107), new EcBlock(5, 108)),
+                    new EcBlocks(28, new EcBlock(10, 46), new EcBlock(1, 47)),
+                    new EcBlocks(28, new EcBlock(1, 22), new EcBlock(15, 23)),
+                    new EcBlocks(28, new EcBlock(2, 14), new EcBlock(17, 15)),
+                );
+                break;
+
+            case 18:
+                $patterns = array(6, 30, 56, 82);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(5, 120), new EcBlock(1, 121)),
+                    new EcBlocks(26, new EcBlock(9, 43), new EcBlock(4, 44)),
+                    new EcBlocks(28, new EcBlock(17, 22), new EcBlock(1, 23)),
+                    new EcBlocks(28, new EcBlock(2, 14), new EcBlock(19, 15)),
+                );
+                break;
+
+            case 19:
+                $patterns = array(6, 30, 58, 86);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(3, 113), new EcBlock(4, 114)),
+                    new EcBlocks(26, new EcBlock(3, 44), new EcBlock(11, 45)),
+                    new EcBlocks(26, new EcBlock(17, 21), new EcBlock(4, 22)),
+                    new EcBlocks(26, new EcBlock(9, 13), new EcBlock(16, 14)),
+                );
+                break;
+
+            case 20:
+                $patterns = array(6, 34, 62, 90);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(3, 107), new EcBlock(5, 108)),
+                    new EcBlocks(26, new EcBlock(3, 41), new EcBlock(13, 42)),
+                    new EcBlocks(30, new EcBlock(15, 24), new EcBlock(5, 25)),
+                    new EcBlocks(28, new EcBlock(15, 15), new EcBlock(10, 16)),
+                );
+                break;
+
+            case 21:
+                $patterns = array(6, 28, 50, 72, 94);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(4, 116), new EcBlock(4, 117)),
+                    new EcBlocks(26, new EcBlock(17, 42)),
+                    new EcBlocks(28, new EcBlock(17, 22), new EcBlock(6, 23)),
+                    new EcBlocks(30, new EcBlock(19, 16), new EcBlock(6, 17)),
+                );
+                break;
+
+            case 22:
+                $patterns = array(6, 26, 50, 74, 98);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(2, 111), new EcBlock(7, 112)),
+                    new EcBlocks(28, new EcBlock(17, 46)),
+                    new EcBlocks(30, new EcBlock(7, 24), new EcBlock(16, 25)),
+                    new EcBlocks(24, new EcBlock(34, 13)),
+                );
+                break;
+
+            case 23:
+                $patterns = array(6, 30, 54, 78, 102);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(4, 121), new EcBlock(5, 122)),
+                    new EcBlocks(28, new EcBlock(4, 47), new EcBlock(14, 48)),
+                    new EcBlocks(30, new EcBlock(11, 24), new EcBlock(14, 25)),
+                    new EcBlocks(30, new EcBlock(16, 15), new EcBlock(14, 16)),
+                );
+                break;
+
+            case 24:
+                $patterns = array(6, 28, 54, 80, 106);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(6, 117), new EcBlock(4, 118)),
+                    new EcBlocks(28, new EcBlock(6, 45), new EcBlock(14, 46)),
+                    new EcBlocks(30, new EcBlock(11, 24), new EcBlock(16, 25)),
+                    new EcBlocks(30, new EcBlock(30, 16), new EcBlock(2, 17)),
+                );
+                break;
+
+            case 25:
+                $patterns = array(6, 32, 58, 84, 110);
+                $ecBlocks = array(
+                    new EcBlocks(26, new EcBlock(8, 106), new EcBlock(4, 107)),
+                    new EcBlocks(28, new EcBlock(8, 47), new EcBlock(13, 48)),
+                    new EcBlocks(30, new EcBlock(7, 24), new EcBlock(22, 25)),
+                    new EcBlocks(30, new EcBlock(22, 15), new EcBlock(13, 16)),
+                );
+                break;
+
+            case 26:
+                $patterns = array(6, 30, 58, 86, 114);
+                $ecBlocks = array(
+                    new EcBlocks(28, new EcBlock(10, 114), new EcBlock(2, 115)),
+                    new EcBlocks(28, new EcBlock(19, 46), new EcBlock(4, 47)),
+                    new EcBlocks(28, new EcBlock(28, 22), new EcBlock(6, 23)),
+                    new EcBlocks(30, new EcBlock(33, 16), new EcBlock(4, 17)),
+                );
+                break;
+
+            case 27:
+                $patterns = array(6, 34, 62, 90, 118);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(8, 122), new EcBlock(4, 123)),
+                    new EcBlocks(28, new EcBlock(22, 45), new EcBlock(3, 46)),
+                    new EcBlocks(30, new EcBlock(8, 23), new EcBlock(26, 24)),
+                    new EcBlocks(30, new EcBlock(12, 15), new EcBlock(28, 16)),
+                );
+                break;
+
+            case 28:
+                $patterns = array(6, 26, 50, 74, 98, 122);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(3, 117), new EcBlock(10, 118)),
+                    new EcBlocks(28, new EcBlock(3, 45), new EcBlock(23, 46)),
+                    new EcBlocks(30, new EcBlock(4, 24), new EcBlock(31, 25)),
+                    new EcBlocks(30, new EcBlock(11, 15), new EcBlock(31, 16)),
+                );
+                break;
+
+            case 29:
+                $patterns = array(6, 30, 54, 78, 102, 126);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(7, 116), new EcBlock(7, 117)),
+                    new EcBlocks(28, new EcBlock(21, 45), new EcBlock(7, 46)),
+                    new EcBlocks(30, new EcBlock(1, 23), new EcBlock(37, 24)),
+                    new EcBlocks(30, new EcBlock(19, 15), new EcBlock(26, 16)),
+                );
+                break;
+
+            case 30:
+                $patterns = array(6, 26, 52, 78, 104, 130);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(5, 115), new EcBlock(10, 116)),
+                    new EcBlocks(28, new EcBlock(19, 47), new EcBlock(10, 48)),
+                    new EcBlocks(30, new EcBlock(15, 24), new EcBlock(25, 25)),
+                    new EcBlocks(30, new EcBlock(23, 15), new EcBlock(25, 16)),
+                );
+                break;
+
+            case 31:
+                $patterns = array(6, 30, 56, 82, 108, 134);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(13, 115), new EcBlock(3, 116)),
+                    new EcBlocks(28, new EcBlock(2, 46), new EcBlock(29, 47)),
+                    new EcBlocks(30, new EcBlock(42, 24), new EcBlock(1, 25)),
+                    new EcBlocks(30, new EcBlock(23, 15), new EcBlock(28, 16)),
+                );
+                break;
+
+            case 32:
+                $patterns = array(6, 34, 60, 86, 112, 138);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(17, 115)),
+                    new EcBlocks(28, new EcBlock(10, 46), new EcBlock(23, 47)),
+                    new EcBlocks(30, new EcBlock(10, 24), new EcBlock(35, 25)),
+                    new EcBlocks(30, new EcBlock(19, 15), new EcBlock(35, 16)),
+                );
+                break;
+
+            case 33:
+                $patterns = array(6, 30, 58, 86, 114, 142);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(17, 115), new EcBlock(1, 116)),
+                    new EcBlocks(28, new EcBlock(14, 46), new EcBlock(21, 47)),
+                    new EcBlocks(30, new EcBlock(29, 24), new EcBlock(19, 25)),
+                    new EcBlocks(30, new EcBlock(11, 15), new EcBlock(46, 16)),
+                );
+                break;
+
+            case 34:
+                $patterns = array(6, 34, 62, 90, 118, 146);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(13, 115), new EcBlock(6, 116)),
+                    new EcBlocks(28, new EcBlock(14, 46), new EcBlock(23, 47)),
+                    new EcBlocks(30, new EcBlock(44, 24), new EcBlock(7, 25)),
+                    new EcBlocks(30, new EcBlock(59, 16), new EcBlock(1, 17)),
+                );
+                break;
+
+            case 35:
+                $patterns = array(6, 30, 54, 78, 102, 126, 150);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(12, 121), new EcBlock(7, 122)),
+                    new EcBlocks(28, new EcBlock(12, 47), new EcBlock(26, 48)),
+                    new EcBlocks(30, new EcBlock(39, 24), new EcBlock(14, 25)),
+                    new EcBlocks(30, new EcBlock(22, 15), new EcBlock(41, 16)),
+                );
+                break;
+
+            case 36:
+                $patterns = array(6, 24, 50, 76, 102, 128, 154);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(6, 121), new EcBlock(14, 122)),
+                    new EcBlocks(28, new EcBlock(6, 47), new EcBlock(34, 48)),
+                    new EcBlocks(30, new EcBlock(46, 24), new EcBlock(10, 25)),
+                    new EcBlocks(30, new EcBlock(2, 15), new EcBlock(64, 16)),
+                );
+                break;
+
+            case 37:
+                $patterns = array(6, 28, 54, 80, 106, 132, 158);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(17, 122), new EcBlock(4, 123)),
+                    new EcBlocks(28, new EcBlock(29, 46), new EcBlock(14, 47)),
+                    new EcBlocks(30, new EcBlock(49, 24), new EcBlock(10, 25)),
+                    new EcBlocks(30, new EcBlock(24, 15), new EcBlock(46, 16)),
+                );
+                break;
+
+            case 38:
+                $patterns = array(6, 32, 58, 84, 110, 136, 162);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(4, 122), new EcBlock(18, 123)),
+                    new EcBlocks(28, new EcBlock(13, 46), new EcBlock(32, 47)),
+                    new EcBlocks(30, new EcBlock(48, 24), new EcBlock(14, 25)),
+                    new EcBlocks(30, new EcBlock(42, 15), new EcBlock(32, 16)),
+                );
+                break;
+
+            case 39:
+                $patterns = array(6, 26, 54, 82, 110, 138, 166);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(20, 117), new EcBlock(4, 118)),
+                    new EcBlocks(28, new EcBlock(40, 47), new EcBlock(7, 48)),
+                    new EcBlocks(30, new EcBlock(43, 24), new EcBlock(22, 25)),
+                    new EcBlocks(30, new EcBlock(10, 15), new EcBlock(67, 16)),
+                );
+                break;
+
+            case 40:
+                $patterns = array(6, 30, 58, 86, 114, 142, 170);
+                $ecBlocks = array(
+                    new EcBlocks(30, new EcBlock(19, 118), new EcBlock(6, 119)),
+                    new EcBlocks(28, new EcBlock(18, 47), new EcBlock(31, 48)),
+                    new EcBlocks(30, new EcBlock(34, 24), new EcBlock(34, 25)),
+                    new EcBlocks(30, new EcBlock(20, 15), new EcBlock(61, 16)),
+                );
+                break;
+        }
+
+        self::$versions[$versionNumber - 1] = new self(
+            $versionNumber,
+            SplFixedArray::fromArray($patterns, false),
+            SplFixedArray::fromArray($ecBlocks, false)
+        );
+    }
+}

--- a/includes/BaconQrCode/Common/Version.php
+++ b/includes/BaconQrCode/Common/Version.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Common;
+namespace TwoFactor\BaconQrCode\Common;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Encoder/BlockPair.php
+++ b/includes/BaconQrCode/Encoder/BlockPair.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use SplFixedArray;
+
+/**
+ * Block pair.
+ */
+class BlockPair
+{
+    /**
+     * Data bytes in the block.
+     *
+     * @var SplFixedArray
+     */
+    protected $dataBytes;
+
+    /**
+     * Error correction bytes in the block.
+     *
+     * @var SplFixedArray
+     */
+    protected $errorCorrectionBytes;
+
+    /**
+     * Creates a new block pair.
+     *
+     * @param SplFixedArray $data
+     * @param SplFixedArray $errorCorrection
+     */
+    public function __construct(SplFixedArray $data, SplFixedArray $errorCorrection)
+    {
+        $this->dataBytes            = $data;
+        $this->errorCorrectionBytes = $errorCorrection;
+    }
+
+    /**
+     * Gets the data bytes.
+     *
+     * @return SplFixedArray
+     */
+    public function getDataBytes()
+    {
+        return $this->dataBytes;
+    }
+
+    /**
+     * Gets the error correction bytes.
+     *
+     * @return SplFixedArray
+     */
+    public function getErrorCorrectionBytes()
+    {
+        return $this->errorCorrectionBytes;
+    }
+}

--- a/includes/BaconQrCode/Encoder/BlockPair.php
+++ b/includes/BaconQrCode/Encoder/BlockPair.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Encoder/ByteMatrix.php
+++ b/includes/BaconQrCode/Encoder/ByteMatrix.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use SplFixedArray;
+
+/**
+ * Byte matrix.
+ */
+class ByteMatrix
+{
+    /**
+     * Bytes in the matrix, represented as array.
+     *
+     * @var SplFixedArray
+     */
+    protected $bytes;
+
+    /**
+     * Width of the matrix.
+     *
+     * @var integer
+     */
+    protected $width;
+
+    /**
+     * Height of the matrix.
+     *
+     * @var integer
+     */
+    protected $height;
+
+    /**
+     * Creates a new byte matrix.
+     *
+     * @param  integer $width
+     * @param  integer $height
+     */
+    public function __construct($width, $height)
+    {
+        $this->height = $height;
+        $this->width  = $width;
+        $this->bytes  = new SplFixedArray($height);
+
+        for ($y = 0; $y < $height; $y++) {
+            $this->bytes[$y] = new SplFixedArray($width);
+        }
+    }
+
+    /**
+     * Gets the width of the matrix.
+     *
+     * @return integer
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * Gets the height of the matrix.
+     *
+     * @return integer
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * Gets the internal representation of the matrix.
+     *
+     * @return SplFixedArray
+     */
+    public function getArray()
+    {
+        return $this->bytes;
+    }
+
+    /**
+     * Gets the byte for a specific position.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @return integer
+     */
+    public function get($x, $y)
+    {
+        return $this->bytes[$y][$x];
+    }
+
+    /**
+     * Sets the byte for a specific position.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @param  integer $value
+     * @return void
+     */
+    public function set($x, $y, $value)
+    {
+        $this->bytes[$y][$x] = (int) $value;
+    }
+
+    /**
+     * Clears the matrix with a specific value.
+     *
+     * @param  integer $value
+     * @return void
+     */
+    public function clear($value)
+    {
+        for ($y = 0; $y < $this->height; $y++) {
+            for ($x = 0; $x < $this->width; $x++) {
+                $this->bytes[$y][$x] = $value;
+            }
+        }
+    }
+
+    /**
+     * Returns a string representation of the matrix.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = '';
+
+        for ($y = 0; $y < $this->height; $y++) {
+            for ($x = 0; $x < $this->width; $x++) {
+                switch ($this->bytes[$y][$x]) {
+                    case 0:
+                        $result .= ' 0';
+                        break;
+
+                    case 1:
+                        $result .= ' 1';
+                        break;
+
+                    default:
+                        $result .= '  ';
+                        break;
+                }
+            }
+
+            $result .= "\n";
+        }
+
+        return $result;
+    }
+}

--- a/includes/BaconQrCode/Encoder/ByteMatrix.php
+++ b/includes/BaconQrCode/Encoder/ByteMatrix.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
 use SplFixedArray;
 

--- a/includes/BaconQrCode/Encoder/Encoder.php
+++ b/includes/BaconQrCode/Encoder/Encoder.php
@@ -1,0 +1,687 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use BaconQrCode\Common\BitArray;
+use BaconQrCode\Common\CharacterSetEci;
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Common\Mode;
+use BaconQrCode\Common\ReedSolomonCodec;
+use BaconQrCode\Common\Version;
+use BaconQrCode\Exception;
+use SplFixedArray;
+
+/**
+ * Encoder.
+ */
+class Encoder
+{
+    /**
+     * Default byte encoding.
+     */
+    const DEFAULT_BYTE_MODE_ECODING = 'ISO-8859-1';
+
+    /**
+     * The original table is defined in the table 5 of JISX0510:2004 (p.19).
+     *
+     * @var array
+     */
+    protected static $alphanumericTable = array(
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  // 0x00-0x0f
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  // 0x10-0x1f
+        36, -1, -1, -1, 37, 38, -1, -1, -1, -1, 39, 40, -1, 41, 42, 43,  // 0x20-0x2f
+        0,   1,  2,  3,  4,  5,  6,  7,  8,  9, 44, -1, -1, -1, -1, -1,  // 0x30-0x3f
+        -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,  // 0x40-0x4f
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1,  // 0x50-0x5f
+    );
+
+    /**
+     * Codec cache.
+     *
+     * @var array
+     */
+    protected static $codecs = array();
+
+    /**
+     * Encodes "content" with the error correction level "ecLevel".
+     *
+     * @param  string               $content
+     * @param  ErrorCorrectionLevel $ecLevel
+     * @param  ?                    $hints
+     * @return QrCode
+     */
+    public static function encode($content, ErrorCorrectionLevel $ecLevel, $encoding = self::DEFAULT_BYTE_MODE_ECODING)
+    {
+        // Pick an encoding mode appropriate for the content. Note that this
+        // will not attempt to use multiple modes / segments even if that were
+        // more efficient. Would be nice.
+        $mode = self::chooseMode($content, $encoding);
+
+        // This will store the header information, like mode and length, as well
+        // as "header" segments like an ECI segment.
+        $headerBits = new BitArray();
+
+        // Append ECI segment if applicable
+        if ($mode->get() === Mode::BYTE && $encoding !== self::DEFAULT_BYTE_MODE_ECODING) {
+            $eci = CharacterSetEci::getCharacterSetEciByName($encoding);
+
+            if ($eci !== null) {
+                self::appendEci($eci, $headerBits);
+            }
+        }
+
+        // (With ECI in place,) Write the mode marker
+        self::appendModeInfo($mode, $headerBits);
+
+        // Collect data within the main segment, separately, to count its size
+        // if needed. Don't add it to main payload yet.
+        $dataBits = new BitArray();
+        self::appendBytes($content, $mode, $dataBits, $encoding);
+
+        // Hard part: need to know version to know how many bits length takes.
+        // But need to know how many bits it takes to know version. First we
+        // take a guess at version by assuming version will be the minimum, 1:
+        $provisionalBitsNeeded = $headerBits->getSize()
+                               + $mode->getCharacterCountBits(Version::getVersionForNumber(1))
+                               + $dataBits->getSize();
+        $provisionalVersion = self::chooseVersion($provisionalBitsNeeded, $ecLevel);
+
+        // Use that guess to calculate the right version. I am still not sure
+        // this works in 100% of cases.
+        $bitsNeeded = $headerBits->getSize()
+                    + $mode->getCharacterCountBits($provisionalVersion)
+                    + $dataBits->getSize();
+        $version = self::chooseVersion($bitsNeeded, $ecLevel);
+
+        $headerAndDataBits = new BitArray();
+        $headerAndDataBits->appendBitArray($headerBits);
+
+        // Find "length" of main segment and write it.
+        $numLetters = ($mode->get() === Mode::BYTE ? $dataBits->getSizeInBytes() : strlen($content));
+        self::appendLengthInfo($numLetters, $version, $mode, $headerAndDataBits);
+
+        // Put data together into the overall payload.
+        $headerAndDataBits->appendBitArray($dataBits);
+        $ecBlocks     = $version->getEcBlocksForLevel($ecLevel);
+        $numDataBytes = $version->getTotalCodewords() - $ecBlocks->getTotalEcCodewords();
+
+        // Terminate the bits properly.
+        self::terminateBits($numDataBytes, $headerAndDataBits);
+
+        // Interleave data bits with error correction code.
+        $finalBits = self::interleaveWithEcBytes(
+            $headerAndDataBits,
+            $version->getTotalCodewords(),
+            $numDataBytes,
+            $ecBlocks->getNumBlocks()
+        );
+
+        $qrCode = new QrCode();
+        $qrCode->setErrorCorrectionLevel($ecLevel);
+        $qrCode->setMode($mode);
+        $qrCode->setVersion($version);
+
+        // Choose the mask pattern and set to "qrCode".
+        $dimension   = $version->getDimensionForVersion();
+        $matrix      = new ByteMatrix($dimension, $dimension);
+        $maskPattern = self::chooseMaskPattern($finalBits, $ecLevel, $version, $matrix);
+        $qrCode->setMaskPattern($maskPattern);
+
+        // Build the matrix and set it to "qrCode".
+        MatrixUtil::buildMatrix($finalBits, $ecLevel, $version, $maskPattern, $matrix);
+        $qrCode->setMatrix($matrix);
+
+        return $qrCode;
+    }
+
+    /**
+     * Gets the alphanumeric code for a byte.
+     *
+     * @param  string|integer $code
+     * @return integer
+     */
+    protected static function getAlphanumericCode($code)
+    {
+        $code = (is_string($code) ? ord($code) : $code);
+
+        if (isset(self::$alphanumericTable[$code])) {
+            return self::$alphanumericTable[$code];
+        }
+
+        return -1;
+    }
+
+    /**
+     * Chooses the best mode for a given content.
+     *
+     * @param  string $content
+     * @param  string $encoding
+     * @return Mode
+     */
+    protected static function chooseMode($content, $encoding = null)
+    {
+        if (strcasecmp($encoding, 'SHIFT-JIS') === 0) {
+            return self::isOnlyDoubleByteKanji($content) ? new Mode(Mode::KANJI) : new Mode(Mode::BYTE);
+        }
+
+        $hasNumeric      = false;
+        $hasAlphanumeric = false;
+        $contentLength   = strlen($content);
+
+        for ($i = 0; $i < $contentLength; $i++) {
+            $char = $content[$i];
+
+            if (ctype_digit($char)) {
+                $hasNumeric = true;
+            } elseif (self::getAlphanumericCode($char) !== -1) {
+                $hasAlphanumeric = true;
+            } else {
+                return new Mode(Mode::BYTE);
+            }
+        }
+
+        if ($hasAlphanumeric) {
+            return new Mode(Mode::ALPHANUMERIC);
+        } elseif ($hasNumeric) {
+            return new Mode(Mode::NUMERIC);
+        }
+
+        return new Mode(Mode::BYTE);
+    }
+
+    /**
+     * Calculates the mask penalty for a matrix.
+     *
+     * @param  ByteMatrix $matrix
+     * @return integer
+     */
+    protected static function calculateMaskPenalty(ByteMatrix $matrix)
+    {
+        return (
+            MaskUtil::applyMaskPenaltyRule1($matrix)
+            + MaskUtil::applyMaskPenaltyRule2($matrix)
+            + MaskUtil::applyMaskPenaltyRule3($matrix)
+            + MaskUtil::applyMaskPenaltyRule4($matrix)
+        );
+    }
+
+    /**
+     * Chooses the best mask pattern for a matrix.
+     *
+     * @param  BitArray             $bits
+     * @param  ErrorCorrectionLevel $ecLevel
+     * @param  Version              $version
+     * @param  ByteMatrix           $matrix
+     * @return integer
+     */
+    protected static function chooseMaskPattern(
+        BitArray $bits,
+        ErrorCorrectionLevel $ecLevel,
+        Version $version,
+        ByteMatrix $matrix
+    ) {
+        $minPenality     = PHP_INT_MAX;
+        $bestMaskPattern = -1;
+
+        for ($maskPattern = 0; $maskPattern < QrCode::NUM_MASK_PATTERNS; $maskPattern++) {
+            MatrixUtil::buildMatrix($bits, $ecLevel, $version, $maskPattern, $matrix);
+            $penalty = self::calculateMaskPenalty($matrix);
+
+            if ($penalty < $minPenality) {
+                $minPenality     = $penalty;
+                $bestMaskPattern = $maskPattern;
+            }
+        }
+
+        return $bestMaskPattern;
+    }
+
+    /**
+     * Chooses the best version for the input.
+     *
+     * @param  integer              $numInputBits
+     * @param  ErrorCorrectionLevel $ecLevel
+     * @return Version
+     * @throws Exception\WriterException
+     */
+    protected static function chooseVersion($numInputBits, ErrorCorrectionLevel $ecLevel)
+    {
+        for ($versionNum = 1; $versionNum <= 40; $versionNum++) {
+            $version  = Version::getVersionForNumber($versionNum);
+            $numBytes = $version->getTotalCodewords();
+
+            $ecBlocks   = $version->getEcBlocksForLevel($ecLevel);
+            $numEcBytes = $ecBlocks->getTotalEcCodewords();
+
+            $numDataBytes    = $numBytes - $numEcBytes;
+            $totalInputBytes = intval(($numInputBits + 8) / 8);
+
+            if ($numDataBytes >= $totalInputBytes) {
+                return $version;
+            }
+        }
+
+        throw new Exception\WriterException('Data too big');
+    }
+
+    /**
+     * Terminates the bits in a bit array.
+     *
+     * @param  integer  $numDataBytes
+     * @param  BitArray $bits
+     * @throws Exception\WriterException
+     */
+    protected static function terminateBits($numDataBytes, BitArray $bits)
+    {
+        $capacity = $numDataBytes << 3;
+
+        if ($bits->getSize() > $capacity) {
+            throw new Exception\WriterException('Data bits cannot fit in the QR code');
+        }
+
+        for ($i = 0; $i < 4 && $bits->getSize() < $capacity; $i++) {
+            $bits->appendBit(false);
+        }
+
+        $numBitsInLastByte = $bits->getSize() & 0x7;
+
+        if ($numBitsInLastByte > 0) {
+            for ($i = $numBitsInLastByte; $i < 8; $i++) {
+                $bits->appendBit(false);
+            }
+        }
+
+        $numPaddingBytes = $numDataBytes - $bits->getSizeInBytes();
+
+        for ($i = 0; $i < $numPaddingBytes; $i++) {
+            $bits->appendBits(($i & 0x1) === 0 ? 0xec : 0x11, 8);
+        }
+
+        if ($bits->getSize() !== $capacity) {
+            throw new Exception\WriterException('Bits size does not equal capacity');
+        }
+    }
+
+    /**
+     * Gets number of data- and EC bytes for a block ID.
+     *
+     * @param  integer $numTotalBytes
+     * @param  integer $numDataBytes
+     * @param  integer $numRsBlocks
+     * @param  integer $blockId
+     * @return array
+     * @throws Exception\WriterException
+     */
+    protected static function getNumDataBytesAndNumEcBytesForBlockId(
+        $numTotalBytes,
+        $numDataBytes,
+        $numRsBlocks,
+        $blockId
+    ) {
+        if ($blockId >= $numRsBlocks) {
+            throw new Exception\WriterException('Block ID too large');
+        }
+
+        $numRsBlocksInGroup2   = $numTotalBytes % $numRsBlocks;
+        $numRsBlocksInGroup1   = $numRsBlocks - $numRsBlocksInGroup2;
+        $numTotalBytesInGroup1 = intval($numTotalBytes / $numRsBlocks);
+        $numTotalBytesInGroup2 = $numTotalBytesInGroup1 + 1;
+        $numDataBytesInGroup1  = intval($numDataBytes / $numRsBlocks);
+        $numDataBytesInGroup2  = $numDataBytesInGroup1 + 1;
+        $numEcBytesInGroup1    = $numTotalBytesInGroup1 - $numDataBytesInGroup1;
+        $numEcBytesInGroup2    = $numTotalBytesInGroup2 - $numDataBytesInGroup2;
+
+        if ($numEcBytesInGroup1 !== $numEcBytesInGroup2) {
+            throw new Exception\WriterException('EC bytes mismatch');
+        }
+
+        if ($numRsBlocks !== $numRsBlocksInGroup1 + $numRsBlocksInGroup2) {
+            throw new Exception\WriterException('RS blocks mismatch');
+        }
+
+        if ($numTotalBytes !==
+            (($numDataBytesInGroup1 + $numEcBytesInGroup1) * $numRsBlocksInGroup1)
+            + (($numDataBytesInGroup2 + $numEcBytesInGroup2) * $numRsBlocksInGroup2)
+        ) {
+            throw new Exception\WriterException('Total bytes mismatch');
+        }
+
+        if ($blockId < $numRsBlocksInGroup1) {
+            return array($numDataBytesInGroup1, $numEcBytesInGroup1);
+        } else {
+            return array($numDataBytesInGroup2, $numEcBytesInGroup2);
+        }
+    }
+
+    /**
+     * Interleaves data with EC bytes.
+     *
+     * @param  BitArray $bits
+     * @param  integer  $numTotalBytes
+     * @param  integer  $numDataBytes
+     * @param  integer  $numRsBlocks
+     * @return BitArray
+     * @throws Exception\WriterException
+     */
+    protected static function interleaveWithEcBytes(BitArray $bits, $numTotalBytes, $numDataBytes, $numRsBlocks)
+    {
+        if ($bits->getSizeInBytes() !== $numDataBytes) {
+            throw new Exception\WriterException('Number of bits and data bytes does not match');
+        }
+
+        $dataBytesOffset = 0;
+        $maxNumDataBytes = 0;
+        $maxNumEcBytes   = 0;
+
+        $blocks = new SplFixedArray($numRsBlocks);
+
+        for ($i = 0; $i < $numRsBlocks; $i++) {
+            list($numDataBytesInBlock, $numEcBytesInBlock) = self::getNumDataBytesAndNumEcBytesForBlockId(
+                $numTotalBytes,
+                $numDataBytes,
+                $numRsBlocks,
+                $i
+            );
+
+            $size       = $numDataBytesInBlock;
+            $dataBytes  = $bits->toBytes(8 * $dataBytesOffset, $size);
+            $ecBytes    = self::generateEcBytes($dataBytes, $numEcBytesInBlock);
+            $blocks[$i] = new BlockPair($dataBytes, $ecBytes);
+
+            $maxNumDataBytes  = max($maxNumDataBytes, $size);
+            $maxNumEcBytes    = max($maxNumEcBytes, count($ecBytes));
+            $dataBytesOffset += $numDataBytesInBlock;
+        }
+
+        if ($numDataBytes !== $dataBytesOffset) {
+            throw new Exception\WriterException('Data bytes does not match offset');
+        }
+
+        $result = new BitArray();
+
+        for ($i = 0; $i < $maxNumDataBytes; $i++) {
+            foreach ($blocks as $block) {
+                $dataBytes = $block->getDataBytes();
+
+                if ($i < count($dataBytes)) {
+                    $result->appendBits($dataBytes[$i], 8);
+                }
+            }
+        }
+
+        for ($i = 0; $i < $maxNumEcBytes; $i++) {
+            foreach ($blocks as $block) {
+                $ecBytes = $block->getErrorCorrectionBytes();
+
+                if ($i < count($ecBytes)) {
+                    $result->appendBits($ecBytes[$i], 8);
+                }
+            }
+        }
+
+        if ($numTotalBytes !== $result->getSizeInBytes()) {
+            throw new Exception\WriterException('Interleaving error: ' . $numTotalBytes . ' and ' . $result->getSizeInBytes() . ' differ');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Generates EC bytes for given data.
+     *
+     * @param  SplFixedArray $dataBytes
+     * @param  integer       $numEcBytesInBlock
+     * @return SplFixedArray
+     */
+    protected static function generateEcBytes(SplFixedArray $dataBytes, $numEcBytesInBlock)
+    {
+        $numDataBytes = count($dataBytes);
+        $toEncode     = new SplFixedArray($numDataBytes + $numEcBytesInBlock);
+
+        for ($i = 0; $i < $numDataBytes; $i++) {
+            $toEncode[$i] = $dataBytes[$i] & 0xff;
+        }
+
+        $ecBytes = new SplFixedArray($numEcBytesInBlock);
+        $codec   = self::getCodec($numDataBytes, $numEcBytesInBlock);
+        $codec->encode($toEncode, $ecBytes);
+
+        return $ecBytes;
+    }
+
+    /**
+     * Gets an RS codec and caches it.
+     *
+     * @param  integer $numDataBytes
+     * @param  integer $numEcBytesInBlock
+     * @return ReedSolomonCodec
+     */
+    protected static function getCodec($numDataBytes, $numEcBytesInBlock)
+    {
+        $cacheId = $numDataBytes . '-' . $numEcBytesInBlock;
+
+        if (!isset(self::$codecs[$cacheId])) {
+            self::$codecs[$cacheId] = new ReedSolomonCodec(
+                8,
+                0x11d,
+                0,
+                1,
+                $numEcBytesInBlock,
+                255 - $numDataBytes - $numEcBytesInBlock
+            );
+        }
+
+        return self::$codecs[$cacheId];
+    }
+
+    /**
+     * Appends mode information to a bit array.
+     *
+     * @param  Mode     $mode
+     * @param  BitArray $bits
+     * @return void
+     */
+    protected static function appendModeInfo(Mode $mode, BitArray $bits)
+    {
+        $bits->appendBits($mode->get(), 4);
+    }
+
+    /**
+     * Appends length information to a bit array.
+     *
+     * @param  integer  $numLetters
+     * @param  Version  $version
+     * @param  Mode     $mode
+     * @param  BitArray $bits
+     * @return void
+     * @throws Exception\WriterException
+     */
+    protected static function appendLengthInfo($numLetters, Version $version, Mode $mode, BitArray $bits)
+    {
+        $numBits = $mode->getCharacterCountBits($version);
+
+        if ($numLetters >= (1 << $numBits)) {
+            throw new Exception\WriterException($numLetters . ' is bigger than ' . ((1 << $numBits) - 1));
+        }
+
+        $bits->appendBits($numLetters, $numBits);
+    }
+
+    /**
+     * Appends bytes to a bit array in a specific mode.
+     *
+     * @param  stirng   $content
+     * @param  Mode     $mode
+     * @param  BitArray $bits
+     * @param  string   $encoding
+     * @return void
+     * @throws Exception\WriterException
+     */
+    protected static function appendBytes($content, Mode $mode, BitArray $bits, $encoding)
+    {
+        switch ($mode->get()) {
+            case Mode::NUMERIC:
+                self::appendNumericBytes($content, $bits);
+                break;
+
+            case Mode::ALPHANUMERIC:
+                self::appendAlphanumericBytes($content, $bits);
+                break;
+
+            case Mode::BYTE:
+                self::append8BitBytes($content, $bits, $encoding);
+                break;
+
+            case Mode::KANJI:
+                self::appendKanjiBytes($content, $bits);
+                break;
+
+            default:
+                throw new Exception\WriterException('Invalid mode: ' . $mode->get());
+        }
+    }
+
+    /**
+     * Appends numeric bytes to a bit array.
+     *
+     * @param  string   $content
+     * @param  BitArray $bits
+     * @return void
+     */
+    protected static function appendNumericBytes($content, BitArray $bits)
+    {
+        $length = strlen($content);
+        $i      = 0;
+
+        while ($i < $length) {
+            $num1 = (int) $content[$i];
+
+            if ($i + 2 < $length) {
+                // Encode three numeric letters in ten bits.
+                $num2 = (int) $content[$i + 1];
+                $num3 = (int) $content[$i + 2];
+                $bits->appendBits($num1 * 100 + $num2 * 10 + $num3, 10);
+                $i += 3;
+            } elseif ($i + 1 < $length) {
+                // Encode two numeric letters in seven bits.
+                $num2 = (int) $content[$i + 1];
+                $bits->appendBits($num1 * 10 + $num2, 7);
+                $i += 2;
+            } else {
+                // Encode one numeric letter in four bits.
+                $bits->appendBits($num1, 4);
+                $i++;
+            }
+        }
+    }
+
+    /**
+     * Appends alpha-numeric bytes to a bit array.
+     *
+     * @param  string   $content
+     * @param  BitArray $bits
+     * @return void
+     */
+    protected static function appendAlphanumericBytes($content, BitArray $bits)
+    {
+        $length = strlen($content);
+        $i      = 0;
+
+        while ($i < $length) {
+            if (-1 === ($code1 = self::getAlphanumericCode($content[$i]))) {
+                throw new Exception\WriterException('Invalid alphanumeric code');
+            }
+
+            if ($i + 1 < $length) {
+                if (-1 === ($code2 = self::getAlphanumericCode($content[$i + 1]))) {
+                    throw new Exception\WriterException('Invalid alphanumeric code');
+                }
+
+                // Encode two alphanumeric letters in 11 bits.
+                $bits->appendBits($code1 * 45 + $code2, 11);
+                $i += 2;
+            } else {
+                // Encode one alphanumeric letter in six bits.
+                $bits->appendBits($code1, 6);
+                $i++;
+            }
+        }
+    }
+
+    /**
+     * Appends regular 8-bit bytes to a bit array.
+     *
+     * @param  string   $content
+     * @param  BitArray $bits
+     * @return void
+     */
+    protected static function append8BitBytes($content, BitArray $bits, $encoding)
+    {
+        if (false === ($bytes = @iconv('utf-8', $encoding, $content))) {
+            throw new Exception\WriterException('Could not encode content to ' . $encoding);
+        }
+
+        $length = strlen($bytes);
+
+        for ($i = 0; $i < $length; $i++) {
+            $bits->appendBits(ord($bytes[$i]), 8);
+        }
+    }
+
+    /**
+     * Appends KANJI bytes to a bit array.
+     *
+     * @param  string   $content
+     * @param  BitArray $bits
+     * @return void
+     */
+    protected static function appendKanjiBytes($content, BitArray $bits)
+    {
+        if (strlen($content) % 2 > 0) {
+            // We just do a simple length check here. The for loop will check
+            // individual characters.
+            throw new Exception\WriterException('Content does not seem to be encoded in SHIFT-JIS');
+        }
+
+        $length = strlen($content);
+
+        for ($i = 0; $i < $length; $i += 2) {
+            $byte1 = ord($content[$i]) & 0xff;
+            $byte2 = ord($content[$i + 1]) & 0xff;
+            $code  = ($byte1 << 8) | $byte2;
+
+            if ($code >= 0x8140 && $code <= 0x9ffc) {
+                $subtracted = $code - 0x8140;
+            } elseif ($code >= 0xe040 && $code <= 0xebbf) {
+                $subtracted = $code - 0xc140;
+            } else {
+                throw new Exception\WriterException('Invalid byte sequence');
+            }
+
+            $encoded = (($subtracted >> 8) * 0xc0) + ($subtracted & 0xff);
+
+            $bits->appendBits($encoded, 13);
+        }
+    }
+
+    /**
+     * Appends ECI information to a bit array.
+     *
+     * @param  CharacterSetEci $eci
+     * @param  BitArray        $bits
+     * @return void
+     */
+    protected static function appendEci(CharacterSetEci $eci, BitArray $bits)
+    {
+        $mode = new Mode(Mode::ECI);
+        $bits->appendBits($mode->get(), 4);
+        $bits->appendBits($eci->get(), 8);
+    }
+}

--- a/includes/BaconQrCode/Encoder/Encoder.php
+++ b/includes/BaconQrCode/Encoder/Encoder.php
@@ -7,15 +7,15 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
-use BaconQrCode\Common\BitArray;
-use BaconQrCode\Common\CharacterSetEci;
-use BaconQrCode\Common\ErrorCorrectionLevel;
-use BaconQrCode\Common\Mode;
-use BaconQrCode\Common\ReedSolomonCodec;
-use BaconQrCode\Common\Version;
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Common\BitArray;
+use TwoFactor\BaconQrCode\Common\CharacterSetEci;
+use TwoFactor\BaconQrCode\Common\ErrorCorrectionLevel;
+use TwoFactor\BaconQrCode\Common\Mode;
+use TwoFactor\BaconQrCode\Common\ReedSolomonCodec;
+use TwoFactor\BaconQrCode\Common\Version;
+use TwoFactor\BaconQrCode\Exception;
 use SplFixedArray;
 
 /**

--- a/includes/BaconQrCode/Encoder/MaskUtil.php
+++ b/includes/BaconQrCode/Encoder/MaskUtil.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use BaconQrCode\Common\BitUtils;
+
+/**
+ * Mask utility.
+ */
+class MaskUtil
+{
+    /**#@+
+     * Penalty weights from section 6.8.2.1
+     */
+    const N1 = 3;
+    const N2 = 3;
+    const N3 = 40;
+    const N4 = 10;
+    /**#@-*/
+
+    /**
+     * Applies mask penalty rule 1 and returns the penalty.
+     *
+     * Finds repetitive cells with the same color and gives penalty to them.
+     * Example: 00000 or 11111.
+     *
+     * @param  ByteMatrix $matrix
+     * @return integer
+     */
+    public static function applyMaskPenaltyRule1(ByteMatrix $matrix)
+    {
+        return (
+            self::applyMaskPenaltyRule1Internal($matrix, true)
+            + self::applyMaskPenaltyRule1Internal($matrix, false)
+        );
+    }
+
+    /**
+     * Applies mask penalty rule 2 and returns the penalty.
+     *
+     * Finds 2x2 blocks with the same color and gives penalty to them. This is
+     * actually equivalent to the spec's rule, which is to find MxN blocks and
+     * give a penalty proportional to (M-1)x(N-1), because this is the number of
+     * 2x2 blocks inside such a block.
+     *
+     * @param  ByteMatrix $matrix
+     * @return integer
+     */
+    public static function applyMaskPenaltyRule2(ByteMatrix $matrix)
+    {
+        $penalty = 0;
+        $array   = $matrix->getArray();
+        $width   = $matrix->getWidth();
+        $height  = $matrix->getHeight();
+
+        for ($y = 0; $y < $height - 1; $y++) {
+            for ($x = 0; $x < $width - 1; $x++) {
+                $value = $array[$y][$x];
+
+                if ($value === $array[$y][$x + 1] && $value === $array[$y + 1][$x] && $value === $array[$y + 1][$x + 1]) {
+                    $penalty++;
+                }
+            }
+        }
+
+        return self::N2 * $penalty;
+    }
+
+    /**
+     * Applies mask penalty rule 3 and returns the penalty.
+     *
+     * Finds consecutive cells of 00001011101 or 10111010000, and gives penalty
+     * to them. If we find patterns like 000010111010000, we give penalties
+     * twice (i.e. 40 * 2).
+     *
+     * @param  ByteMatrix $matrix
+     * @return integer
+     */
+    public static function applyMaskPenaltyRule3(ByteMatrix $matrix)
+    {
+        $penalty = 0;
+        $array   = $matrix->getArray();
+        $width   = $matrix->getWidth();
+        $height  = $matrix->getHeight();
+
+        for ($y = 0; $y < $height; $y++) {
+            for ($x = 0; $x < $width; $x++) {
+                if (
+                    $x + 6 < $width
+                    && $array[$y][$x] === 1
+                    && $array[$y][$x + 1] === 0
+                    && $array[$y][$x + 2] === 1
+                    && $array[$y][$x + 3] === 1
+                    && $array[$y][$x + 4] === 1
+                    && $array[$y][$x + 5] === 0
+                    && $array[$y][$x + 6] === 1
+                    && (
+                        (
+                            $x + 10 < $width
+                            && $array[$y][$x + 7] === 0
+                            && $array[$y][$x + 8] === 0
+                            && $array[$y][$x + 9] === 0
+                            && $array[$y][$x + 10] === 0
+                        )
+                        || (
+                            $x - 4 >= 0
+                            && $array[$y][$x - 1] === 0
+                            && $array[$y][$x - 2] === 0
+                            && $array[$y][$x - 3] === 0
+                            && $array[$y][$x - 4] === 0
+                        )
+                    )
+                ) {
+                    $penalty += self::N3;
+                }
+
+                if (
+                    $y + 6 < $height
+                    && $array[$y][$x] === 1
+                    && $array[$y + 1][$x] === 0
+                    && $array[$y + 2][$x] === 1
+                    && $array[$y + 3][$x] === 1
+                    && $array[$y + 4][$x] === 1
+                    && $array[$y + 5][$x] === 0
+                    && $array[$y + 6][$x] === 1
+                    && (
+                        (
+                            $y + 10 < $height
+                            && $array[$y + 7][$x] === 0
+                            && $array[$y + 8][$x] === 0
+                            && $array[$y + 9][$x] === 0
+                            && $array[$y + 10][$x] === 0
+                        )
+                        || (
+                            $y - 4 >= 0
+                            && $array[$y - 1][$x] === 0
+                            && $array[$y - 2][$x] === 0
+                            && $array[$y - 3][$x] === 0
+                            && $array[$y - 4][$x] === 0
+                        )
+                    )
+                ) {
+                    $penalty += self::N3;
+                }
+            }
+        }
+
+        return $penalty;
+    }
+
+    /**
+     * Applies mask penalty rule 4 and returns the penalty.
+     *
+     * Calculates the ratio of dark cells and gives penalty if the ratio is far
+     * from 50%. It gives 10 penalty for 5% distance.
+     *
+     * @param  ByteMatrix $matrix
+     * @return integer
+     */
+    public static function applyMaskPenaltyRule4(ByteMatrix $matrix)
+    {
+        $numDarkCells = 0;
+
+        $array  = $matrix->getArray();
+        $width  = $matrix->getWidth();
+        $height = $matrix->getHeight();
+
+        for ($y = 0; $y < $height; $y++) {
+            $arrayY = $array[$y];
+
+            for ($x = 0; $x < $width; $x++) {
+                if ($arrayY[$x] === 1) {
+                    $numDarkCells++;
+                }
+            }
+        }
+
+        $numTotalCells         = $height * $width;
+        $darkRatio             = $numDarkCells / $numTotalCells;
+        $fixedPercentVariances = (int) (abs($darkRatio - 0.5) * 20);
+
+        return $fixedPercentVariances * self::N4;
+    }
+
+    /**
+     * Returns the mask bit for "getMaskPattern" at "x" and "y".
+     *
+     * See 8.8 of JISX0510:2004 for mask pattern conditions.
+     *
+     * @param  integer $maskPattern
+     * @param  integer $x
+     * @param  integer $y
+     * @return integer
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function getDataMaskBit($maskPattern, $x, $y)
+    {
+        switch ($maskPattern) {
+            case 0:
+                $intermediate = ($y + $x) & 0x1;
+                break;
+
+            case 1:
+                $intermediate = $y & 0x1;
+                break;
+
+            case 2:
+                $intermediate = $x % 3;
+                break;
+
+            case 3:
+                $intermediate = ($y + $x) % 3;
+                break;
+
+            case 4:
+                $intermediate = (BitUtils::unsignedRightShift($y, 1) + ($x / 3)) & 0x1;
+                break;
+
+            case 5:
+                $temp         = $y * $x;
+                $intermediate = ($temp & 0x1) + ($temp % 3);
+                break;
+
+            case 6:
+                $temp         = $y * $x;
+                $intermediate = (($temp & 0x1) + ($temp % 3)) & 0x1;
+                break;
+
+            case 7:
+                $temp         = $y * $x;
+                $intermediate = (($temp % 3) + (($y + $x) & 0x1)) & 0x1;
+                break;
+
+            default:
+                throw new Exception\InvalidArgumentException('Invalid mask pattern: ' . $maskPattern);
+        }
+
+        return $intermediate === 0;
+    }
+
+    /**
+     * Helper function for applyMaskPenaltyRule1.
+     *
+     * We need this for doing this calculation in both vertical and horizontal
+     * orders respectively.
+     *
+     * @param  ByteMatrix $matrix
+     * @param  boolean    $isHorizontal
+     * @return integer
+     */
+    protected static function applyMaskPenaltyRule1Internal(ByteMatrix $matrix, $isHorizontal)
+    {
+        $penalty = 0;
+        $iLimit  = $isHorizontal ? $matrix->getHeight() : $matrix->getWidth();
+        $jLimit  = $isHorizontal ? $matrix->getWidth() : $matrix->getHeight();
+        $array   = $matrix->getArray();
+
+        for ($i = 0; $i < $iLimit; $i++) {
+            $numSameBitCells = 0;
+            $prevBit         = -1;
+
+            for ($j = 0; $j < $jLimit; $j++) {
+                $bit = $isHorizontal ? $array[$i][$j] : $array[$j][$i];
+
+                if ($bit === $prevBit) {
+                    $numSameBitCells++;
+                } else {
+                    if ($numSameBitCells >= 5) {
+                        $penalty += self::N1 + ($numSameBitCells - 5);
+                    }
+
+                    $numSameBitCells = 1;
+                    $prevBit         = $bit;
+                }
+            }
+
+            if ($numSameBitCells >= 5) {
+                $penalty += self::N1 + ($numSameBitCells - 5);
+            }
+        }
+
+        return $penalty;
+    }
+}

--- a/includes/BaconQrCode/Encoder/MaskUtil.php
+++ b/includes/BaconQrCode/Encoder/MaskUtil.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
-use BaconQrCode\Common\BitUtils;
+use TwoFactor\BaconQrCode\Common\BitUtils;
 
 /**
  * Mask utility.

--- a/includes/BaconQrCode/Encoder/MatrixUtil.php
+++ b/includes/BaconQrCode/Encoder/MatrixUtil.php
@@ -1,0 +1,580 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use BaconQrCode\Common\BitArray;
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Common\Version;
+use BaconQrCode\Exception;
+
+/**
+ * Matrix utility.
+ */
+class MatrixUtil
+{
+    /**
+     * Position detection pattern.
+     *
+     * @var array
+     */
+    protected static $positionDetectionPattern = array(
+        array(1, 1, 1, 1, 1, 1, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 0, 1, 1, 1, 0, 1),
+        array(1, 0, 1, 1, 1, 0, 1),
+        array(1, 0, 1, 1, 1, 0, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 1, 1, 1, 1, 1, 1),
+    );
+
+    /**
+     * Position adjustment pattern.
+     *
+     * @var array
+     */
+    protected static $positionAdjustmentPattern = array(
+        array(1, 1, 1, 1, 1),
+        array(1, 0, 0, 0, 1),
+        array(1, 0, 1, 0, 1),
+        array(1, 0, 0, 0, 1),
+        array(1, 1, 1, 1, 1),
+    );
+
+    /**
+     * Coordinates for position adjustment patterns for each version.
+     *
+     * @var array
+     */
+    protected static $positionAdjustmentPatternCoordinateTable = array(
+        array(null, null, null, null, null, null, null), // Version 1
+        array(   6,   18, null, null, null, null, null), // Version 2
+        array(   6,   22, null, null, null, null, null), // Version 3
+        array(   6,   26, null, null, null, null, null), // Version 4
+        array(   6,   30, null, null, null, null, null), // Version 5
+        array(   6,   34, null, null, null, null, null), // Version 6
+        array(   6,   22,   38, null, null, null, null), // Version 7
+        array(   6,   24,   42, null, null, null, null), // Version 8
+        array(   6,   26,   46, null, null, null, null), // Version 9
+        array(   6,   28,   50, null, null, null, null), // Version 10
+        array(   6,   30,   54, null, null, null, null), // Version 11
+        array(   6,   32,   58, null, null, null, null), // Version 12
+        array(   6,   34,   62, null, null, null, null), // Version 13
+        array(   6,   26,   46,   66, null, null, null), // Version 14
+        array(   6,   26,   48,   70, null, null, null), // Version 15
+        array(   6,   26,   50,   74, null, null, null), // Version 16
+        array(   6,   30,   54,   78, null, null, null), // Version 17
+        array(   6,   30,   56,   82, null, null, null), // Version 18
+        array(   6,   30,   58,   86, null, null, null), // Version 19
+        array(   6,   34,   62,   90, null, null, null), // Version 20
+        array(   6,   28,   50,   72,   94, null, null), // Version 21
+        array(   6,   26,   50,   74,   98, null, null), // Version 22
+        array(   6,   30,   54,   78,  102, null, null), // Version 23
+        array(   6,   28,   54,   80,  106, null, null), // Version 24
+        array(   6,   32,   58,   84,  110, null, null), // Version 25
+        array(   6,   30,   58,   86,  114, null, null), // Version 26
+        array(   6,   34,   62,   90,  118, null, null), // Version 27
+        array(   6,   26,   50,   74,   98,  122, null), // Version 28
+        array(   6,   30,   54,   78,  102,  126, null), // Version 29
+        array(   6,   26,   52,   78,  104,  130, null), // Version 30
+        array(   6,   30,   56,   82,  108,  134, null), // Version 31
+        array(   6,   34,   60,   86,  112,  138, null), // Version 32
+        array(   6,   30,   58,   86,  114,  142, null), // Version 33
+        array(   6,   34,   62,   90,  118,  146, null), // Version 34
+        array(   6,   30,   54,   78,  102,  126,  150), // Version 35
+        array(   6,   24,   50,   76,  102,  128,  154), // Version 36
+        array(   6,   28,   54,   80,  106,  132,  158), // Version 37
+        array(   6,   32,   58,   84,  110,  136,  162), // Version 38
+        array(   6,   26,   54,   82,  110,  138,  166), // Version 39
+        array(   6,   30,   58,   86,  114,  142,  170), // Version 40
+    );
+
+    /**
+     * Type information coordinates.
+     *
+     * @var array
+     */
+    protected static $typeInfoCoordinates = array(
+        array(8, 0),
+        array(8, 1),
+        array(8, 2),
+        array(8, 3),
+        array(8, 4),
+        array(8, 5),
+        array(8, 7),
+        array(8, 8),
+        array(7, 8),
+        array(5, 8),
+        array(4, 8),
+        array(3, 8),
+        array(2, 8),
+        array(1, 8),
+        array(0, 8),
+    );
+
+    /**
+     * Version information polynomial.
+     *
+     * @var integer
+     */
+    protected static $versionInfoPoly = 0x1f25;
+
+    /**
+     * Type information polynomial.
+     *
+     * @var integer
+     */
+    protected static $typeInfoPoly = 0x537;
+
+    /**
+     * Type information mask pattern.
+     *
+     * @var integer
+     */
+    protected static $typeInfoMaskPattern = 0x5412;
+
+    /**
+     * Clears a given matrix.
+     *
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    public static function clearMatrix(ByteMatrix $matrix)
+    {
+        $matrix->clear(-1);
+    }
+
+    /**
+     * Builds a complete matrix.
+     *
+     * @param  BitArray             $dataBits
+     * @param  ErrorCorrectionLevel $level
+     * @param  Version              $version
+     * @param  integer              $maskPattern
+     * @param  ByteMatrix           $matrix
+     * @return void
+     */
+    public static function buildMatrix(
+        BitArray $dataBits,
+        ErrorCorrectionLevel $level,
+        Version $version,
+        $maskPattern,
+        ByteMatrix $matrix
+    ) {
+        self::clearMatrix($matrix);
+        self::embedBasicPatterns($version, $matrix);
+        self::embedTypeInfo($level, $maskPattern, $matrix);
+        self::maybeEmbedVersionInfo($version, $matrix);
+        self::embedDataBits($dataBits, $maskPattern, $matrix);
+    }
+
+    /**
+     * Embeds type information into a matrix.
+     *
+     * @param  ErrorCorrectionLevel $level
+     * @param  integer              $maskPattern
+     * @param  ByteMatrix           $matrix
+     * @return void
+     */
+    protected static function embedTypeInfo(ErrorCorrectionLevel $level, $maskPattern, ByteMatrix $matrix)
+    {
+        $typeInfoBits = new BitArray();
+        self::makeTypeInfoBits($level, $maskPattern, $typeInfoBits);
+
+        $typeInfoBitsSize = $typeInfoBits->getSize();
+
+        for ($i = 0; $i < $typeInfoBitsSize; $i++) {
+            $bit = $typeInfoBits->get($typeInfoBitsSize - 1 - $i);
+
+            $x1 = self::$typeInfoCoordinates[$i][0];
+            $y1 = self::$typeInfoCoordinates[$i][1];
+
+            $matrix->set($x1, $y1, $bit);
+
+            if ($i < 8) {
+                $x2 = $matrix->getWidth() - $i - 1;
+                $y2 = 8;
+            } else {
+                $x2 = 8;
+                $y2 = $matrix->getHeight() - 7 + ($i - 8);
+            }
+
+            $matrix->set($x2, $y2, $bit);
+        }
+    }
+
+    /**
+     * Generates type information bits and appends them to a bit array.
+     *
+     * @param  ErrorCorrectionLevel $level
+     * @param  integer $maskPattern
+     * @param  BitArray $bits
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected static function makeTypeInfoBits(ErrorCorrectionLevel $level, $maskPattern, BitArray $bits)
+    {
+        $typeInfo = ($level->get() << 3) | $maskPattern;
+        $bits->appendBits($typeInfo, 5);
+
+        $bchCode = self::calculateBchCode($typeInfo, self::$typeInfoPoly);
+        $bits->appendBits($bchCode, 10);
+
+        $maskBits = new BitArray();
+        $maskBits->appendBits(self::$typeInfoMaskPattern, 15);
+        $bits->xorBits($maskBits);
+
+        if ($bits->getSize() !== 15) {
+            throw new Exception\RuntimeException('Bit array resulted in invalid size: ' . $bits->getSize());
+        }
+    }
+
+    /**
+     * Embeds version information if required.
+     *
+     * @param  Version    $version
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function maybeEmbedVersionInfo(Version $version, ByteMatrix $matrix)
+    {
+        if ($version->getVersionNumber() < 7) {
+            return;
+        }
+
+        $versionInfoBits = new BitArray();
+        self::makeVersionInfoBits($version, $versionInfoBits);
+
+        $bitIndex = 6 * 3 - 1;
+
+        for ($i = 0; $i < 6; $i++) {
+            for ($j = 0; $j < 3; $j++) {
+                $bit = $versionInfoBits->get($bitIndex);
+                $bitIndex--;
+
+                $matrix->set($i, $matrix->getHeight() - 11 + $j, $bit);
+                $matrix->set($matrix->getHeight() - 11 + $j, $i, $bit);
+            }
+        }
+    }
+
+    /**
+     * Generates version information bits and appends them to a bit array.
+     *
+     * @param  Version  $version
+     * @param  BitArray $bits
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected static function makeVersionInfoBits(Version $version, BitArray $bits)
+    {
+        $bits->appendBits($version->getVersionNumber(), 6);
+
+        $bchCode = self::calculateBchCode($version->getVersionNumber(), self::$versionInfoPoly);
+        $bits->appendBits($bchCode, 12);
+
+        if ($bits->getSize() !== 18) {
+            throw new Exception\RuntimeException('Bit array resulted in invalid size: ' . $bits->getSize());
+        }
+    }
+
+    /**
+     * Calculates the BHC code for a value and a polynomial.
+     *
+     * @param  integer $value
+     * @param  integer $poly
+     * @return integer
+     */
+    protected static function calculateBchCode($value, $poly)
+    {
+        $msbSetInPoly   = self::findMsbSet($poly);
+        $value        <<= $msbSetInPoly - 1;
+
+        while (self::findMsbSet($value) >= $msbSetInPoly) {
+            $value ^= $poly << (self::findMsbSet($value) - $msbSetInPoly);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Finds and MSB set.
+     *
+     * @param  integer $value
+     * @return integer
+     */
+    protected static function findMsbSet($value)
+    {
+        $numDigits = 0;
+
+        while ($value !== 0) {
+            $value >>= 1;
+            $numDigits++;
+        }
+
+        return $numDigits;
+    }
+
+    /**
+     * Embeds basic patterns into a matrix.
+     *
+     * @param  Version    $version
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function embedBasicPatterns(Version $version, ByteMatrix $matrix)
+    {
+        self::embedPositionDetectionPatternsAndSeparators($matrix);
+        self::embedDarkDotAtLeftBottomCorner($matrix);
+        self::maybeEmbedPositionAdjustmentPatterns($version, $matrix);
+        self::embedTimingPatterns($matrix);
+    }
+
+    /**
+     * Embeds position detection patterns and separators into a byte matrix.
+     *
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function embedPositionDetectionPatternsAndSeparators(ByteMatrix $matrix)
+    {
+        $pdpWidth = count(self::$positionDetectionPattern[0]);
+
+        self::embedPositionDetectionPattern(0, 0, $matrix);
+        self::embedPositionDetectionPattern($matrix->getWidth() - $pdpWidth, 0, $matrix);
+        self::embedPositionDetectionPattern(0, $matrix->getWidth() - $pdpWidth, $matrix);
+
+        $hspWidth = 8;
+
+        self::embedHorizontalSeparationPattern(0, $hspWidth - 1, $matrix);
+        self::embedHorizontalSeparationPattern($matrix->getWidth() - $hspWidth, $hspWidth - 1, $matrix);
+        self::embedHorizontalSeparationPattern(0, $matrix->getWidth() - $hspWidth, $matrix);
+
+        $vspSize = 7;
+
+        self::embedVerticalSeparationPattern($vspSize, 0, $matrix);
+        self::embedVerticalSeparationPattern($matrix->getHeight() - $vspSize - 1, 0, $matrix);
+        self::embedVerticalSeparationPattern($vspSize, $matrix->getHeight() - $vspSize, $matrix);
+    }
+
+    /**
+     * Embeds a single position detection pattern into a byte matrix.
+     *
+     * @param  integer    $xStart
+     * @param  integer    $yStart
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function embedPositionDetectionPattern($xStart, $yStart, ByteMatrix $matrix)
+    {
+        for ($y = 0; $y < 7; $y++) {
+            for ($x = 0; $x < 7; $x++) {
+                $matrix->set($xStart + $x, $yStart + $y, self::$positionDetectionPattern[$y][$x]);
+            }
+        }
+    }
+
+    /**
+     * Embeds a single horizontal separation pattern.
+     *
+     * @param  integer    $xStart
+     * @param  integer    $yStart
+     * @param  ByteMatrix $matrix
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected static function embedHorizontalSeparationPattern($xStart, $yStart, ByteMatrix $matrix)
+    {
+        for ($x = 0; $x < 8; $x++) {
+            if ($matrix->get($xStart + $x, $yStart) !== -1) {
+                throw new Exception\RuntimeException('Byte already set');
+            }
+
+            $matrix->set($xStart + $x, $yStart, 0);
+        }
+    }
+
+    /**
+     * Embeds a single vertical separation pattern.
+     *
+     * @param  integer    $xStart
+     * @param  integer    $yStart
+     * @param  ByteMatrix $matrix
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected static function embedVerticalSeparationPattern($xStart, $yStart, ByteMatrix $matrix)
+    {
+        for ($y = 0; $y < 7; $y++) {
+            if ($matrix->get($xStart, $yStart + $y) !== -1) {
+                throw new Exception\RuntimeException('Byte already set');
+            }
+
+            $matrix->set($xStart, $yStart + $y, 0);
+        }
+    }
+
+    /**
+     * Embeds a dot at the left bottom corner.
+     *
+     * @param  ByteMatrix $matrix
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    protected static function embedDarkDotAtLeftBottomCorner(ByteMatrix $matrix)
+    {
+        if ($matrix->get(8, $matrix->getHeight() - 8) === 0) {
+            throw new Exception\RuntimeException('Byte already set to 0');
+        }
+
+        $matrix->set(8, $matrix->getHeight() - 8, 1);
+    }
+
+    /**
+     * Embeds position adjustment patterns if required.
+     *
+     * @param  Version    $version
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function maybeEmbedPositionAdjustmentPatterns(Version $version, ByteMatrix $matrix)
+    {
+        if ($version->getVersionNumber() < 2) {
+            return;
+        }
+
+        $index = $version->getVersionNumber() - 1;
+
+        $coordinates    = self::$positionAdjustmentPatternCoordinateTable[$index];
+        $numCoordinates = count($coordinates);
+
+        for ($i = 0; $i < $numCoordinates; $i++) {
+            for ($j = 0; $j < $numCoordinates; $j++) {
+                $y = $coordinates[$i];
+                $x = $coordinates[$j];
+
+                if ($x === null || $y === null) {
+                    continue;
+                }
+
+                if ($matrix->get($x, $y) === -1) {
+                    self::embedPositionAdjustmentPattern($x - 2, $y - 2, $matrix);
+                }
+            }
+        }
+    }
+
+    /**
+     * Embeds a single position adjustment pattern.
+     *
+     * @param  integer    $xStart
+     * @param  intger     $yStart
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function embedPositionAdjustmentPattern($xStart, $yStart, ByteMatrix $matrix)
+    {
+        for ($y = 0; $y < 5; $y++) {
+            for ($x = 0; $x < 5; $x++) {
+                $matrix->set($xStart + $x, $yStart + $y, self::$positionAdjustmentPattern[$y][$x]);
+            }
+        }
+    }
+
+    /**
+     * Embeds timing patterns into a matrix.
+     *
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    protected static function embedTimingPatterns(ByteMatrix $matrix)
+    {
+        $matrixWidth = $matrix->getWidth();
+
+        for ($i = 8; $i < $matrixWidth - 8; $i++) {
+            $bit = ($i + 1) % 2;
+
+            if ($matrix->get($i, 6) === -1) {
+                $matrix->set($i, 6, $bit);
+            }
+
+            if ($matrix->get(6, $i) === -1) {
+                $matrix->set(6, $i, $bit);
+            }
+        }
+    }
+
+    /**
+     * Embeds "dataBits" using "getMaskPattern".
+     *
+     *  For debugging purposes, it skips masking process if "getMaskPattern" is
+     * -1. See 8.7 of JISX0510:2004 (p.38) for how to embed data bits.
+     *
+     * @param  BitArray   $dataBits
+     * @param  integer    $maskPattern
+     * @param  ByteMatrix $matrix
+     * @return void
+     * @throws Exception\WriterException
+     */
+    protected static function embedDataBits(BitArray $dataBits, $maskPattern, ByteMatrix $matrix)
+    {
+        $bitIndex  = 0;
+        $direction = -1;
+
+        // Start from the right bottom cell.
+        $x = $matrix->getWidth() - 1;
+        $y = $matrix->getHeight() - 1;
+
+        while ($x > 0) {
+            // Skip vertical timing pattern.
+            if ($x === 6) {
+                $x--;
+            }
+
+            while ($y >= 0 && $y < $matrix->getHeight()) {
+                for ($i = 0; $i < 2; $i++) {
+                    $xx = $x - $i;
+
+                    // Skip the cell if it's not empty.
+                    if ($matrix->get($xx, $y) !== -1) {
+                        continue;
+                    }
+
+                    if ($bitIndex < $dataBits->getSize()) {
+                        $bit = $dataBits->get($bitIndex);
+                        $bitIndex++;
+                    } else {
+                        // Padding bit. If there is no bit left, we'll fill the
+                        // left cells with 0, as described in 8.4.9 of
+                        // JISX0510:2004 (p. 24).
+                        $bit = false;
+                    }
+
+                    // Skip masking if maskPattern is -1.
+                    if ($maskPattern !== -1 && MaskUtil::getDataMaskBit($maskPattern, $xx, $y)) {
+                        $bit = !$bit;
+                    }
+
+                    $matrix->set($xx, $y, $bit);
+                }
+
+                $y += $direction;
+            }
+
+            $direction  = -$direction;
+            $y         += $direction;
+            $x         -= 2;
+        }
+
+        // All bits should be consumed
+        if ($bitIndex !== $dataBits->getSize()) {
+            throw new Exception\WriterException('Not all bits consumed (' . $bitIndex . ' out of ' . $dataBits->getSize() .')');
+        }
+    }
+}

--- a/includes/BaconQrCode/Encoder/MatrixUtil.php
+++ b/includes/BaconQrCode/Encoder/MatrixUtil.php
@@ -7,12 +7,12 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
-use BaconQrCode\Common\BitArray;
-use BaconQrCode\Common\ErrorCorrectionLevel;
-use BaconQrCode\Common\Version;
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Common\BitArray;
+use TwoFactor\BaconQrCode\Common\ErrorCorrectionLevel;
+use TwoFactor\BaconQrCode\Common\Version;
+use TwoFactor\BaconQrCode\Exception;
 
 /**
  * Matrix utility.

--- a/includes/BaconQrCode/Encoder/QrCode.php
+++ b/includes/BaconQrCode/Encoder/QrCode.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Encoder;
+
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Common\Mode;
+use BaconQrCode\Common\Version;
+
+/**
+ * QR code.
+ */
+class QrCode
+{
+    /**
+     * Number of possible mask patterns.
+     */
+    const NUM_MASK_PATTERNS = 8;
+
+    /**
+     * Mode of the QR code.
+     *
+     * @var Mode
+     */
+    protected $mode;
+
+    /**
+     * EC level of the QR code.
+     *
+     * @var ErrorCorrectionLevel
+     */
+    protected $errorCorrectionLevel;
+
+    /**
+     * Version of the QR code.
+     *
+     * @var Version
+     */
+    protected $version;
+
+    /**
+     * Mask pattern of the QR code.
+     *
+     * @var integer
+     */
+    protected $maskPattern = -1;
+
+    /**
+     * Matrix of the QR code.
+     *
+     * @var ByteMatrix
+     */
+    protected $matrix;
+
+    /**
+     * Gets the mode.
+     *
+     * @return Mode
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Sets the mode.
+     *
+     * @param  Mode $mode
+     * @return void
+     */
+    public function setMode(Mode $mode)
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * Gets the EC level.
+     *
+     * @return ErrorCorrectionLevel
+     */
+    public function getErrorCorrectionLevel()
+    {
+        return $this->errorCorrectionLevel;
+    }
+
+    /**
+     * Sets the EC level.
+     *
+     * @param  ErrorCorrectionLevel $errorCorrectionLevel
+     * @return void
+     */
+    public function setErrorCorrectionLevel(ErrorCorrectionLevel $errorCorrectionLevel)
+    {
+        $this->errorCorrectionLevel = $errorCorrectionLevel;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @return Version
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets the version.
+     *
+     * @param  Version $version
+     * @return void
+     */
+    public function setVersion(Version $version)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * Gets the mask pattern.
+     *
+     * @return integer
+     */
+    public function getMaskPattern()
+    {
+        return $this->maskPattern;
+    }
+
+    /**
+     * Sets the mask pattern.
+     *
+     * @param  integer $maskPattern
+     * @return void
+     */
+    public function setMaskPattern($maskPattern)
+    {
+        $this->maskPattern = $maskPattern;
+    }
+
+    /**
+     * Gets the matrix.
+     *
+     * @return ByteMatrix
+     */
+    public function getMatrix()
+    {
+        return $this->matrix;
+    }
+
+    /**
+     * Sets the matrix.
+     *
+     * @param  ByteMatrix $matrix
+     * @return void
+     */
+    public function setMatrix(ByteMatrix $matrix)
+    {
+        $this->matrix = $matrix;
+    }
+
+    /**
+     * Validates whether a mask pattern is valid.
+     *
+     * @param  integer $maskPattern
+     * @return boolean
+     */
+    public static function isValidMaskPattern($maskPattern)
+    {
+        return $maskPattern > 0 && $maskPattern < self::NUM_MASK_PATTERNS;
+    }
+
+    /**
+     * Returns a string representation of the QR code.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $result = "<<\n"
+                . " mode: " . $this->mode . "\n"
+                . " ecLevel: " . $this->errorCorrectionLevel . "\n"
+                . " version: " . $this->version . "\n"
+                . " maskPattern: " . $this->maskPattern . "\n";
+
+        if ($this->matrix === null) {
+            $result .= " matrix: null\n";
+        } else {
+            $result .= " matrix:\n";
+            $result .= $this->matrix;
+        }
+
+        $result .= ">>\n";
+
+        return $result;
+    }
+}

--- a/includes/BaconQrCode/Encoder/QrCode.php
+++ b/includes/BaconQrCode/Encoder/QrCode.php
@@ -7,11 +7,11 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Encoder;
+namespace TwoFactor\BaconQrCode\Encoder;
 
-use BaconQrCode\Common\ErrorCorrectionLevel;
-use BaconQrCode\Common\Mode;
-use BaconQrCode\Common\Version;
+use TwoFactor\BaconQrCode\Common\ErrorCorrectionLevel;
+use TwoFactor\BaconQrCode\Common\Mode;
+use TwoFactor\BaconQrCode\Common\Version;
 
 /**
  * QR code.

--- a/includes/BaconQrCode/Exception/ExceptionInterface.php
+++ b/includes/BaconQrCode/Exception/ExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/ExceptionInterface.php
+++ b/includes/BaconQrCode/Exception/ExceptionInterface.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 interface ExceptionInterface
 {

--- a/includes/BaconQrCode/Exception/InvalidArgumentException.php
+++ b/includes/BaconQrCode/Exception/InvalidArgumentException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/InvalidArgumentException.php
+++ b/includes/BaconQrCode/Exception/InvalidArgumentException.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/includes/BaconQrCode/Exception/OutOfBoundsException.php
+++ b/includes/BaconQrCode/Exception/OutOfBoundsException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/OutOfBoundsException.php
+++ b/includes/BaconQrCode/Exception/OutOfBoundsException.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
 {

--- a/includes/BaconQrCode/Exception/RuntimeException.php
+++ b/includes/BaconQrCode/Exception/RuntimeException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/RuntimeException.php
+++ b/includes/BaconQrCode/Exception/RuntimeException.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {

--- a/includes/BaconQrCode/Exception/UnexpectedValueException.php
+++ b/includes/BaconQrCode/Exception/UnexpectedValueException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/UnexpectedValueException.php
+++ b/includes/BaconQrCode/Exception/UnexpectedValueException.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {

--- a/includes/BaconQrCode/Exception/WriterException.php
+++ b/includes/BaconQrCode/Exception/WriterException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Exception;
+
+class WriterException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/includes/BaconQrCode/Exception/WriterException.php
+++ b/includes/BaconQrCode/Exception/WriterException.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Exception;
+namespace TwoFactor\BaconQrCode\Exception;
 
 class WriterException extends \RuntimeException implements ExceptionInterface
 {

--- a/includes/BaconQrCode/Renderer/Color/Cmyk.php
+++ b/includes/BaconQrCode/Renderer/Color/Cmyk.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Color;
+
+use BaconQrCode\Exception;
+
+/**
+ * CMYK color.
+ */
+class Cmyk implements ColorInterface
+{
+    /**
+     * Cyan value.
+     *
+     * @var integer
+     */
+    protected $cyan;
+
+    /**
+     * Magenta value.
+     *
+     * @var integer
+     */
+    protected $magenta;
+
+    /**
+     * Yellow value.
+     *
+     * @var integer
+     */
+    protected $yellow;
+
+    /**
+     * Black value.
+     *
+     * @var integer
+     */
+    protected $black;
+
+    /**
+     * Creates a new CMYK color.
+     *
+     * @param integer $cyan
+     * @param integer $magenta
+     * @param integer $yellow
+     * @param integer $black
+     */
+    public function __construct($cyan, $magenta, $yellow, $black)
+    {
+        if ($cyan < 0 || $cyan > 100) {
+            throw new Exception\InvalidArgumentException('Cyan must be between 0 and 100');
+        }
+
+        if ($magenta < 0 || $magenta > 100) {
+            throw new Exception\InvalidArgumentException('Magenta must be between 0 and 100');
+        }
+
+        if ($yellow < 0 || $yellow > 100) {
+            throw new Exception\InvalidArgumentException('Yellow must be between 0 and 100');
+        }
+
+        if ($black < 0 || $black > 100) {
+            throw new Exception\InvalidArgumentException('Black must be between 0 and 100');
+        }
+
+        $this->cyan    = (int) $cyan;
+        $this->magenta = (int) $magenta;
+        $this->yellow  = (int) $yellow;
+        $this->black   = (int) $black;
+    }
+
+    /**
+     * Returns the cyan value.
+     *
+     * @return integer
+     */
+    public function getCyan()
+    {
+        return $this->cyan;
+    }
+
+    /**
+     * Returns the magenta value.
+     *
+     * @return integer
+     */
+    public function getMagenta()
+    {
+        return $this->magenta;
+    }
+
+    /**
+     * Returns the yellow value.
+     *
+     * @return integer
+     */
+    public function getYellow()
+    {
+        return $this->yellow;
+    }
+
+    /**
+     * Returns the black value.
+     *
+     * @return integer
+     */
+    public function getBlack()
+    {
+        return $this->black;
+    }
+
+    /**
+     * toRgb(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toRgb()
+     * @return Rgb
+     */
+    public function toRgb()
+    {
+        $k = $this->black / 100;
+        $c = (-$k * $this->cyan + $k * 100 + $this->cyan) / 100;
+        $m = (-$k * $this->magenta + $k * 100 + $this->magenta) / 100;
+        $y = (-$k * $this->yellow + $k * 100 + $this->yellow) / 100;
+
+        return new Rgb(
+            -$c * 255 + 255,
+            -$m * 255 + 255,
+            -$y * 255 + 255
+        );
+    }
+
+    /**
+     * toCmyk(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toCmyk()
+     * @return Cmyk
+     */
+    public function toCmyk()
+    {
+        return $this;
+    }
+
+    /**
+     * toGray(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toGray()
+     * @return Gray
+     */
+    public function toGray()
+    {
+        return $this->toRgb()->toGray();
+    }
+}

--- a/includes/BaconQrCode/Renderer/Color/Cmyk.php
+++ b/includes/BaconQrCode/Renderer/Color/Cmyk.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Color;
+namespace TwoFactor\BaconQrCode\Renderer\Color;
 
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Exception;
 
 /**
  * CMYK color.

--- a/includes/BaconQrCode/Renderer/Color/ColorInterface.php
+++ b/includes/BaconQrCode/Renderer/Color/ColorInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Color;
+
+/**
+ * Color interface.
+ */
+interface ColorInterface
+{
+    /**
+     * Converts the color to RGB.
+     *
+     * @return Rgb
+     */
+    public function toRgb();
+
+    /**
+     * Converts the color to CMYK.
+     *
+     * @return Cmyk
+     */
+    public function toCmyk();
+
+    /**
+     * Converts the color to gray.
+     *
+     * @return Gray
+     */
+    public function toGray();
+}

--- a/includes/BaconQrCode/Renderer/Color/ColorInterface.php
+++ b/includes/BaconQrCode/Renderer/Color/ColorInterface.php
@@ -7,7 +7,7 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Color;
+namespace TwoFactor\BaconQrCode\Renderer\Color;
 
 /**
  * Color interface.

--- a/includes/BaconQrCode/Renderer/Color/Gray.php
+++ b/includes/BaconQrCode/Renderer/Color/Gray.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Color;
+
+use BaconQrCode\Exception;
+
+/**
+ * Gray color.
+ */
+class Gray implements ColorInterface
+{
+    /**
+     * Gray value.
+     *
+     * @var integer
+     */
+    protected $gray;
+
+    /**
+     * Creates a new gray color.
+     *
+     * A low gray value means black, while a high value means white.
+     *
+     * @param integer $gray
+     */
+    public function __construct($gray)
+    {
+        if ($gray < 0 || $gray > 100) {
+            throw new Exception\InvalidArgumentException('Gray must be between 0 and 100');
+        }
+
+        $this->gray = (int) $gray;
+    }
+
+    /**
+     * Returns the gray value.
+     *
+     * @return integer
+     */
+    public function getGray()
+    {
+        return $this->gray;
+    }
+
+    /**
+     * toRgb(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toRgb()
+     * @return Rgb
+     */
+    public function toRgb()
+    {
+        return new Rgb($this->gray * 2.55, $this->gray * 2.55, $this->gray * 2.55);
+    }
+
+    /**
+     * toCmyk(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toCmyk()
+     * @return Cmyk
+     */
+    public function toCmyk()
+    {
+        return new Cmyk(0, 0, 0, 100 - $this->gray);
+    }
+
+    /**
+     * toGray(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toGray()
+     * @return Gray
+     */
+    public function toGray()
+    {
+        return $this;
+    }
+}

--- a/includes/BaconQrCode/Renderer/Color/Gray.php
+++ b/includes/BaconQrCode/Renderer/Color/Gray.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Color;
+namespace TwoFactor\BaconQrCode\Renderer\Color;
 
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Exception;
 
 /**
  * Gray color.

--- a/includes/BaconQrCode/Renderer/Color/Rgb.php
+++ b/includes/BaconQrCode/Renderer/Color/Rgb.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Color;
+
+use BaconQrCode\Exception;
+
+/**
+ * RGB color.
+ */
+class Rgb implements ColorInterface
+{
+    /**
+     * Red value.
+     *
+     * @var integer
+     */
+    protected $red;
+
+    /**
+     * Green value.
+     *
+     * @var integer
+     */
+    protected $green;
+
+    /**
+     * Blue value.
+     *
+     * @var integer
+     */
+    protected $blue;
+
+    /**
+     * Creates a new RGB color.
+     *
+     * @param integer $red
+     * @param integer $green
+     * @param integer $blue
+     */
+    public function __construct($red, $green, $blue)
+    {
+        if ($red < 0 || $red > 255) {
+            throw new Exception\InvalidArgumentException('Red must be between 0 and 255');
+        }
+
+        if ($green < 0 || $green > 255) {
+            throw new Exception\InvalidArgumentException('Green must be between 0 and 255');
+        }
+
+        if ($blue < 0 || $blue > 255) {
+            throw new Exception\InvalidArgumentException('Blue must be between 0 and 255');
+        }
+
+        $this->red   = (int) $red;
+        $this->green = (int) $green;
+        $this->blue  = (int) $blue;
+    }
+
+    /**
+     * Returns the red value.
+     *
+     * @return integer
+     */
+    public function getRed()
+    {
+        return $this->red;
+    }
+
+    /**
+     * Returns the green value.
+     *
+     * @return integer
+     */
+    public function getGreen()
+    {
+        return $this->green;
+    }
+
+    /**
+     * Returns the blue value.
+     *
+     * @return integer
+     */
+    public function getBlue()
+    {
+        return $this->blue;
+    }
+
+    /**
+     * Returns a hexadecimal string representation of the RGB value.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('%02x%02x%02x', $this->red, $this->green, $this->blue);
+    }
+
+    /**
+     * toRgb(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toRgb()
+     * @return Rgb
+     */
+    public function toRgb()
+    {
+        return $this;
+    }
+
+    /**
+     * toCmyk(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toCmyk()
+     * @return Cmyk
+     */
+    public function toCmyk()
+    {
+        $c = 1 - ($this->red / 255);
+        $m = 1 - ($this->green / 255);
+        $y = 1 - ($this->blue / 255);
+        $k = min($c, $m, $y);
+
+        return new Cmyk(
+            100 * ($c - $k) / (1 - $k),
+            100 * ($m - $k) / (1 - $k),
+            100 * ($y - $k) / (1 - $k),
+            100 * $k
+        );
+    }
+
+    /**
+     * toGray(): defined by ColorInterface.
+     *
+     * @see    ColorInterface::toGray()
+     * @return Gray
+     */
+    public function toGray()
+    {
+        return new Gray(($this->red * 0.21 + $this->green * 0.71 + $this->blue * 0.07) / 2.55);
+    }
+}

--- a/includes/BaconQrCode/Renderer/Color/Rgb.php
+++ b/includes/BaconQrCode/Renderer/Color/Rgb.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Color;
+namespace TwoFactor\BaconQrCode\Renderer\Color;
 
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Exception;
 
 /**
  * RGB color.

--- a/includes/BaconQrCode/Renderer/Image/AbstractRenderer.php
+++ b/includes/BaconQrCode/Renderer/Image/AbstractRenderer.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Encoder\QrCode;
+use BaconQrCode\Renderer\Color;
+use BaconQrCode\Renderer\Image\Decorator\DecoratorInterface;
+use BaconQrCode\Exception;
+
+/**
+ * Image renderer, supporting multiple backends.
+ */
+abstract class AbstractRenderer implements RendererInterface
+{
+    /**
+     * Margin around the QR code, also known as quiet zone.
+     *
+     * @var integer
+     */
+    protected $margin = 4;
+
+    /**
+     * Requested width of the rendered image.
+     *
+     * @var integer
+     */
+    protected $width = 0;
+
+    /**
+     * Requested height of the rendered image.
+     *
+     * @var integer
+     */
+    protected $height = 0;
+
+    /**
+     * Whether dimensions should be rounded down.
+     *
+     * @var boolean
+     */
+    protected $roundDimensions = true;
+
+    /**
+     * Final width of the image.
+     *
+     * @var integer
+     */
+    protected $finalWidth;
+
+    /**
+     * Final height of the image.
+     *
+     * @var integer
+     */
+    protected $finalHeight;
+
+    /**
+     * Size of each individual block.
+     *
+     * @var integer
+     */
+    protected $blockSize;
+
+    /**
+     * Background color.
+     *
+     * @var Color\ColorInterface
+     */
+    protected $backgroundColor;
+
+    /**
+     * Whether dimensions should be rounded down
+     * 
+     * @var boolean
+     */
+    protected $floorToClosestDimension;
+
+    /**
+     * Foreground color.
+     *
+     * @var Color\ColorInterface
+     */
+    protected $foregroundColor;
+
+    /**
+     * Decorators used on QR codes.
+     *
+     * @var array
+     */
+    protected $decorators = array();
+
+    /**
+     * Sets the margin around the QR code.
+     *
+     * @param  integer $margin
+     * @return AbstractRenderer
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setMargin($margin)
+    {
+        if ($margin < 0) {
+            throw new Exception\InvalidArgumentException('Margin must be equal to greater than 0');
+        }
+
+        $this->margin = (int) $margin;
+        return $this;
+    }
+
+    /**
+     * Gets the margin around the QR code.
+     *
+     * @return integer
+     */
+    public function getMargin()
+    {
+        return $this->margin;
+    }
+
+    /**
+     * Sets the height around the renderd image.
+     *
+     * If the width is smaller than the matrix width plus padding, the renderer
+     * will automatically use that as the width instead of the specified one.
+     *
+     * @param  integer $width
+     * @return AbstractRenderer
+     */
+    public function setWidth($width)
+    {
+        $this->width = (int) $width;
+        return $this;
+    }
+
+    /**
+     * Gets the width of the rendered image.
+     *
+     * @return integer
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * Sets the height around the renderd image.
+     *
+     * If the height is smaller than the matrix height plus padding, the
+     * renderer will automatically use that as the height instead of the
+     * specified one.
+     *
+     * @param  integer $height
+     * @return AbstractRenderer
+     */
+    public function setHeight($height)
+    {
+        $this->height = (int) $height;
+        return $this;
+    }
+
+    /**
+     * Gets the height around the rendered image.
+     *
+     * @return integer
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * Sets whether dimensions should be rounded down.
+     *
+     * @param  boolean $flag
+     * @return AbstractRenderer
+     */
+    public function setRoundDimensions($flag)
+    {
+        $this->floorToClosestDimension = $flag;
+        return $this;
+    }
+
+    /**
+     * Gets whether dimensions should be rounded down.
+     *
+     * @return boolean
+     */
+    public function shouldRoundDimensions()
+    {
+        return $this->floorToClosestDimension;
+    }
+
+    /**
+     * Sets background color.
+     *
+     * @param  Color\ColorInterface $color
+     * @return AbstractRenderer
+     */
+    public function setBackgroundColor(Color\ColorInterface $color)
+    {
+        $this->backgroundColor = $color;
+        return $this;
+    }
+
+    /**
+     * Gets background color.
+     *
+     * @return Color\ColorInterface
+     */
+    public function getBackgroundColor()
+    {
+        if ($this->backgroundColor === null) {
+            $this->backgroundColor = new Color\Gray(100);
+        }
+
+        return $this->backgroundColor;
+    }
+
+    /**
+     * Sets foreground color.
+     *
+     * @param  Color\ColorInterface $color
+     * @return AbstractRenderer
+     */
+    public function setForegroundColor(Color\ColorInterface $color)
+    {
+        $this->foregroundColor = $color;
+        return $this;
+    }
+
+    /**
+     * Gets foreground color.
+     *
+     * @return Color\ColorInterface
+     */
+    public function getForegroundColor()
+    {
+        if ($this->foregroundColor === null) {
+            $this->foregroundColor = new Color\Gray(0);
+        }
+
+        return $this->foregroundColor;
+    }
+
+    /**
+     * Adds a decorator to the renderer.
+     *
+     * @param  DecoratorInterface $decorator
+     * @return AbstractRenderer
+     */
+    public function addDecorator(DecoratorInterface $decorator)
+    {
+        $this->decorators[] = $decorator;
+        return $this;
+    }
+
+    /**
+     * render(): defined by RendererInterface.
+     *
+     * @see    RendererInterface::render()
+     * @param  QrCode $qrCode
+     * @return string
+     */
+    public function render(QrCode $qrCode)
+    {
+        $input        = $qrCode->getMatrix();
+        $inputWidth   = $input->getWidth();
+        $inputHeight  = $input->getHeight();
+        $qrWidth      = $inputWidth + ($this->getMargin() << 1);
+        $qrHeight     = $inputHeight + ($this->getMargin() << 1);
+        $outputWidth  = max($this->getWidth(), $qrWidth);
+        $outputHeight = max($this->getHeight(), $qrHeight);
+        $multiple     = (int) min($outputWidth / $qrWidth, $outputHeight / $qrHeight);
+
+        if ($this->shouldRoundDimensions()) {
+            $outputWidth  -= $outputWidth % $multiple;
+            $outputHeight -= $outputHeight % $multiple;
+        }
+
+        // Padding includes both the quiet zone and the extra white pixels to
+        // accommodate the requested dimensions. For example, if input is 25x25
+        // the QR will be 33x33 including the quiet zone. If the requested size
+        // is 200x160, the multiple will be 4, for a QR of 132x132. These will
+        // handle all the padding from 100x100 (the actual QR) up to 200x160.
+        $leftPadding = (int) (($outputWidth - ($inputWidth * $multiple)) / 2);
+        $topPadding  = (int) (($outputHeight - ($inputHeight * $multiple)) / 2);
+
+        // Store calculated parameters
+        $this->finalWidth  = $outputWidth;
+        $this->finalHeight = $outputHeight;
+        $this->blockSize   = $multiple;
+
+        $this->init();
+        $this->addColor('background', $this->getBackgroundColor());
+        $this->addColor('foreground', $this->getForegroundColor());
+        $this->drawBackground('background');
+
+        foreach ($this->decorators as $decorator) {
+            $decorator->preProcess(
+                $qrCode,
+                $this,
+                $outputWidth,
+                $outputHeight,
+                $leftPadding,
+                $topPadding,
+                $multiple
+            );
+        }
+
+        for ($inputY = 0, $outputY = $topPadding; $inputY < $inputHeight; $inputY++, $outputY += $multiple) {
+            for ($inputX = 0, $outputX = $leftPadding; $inputX < $inputWidth; $inputX++, $outputX += $multiple) {
+                if ($input->get($inputX, $inputY) === 1) {
+                    $this->drawBlock($outputX, $outputY, 'foreground');
+                }
+            }
+        }
+
+        foreach ($this->decorators as $decorator) {
+            $decorator->postProcess(
+                $qrCode,
+                $this,
+                $outputWidth,
+                $outputHeight,
+                $leftPadding,
+                $topPadding,
+                $multiple
+            );
+        }
+
+        return $this->getByteStream();
+    }
+}

--- a/includes/BaconQrCode/Renderer/Image/AbstractRenderer.php
+++ b/includes/BaconQrCode/Renderer/Image/AbstractRenderer.php
@@ -7,12 +7,12 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image;
+namespace TwoFactor\BaconQrCode\Renderer\Image;
 
-use BaconQrCode\Encoder\QrCode;
-use BaconQrCode\Renderer\Color;
-use BaconQrCode\Renderer\Image\Decorator\DecoratorInterface;
-use BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Renderer\Color;
+use TwoFactor\BaconQrCode\Renderer\Image\Decorator\DecoratorInterface;
+use TwoFactor\BaconQrCode\Exception;
 
 /**
  * Image renderer, supporting multiple backends.

--- a/includes/BaconQrCode/Renderer/Image/Decorator/DecoratorInterface.php
+++ b/includes/BaconQrCode/Renderer/Image/Decorator/DecoratorInterface.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image\Decorator;
+
+use BaconQrCode\Encoder\QrCode;
+use BaconQrCode\Renderer\Image\RendererInterface;
+
+/**
+ * Decorator interface.
+ */
+interface DecoratorInterface
+{
+    /**
+     * Pre-process a QR code.
+     *
+     * @param  QrCode            $qrCode
+     * @param  RendererInterface $renderer
+     * @param  integer           $outputWidth
+     * @param  integer           $outputHeight
+     * @param  integer           $leftPadding
+     * @param  integer           $topPadding
+     * @param  integer           $multiple
+     * @return void
+     */
+    public function preProcess(
+        QrCode $qrCode,
+        RendererInterface $renderer,
+        $outputWidth,
+        $outputHeight,
+        $leftPadding,
+        $topPadding,
+        $multiple
+    );
+
+    /**
+     * Post-process a QR code.
+     *
+     * @param  QrCode            $qrCode
+     * @param  RendererInterface $renderer
+     * @param  integer           $outputWidth
+     * @param  integer           $outputHeight
+     * @param  integer           $leftPadding
+     * @param  integer           $topPadding
+     * @param  integer           $multiple
+     * @return void
+     */
+    public function postProcess(
+        QrCode $qrCode,
+        RendererInterface $renderer,
+        $outputWidth,
+        $outputHeight,
+        $leftPadding,
+        $topPadding,
+        $multiple
+    );
+}

--- a/includes/BaconQrCode/Renderer/Image/Decorator/DecoratorInterface.php
+++ b/includes/BaconQrCode/Renderer/Image/Decorator/DecoratorInterface.php
@@ -7,10 +7,10 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image\Decorator;
+namespace TwoFactor\BaconQrCode\Renderer\Image\Decorator;
 
-use BaconQrCode\Encoder\QrCode;
-use BaconQrCode\Renderer\Image\RendererInterface;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Renderer\Image\RendererInterface;
 
 /**
  * Decorator interface.

--- a/includes/BaconQrCode/Renderer/Image/Decorator/FinderPattern.php
+++ b/includes/BaconQrCode/Renderer/Image/Decorator/FinderPattern.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image\Decorator;
+
+use BaconQrCode\Encoder\QrCode;
+use BaconQrCode\Renderer\Image\RendererInterface;
+use BaconQrCode\Renderer\Color;
+
+/**
+ * Finder pattern decorator.
+ */
+class FinderPattern implements DecoratorInterface
+{
+    /**
+     * @var Color\ColorInterface
+     */
+    protected $innerColor;
+
+    /**
+     * @varColor\ColorInterface
+     */
+    protected $outerColor;
+
+    /**
+     * Outer position detection pattern.
+     *
+     * @var array
+     */
+    protected static $outerPositionDetectionPattern = array(
+        array(1, 1, 1, 1, 1, 1, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 0, 0, 0, 0, 0, 1),
+        array(1, 1, 1, 1, 1, 1, 1),
+    );
+
+    /**
+     * Inner position detection pattern.
+     *
+     * @var array
+     */
+    protected static $innerPositionDetectionPattern = array(
+        array(0, 0, 0, 0, 0, 0, 0),
+        array(0, 0, 0, 0, 0, 0, 0),
+        array(0, 0, 1, 1, 1, 0, 0),
+        array(0, 0, 1, 1, 1, 0, 0),
+        array(0, 0, 1, 1, 1, 0, 0),
+        array(0, 0, 0, 0, 0, 0, 0),
+        array(0, 0, 0, 0, 0, 0, 0),
+    );
+
+    /**
+     * Sets outer color.
+     *
+     * @param  Color\ColorInterface $color
+     * @return FinderPattern
+     */
+    public function setOuterColor(Color\ColorInterface $color)
+    {
+        $this->outerColor = $color;
+        return $this;
+    }
+
+    /**
+     * Gets outer color.
+     *
+     * @return Color\ColorInterface
+     */
+    public function getOuterColor()
+    {
+        if ($this->outerColor === null) {
+            $this->outerColor = new Color\Gray(100);
+        }
+
+        return $this->outerColor;
+    }
+
+    /**
+     * Sets inner color.
+     *
+     * @param  Color\ColorInterface $color
+     * @return FinderPattern
+     */
+    public function setInnerColor(Color\ColorInterface $color)
+    {
+        $this->innerColor = $color;
+        return $this;
+    }
+
+    /**
+     * Gets inner color.
+     *
+     * @return Color\ColorInterface
+     */
+    public function getInnerColor()
+    {
+        if ($this->innerColor === null) {
+            $this->innerColor = new Color\Gray(0);
+        }
+
+        return $this->innerColor;
+    }
+
+    /**
+     * preProcess(): defined by DecoratorInterface.
+     *
+     * @see    DecoratorInterface::preProcess()
+     * @param  QrCode            $qrCode
+     * @param  RendererInterface $renderer
+     * @param  integer           $outputWidth
+     * @param  integer           $outputHeight
+     * @param  integer           $leftPadding
+     * @param  integer           $topPadding
+     * @param  integer           $multiple
+     * @return void
+     */
+    public function preProcess(
+        QrCode $qrCode,
+        RendererInterface $renderer,
+        $outputWidth,
+        $outputHeight,
+        $leftPadding,
+        $topPadding,
+        $multiple
+    ) {
+        $matrix    = $qrCode->getMatrix();
+        $positions = array(
+            array(0, 0),
+            array($matrix->getWidth() - 7, 0),
+            array(0, $matrix->getHeight() - 7),
+        );
+
+        foreach (self::$outerPositionDetectionPattern as $y => $row) {
+            foreach ($row as $x => $isSet) {
+                foreach ($positions as $position) {
+                    $matrix->set($x + $position[0], $y + $position[1], 0);
+                }
+            }
+        }
+    }
+
+    /**
+     * postProcess(): defined by DecoratorInterface.
+     *
+     * @see    DecoratorInterface::postProcess()
+     *
+     * @param  QrCode            $qrCode
+     * @param  RendererInterface $renderer
+     * @param  integer           $outputWidth
+     * @param  integer           $outputHeight
+     * @param  integer           $leftPadding
+     * @param  integer           $topPadding
+     * @param  integer           $multiple
+     * @return void
+     */
+    public function postProcess(
+        QrCode $qrCode,
+        RendererInterface $renderer,
+        $outputWidth,
+        $outputHeight,
+        $leftPadding,
+        $topPadding,
+        $multiple
+    ) {
+        $matrix    = $qrCode->getMatrix();
+        $positions = array(
+            array(0, 0),
+            array($matrix->getWidth() - 7, 0),
+            array(0, $matrix->getHeight() - 7),
+        );
+
+        $renderer->addColor('finder-outer', $this->getOuterColor());
+        $renderer->addColor('finder-inner', $this->getInnerColor());
+
+        foreach (self::$outerPositionDetectionPattern as $y => $row) {
+            foreach ($row as $x => $isOuterSet) {
+                $isInnerSet = self::$innerPositionDetectionPattern[$y][$x];
+
+                if ($isOuterSet) {
+                    foreach ($positions as $position) {
+                        $renderer->drawBlock(
+                            $leftPadding + $x * $multiple + $position[0] * $multiple,
+                            $topPadding + $y * $multiple + $position[1] * $multiple,
+                            'finder-outer'
+                        );
+                    }
+                }
+
+                if ($isInnerSet) {
+                    foreach ($positions as $position) {
+                        $renderer->drawBlock(
+                            $leftPadding + $x * $multiple + $position[0] * $multiple,
+                            $topPadding + $y * $multiple + $position[1] * $multiple,
+                            'finder-inner'
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/includes/BaconQrCode/Renderer/Image/Decorator/FinderPattern.php
+++ b/includes/BaconQrCode/Renderer/Image/Decorator/FinderPattern.php
@@ -7,11 +7,11 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image\Decorator;
+namespace TwoFactor\BaconQrCode\Renderer\Image\Decorator;
 
-use BaconQrCode\Encoder\QrCode;
-use BaconQrCode\Renderer\Image\RendererInterface;
-use BaconQrCode\Renderer\Color;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Renderer\Image\RendererInterface;
+use TwoFactor\BaconQrCode\Renderer\Color;
 
 /**
  * Finder pattern decorator.

--- a/includes/BaconQrCode/Renderer/Image/Eps.php
+++ b/includes/BaconQrCode/Renderer/Image/Eps.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Renderer\Color\ColorInterface;
+use BaconQrCode\Renderer\Color\Rgb;
+use BaconQrCode\Renderer\Color\Cmyk;
+use BaconQrCode\Renderer\Color\Gray;
+
+/**
+ * EPS backend.
+ */
+class Eps extends AbstractRenderer
+{
+    /**
+     * EPS string.
+     *
+     * @var string
+     */
+    protected $eps;
+
+    /**
+     * Colors used for drawing.
+     *
+     * @var array
+     */
+    protected $colors = array();
+
+    /**
+     * Current color.
+     *
+     * @var string
+     */
+    protected $currentColor;
+
+    /**
+     * init(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::init()
+     * @return void
+     */
+    public function init()
+    {
+        $this->eps = "%!PS-Adobe-3.0 EPSF-3.0\n"
+                   . "%%BoundingBox: 0 0 " . $this->finalWidth . " " . $this->finalHeight . "\n"
+                   . "/F { rectfill } def\n";
+    }
+
+    /**
+     * addColor(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::addColor()
+     * @param  string         $id
+     * @param  ColorInterface $color
+     * @return void
+     */
+    public function addColor($id, ColorInterface $color)
+    {
+        if (
+            !$color instanceof Rgb
+            && !$color instanceof Cmyk
+            && !$color instanceof Gray
+        ) {
+            $color = $color->toCmyk();
+        }
+
+        $this->colors[$id] = $color;
+    }
+
+    /**
+     * drawBackground(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBackground()
+     * @param  string $colorId
+     * @return void
+     */
+    public function drawBackground($colorId)
+    {
+        $this->setColor($colorId);
+        $this->eps .= "0 0 " . $this->finalWidth . " " . $this->finalHeight . " F\n";
+    }
+
+    /**
+     * drawBlock(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBlock()
+     * @param  integer $x
+     * @param  integer $y
+     * @param  string  $colorId
+     * @return void
+     */
+    public function drawBlock($x, $y, $colorId)
+    {
+        $this->setColor($colorId);
+        $this->eps .= $x . " " . ($this->finalHeight - $y - $this->blockSize) . " " . $this->blockSize . " " . $this->blockSize . " F\n";
+    }
+
+    /**
+     * getByteStream(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::getByteStream()
+     * @return string
+     */
+    public function getByteStream()
+    {
+        return $this->eps;
+    }
+
+    /**
+     * Sets color to use.
+     *
+     * @param  string $colorId
+     * @return void
+     */
+    protected function setColor($colorId)
+    {
+        if ($colorId !== $this->currentColor) {
+            $color = $this->colors[$colorId];
+
+            if ($color instanceof Rgb) {
+                $this->eps .= sprintf(
+                    "%F %F %F setrgbcolor\n",
+                    $color->getRed() / 100,
+                    $color->getGreen() / 100,
+                    $color->getBlue() / 100
+                );
+            } elseif ($color instanceof Cmyk) {
+                $this->eps .= sprintf(
+                    "%F %F %F %F setcmykcolor\n",
+                    $color->getCyan() / 100,
+                    $color->getMagenta() / 100,
+                    $color->getYellow() / 100,
+                    $color->getBlack() / 100
+                );
+            } elseif ($color instanceof Gray) {
+                $this->eps .= sprintf(
+                    "%F setgray\n",
+                    $color->getGray() / 100
+                );
+            }
+
+            $this->currentColor = $colorId;
+        }
+    }
+}

--- a/includes/BaconQrCode/Renderer/Image/Eps.php
+++ b/includes/BaconQrCode/Renderer/Image/Eps.php
@@ -7,12 +7,12 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image;
+namespace TwoFactor\BaconQrCode\Renderer\Image;
 
-use BaconQrCode\Renderer\Color\ColorInterface;
-use BaconQrCode\Renderer\Color\Rgb;
-use BaconQrCode\Renderer\Color\Cmyk;
-use BaconQrCode\Renderer\Color\Gray;
+use TwoFactor\BaconQrCode\Renderer\Color\ColorInterface;
+use TwoFactor\BaconQrCode\Renderer\Color\Rgb;
+use TwoFactor\BaconQrCode\Renderer\Color\Cmyk;
+use TwoFactor\BaconQrCode\Renderer\Color\Gray;
 
 /**
  * EPS backend.

--- a/includes/BaconQrCode/Renderer/Image/Png.php
+++ b/includes/BaconQrCode/Renderer/Image/Png.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Exception;
+use BaconQrCode\Renderer\Color\ColorInterface;
+
+/**
+ * PNG backend.
+ */
+class Png extends AbstractRenderer
+{
+    /**
+     * Image resource used when drawing.
+     *
+     * @var resource
+     */
+    protected $image;
+
+    /**
+     * Colors used for drawing.
+     *
+     * @var array
+     */
+    protected $colors = array();
+
+    /**
+     * init(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::init()
+     * @return void
+     */
+    public function init()
+    {
+        $this->image = imagecreatetruecolor($this->finalWidth, $this->finalHeight);
+    }
+
+    /**
+     * addColor(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::addColor()
+     * @param  string         $id
+     * @param  ColorInterface $color
+     * @return void
+     * @throws Exception\RuntimeException
+     */
+    public function addColor($id, ColorInterface $color)
+    {
+        if ($this->image === null) {
+            throw new Exception\RuntimeException('Colors can only be added after init');
+        }
+
+        $color = $color->toRgb();
+
+        $this->colors[$id] = imagecolorallocate(
+            $this->image,
+            $color->getRed(),
+            $color->getGreen(),
+            $color->getBlue()
+        );
+    }
+
+    /**
+     * drawBackground(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBackground()
+     * @param  string $colorId
+     * @return void
+     */
+    public function drawBackground($colorId)
+    {
+        imagefill($this->image, 0, 0, $this->colors[$colorId]);
+    }
+
+    /**
+     * drawBlock(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBlock()
+     * @param  integer $x
+     * @param  integer $y
+     * @param  string  $colorId
+     * @return void
+     */
+    public function drawBlock($x, $y, $colorId)
+    {
+        imagefilledrectangle(
+            $this->image,
+            $x,
+            $y,
+            $x + $this->blockSize - 1,
+            $y + $this->blockSize - 1,
+            $this->colors[$colorId]
+        );
+    }
+
+    /**
+     * getByteStream(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::getByteStream()
+     * @return string
+     */
+    public function getByteStream()
+    {
+        ob_start();
+        imagepng($this->image);
+        return ob_get_clean();
+    }
+}

--- a/includes/BaconQrCode/Renderer/Image/Png.php
+++ b/includes/BaconQrCode/Renderer/Image/Png.php
@@ -7,10 +7,10 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image;
+namespace TwoFactor\BaconQrCode\Renderer\Image;
 
-use BaconQrCode\Exception;
-use BaconQrCode\Renderer\Color\ColorInterface;
+use TwoFactor\BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Renderer\Color\ColorInterface;
 
 /**
  * PNG backend.

--- a/includes/BaconQrCode/Renderer/Image/RendererInterface.php
+++ b/includes/BaconQrCode/Renderer/Image/RendererInterface.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Renderer\Color\ColorInterface;
+use BaconQrCode\Renderer\RendererInterface as GeneralRendererInterface;
+
+/**
+ * Renderer interface.
+ */
+interface RendererInterface extends GeneralRendererInterface
+{
+    /**
+     * Initiates the drawing area.
+     *
+     * @return void
+     */
+    public function init();
+
+    /**
+     * Adds a color to the drawing area.
+     *
+     * @param  string         $id
+     * @param  ColorInterface $color
+     * @return void
+     */
+    public function addColor($id, ColorInterface $color);
+
+    /**
+     * Draws the background.
+     *
+     * @param  string $colorId
+     * @return void
+     */
+    public function drawBackground($colorId);
+
+    /**
+     * Draws a block at a specified position.
+     *
+     * @param  integer $x
+     * @param  integer $y
+     * @param  string  $colorId
+     * @return void
+     */
+    public function drawBlock($x, $y, $colorId);
+
+    /**
+     * Returns the byte stream representing the QR code.
+     *
+     * @return string
+     */
+    public function getByteStream();
+
+}

--- a/includes/BaconQrCode/Renderer/Image/RendererInterface.php
+++ b/includes/BaconQrCode/Renderer/Image/RendererInterface.php
@@ -7,10 +7,10 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image;
+namespace TwoFactor\BaconQrCode\Renderer\Image;
 
-use BaconQrCode\Renderer\Color\ColorInterface;
-use BaconQrCode\Renderer\RendererInterface as GeneralRendererInterface;
+use TwoFactor\BaconQrCode\Renderer\Color\ColorInterface;
+use TwoFactor\BaconQrCode\Renderer\RendererInterface as GeneralRendererInterface;
 
 /**
  * Renderer interface.

--- a/includes/BaconQrCode/Renderer/Image/Svg.php
+++ b/includes/BaconQrCode/Renderer/Image/Svg.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Image;
+
+use BaconQrCode\Exception;
+use BaconQrCode\Renderer\Color\ColorInterface;
+use SimpleXMLElement;
+
+/**
+ * SVG backend.
+ */
+class Svg extends AbstractRenderer
+{
+    /**
+     * SVG resource.
+     *
+     * @var SimpleXMLElement
+     */
+    protected $svg;
+
+    /**
+     * Colors used for drawing.
+     *
+     * @var array
+     */
+    protected $colors = array();
+
+    /**
+     * Prototype IDs.
+     *
+     * @var array
+     */
+    protected $prototypeIds = array();
+
+    /**
+     * init(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::init()
+     * @return void
+     */
+    public function init()
+    {
+        $this->svg = new SimpleXMLElement(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"/>'
+        );
+        $this->svg->addAttribute('version', '1.1');
+        $this->svg->addAttribute('width', $this->finalWidth . 'px');
+        $this->svg->addAttribute('height', $this->finalHeight . 'px');
+        $this->svg->addAttribute('viewBox', '0 0 ' . $this->finalWidth . ' ' . $this->finalHeight);
+        $this->svg->addChild('defs');
+    }
+
+    /**
+     * addColor(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::addColor()
+     * @param  string         $id
+     * @param  ColorInterface $color
+     * @return void
+     * @throws Exception\InvalidArgumentException
+     */
+    public function addColor($id, ColorInterface $color)
+    {
+        $this->colors[$id] = (string) $color->toRgb();
+    }
+
+    /**
+     * drawBackground(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBackground()
+     * @param  string $colorId
+     * @return void
+     */
+    public function drawBackground($colorId)
+    {
+        $rect = $this->svg->addChild('rect');
+        $rect->addAttribute('x', 0);
+        $rect->addAttribute('y', 0);
+        $rect->addAttribute('width', $this->finalWidth);
+        $rect->addAttribute('height', $this->finalHeight);
+        $rect->addAttribute('fill', '#' . $this->colors[$colorId]);
+    }
+
+    /**
+     * drawBlock(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::drawBlock()
+     * @param  integer $x
+     * @param  integer $y
+     * @param  string  $colorId
+     * @return void
+     */
+    public function drawBlock($x, $y, $colorId)
+    {
+        $use = $this->svg->addChild('use');
+        $use->addAttribute('x', $x);
+        $use->addAttribute('y', $y);
+        $use->addAttribute(
+            'xlink:href',
+            $this->getRectPrototypeId($colorId),
+            'http://www.w3.org/1999/xlink'
+        );
+    }
+
+    /**
+     * getByteStream(): defined by RendererInterface.
+     *
+     * @see    ImageRendererInterface::getByteStream()
+     * @return string
+     */
+    public function getByteStream()
+    {
+        return $this->svg->asXML();
+    }
+
+    /**
+     * Get the prototype ID for a color.
+     *
+     * @param  integer $colorId
+     * @return string
+     */
+    protected function getRectPrototypeId($colorId)
+    {
+        if (!isset($this->prototypeIds[$colorId])) {
+            $id = 'r' . dechex(count($this->prototypeIds));
+
+            $rect = $this->svg->defs->addChild('rect');
+            $rect->addAttribute('id', $id);
+            $rect->addAttribute('width', $this->blockSize);
+            $rect->addAttribute('height', $this->blockSize);
+            $rect->addAttribute('fill', '#' . $this->colors[$colorId]);
+
+            $this->prototypeIds[$colorId] = '#' . $id;
+        }
+
+        return $this->prototypeIds[$colorId];
+    }
+}

--- a/includes/BaconQrCode/Renderer/Image/Svg.php
+++ b/includes/BaconQrCode/Renderer/Image/Svg.php
@@ -7,10 +7,10 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Image;
+namespace TwoFactor\BaconQrCode\Renderer\Image;
 
-use BaconQrCode\Exception;
-use BaconQrCode\Renderer\Color\ColorInterface;
+use TwoFactor\BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Renderer\Color\ColorInterface;
 use SimpleXMLElement;
 
 /**

--- a/includes/BaconQrCode/Renderer/RendererInterface.php
+++ b/includes/BaconQrCode/Renderer/RendererInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer;
+
+use BaconQrCode\Encoder\QrCode;
+
+/**
+ * Renderer interface.
+ */
+interface RendererInterface
+{
+    /**
+     * Renders a QR code.
+     *
+     * @param  QrCode $qrCode
+     * @return string
+     */
+    public function render(QrCode $qrCode);
+}

--- a/includes/BaconQrCode/Renderer/RendererInterface.php
+++ b/includes/BaconQrCode/Renderer/RendererInterface.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer;
+namespace TwoFactor\BaconQrCode\Renderer;
 
-use BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
 
 /**
  * Renderer interface.

--- a/includes/BaconQrCode/Renderer/Text/Html.php
+++ b/includes/BaconQrCode/Renderer/Text/Html.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Text;
+
+use BaconQrCode\Encoder\QrCode;
+
+/**
+ * Html renderer.
+ */
+class Html extends Plain
+{
+    /**
+     * HTML CSS class attribute value.
+     *
+     * @var string
+     */
+    protected $class = '';
+
+    /**
+     * HTML CSS style definition for the code element.
+     *
+     * @var string
+     */
+    protected $style = 'font-family: monospace; line-height: 0.65em; letter-spacing: -1px';
+
+    /**
+     * Set CSS class name.
+     *
+     * @param string $class
+     */
+    public function setClass($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * Get CSS class name.
+     *
+     * @return string
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * Set CSS style value.
+     *
+     * @param string $style
+     */
+    public function setStyle($style)
+    {
+        $this->style = $style;
+    }
+
+    /**
+     * Get CSS style value.
+     *
+     * @return string
+     */
+    public function getStyle()
+    {
+        return $this->style;
+    }
+
+    /**
+     * render(): defined by RendererInterface.
+     *
+     * @see    RendererInterface::render()
+     * @param  QrCode $qrCode
+     * @return string
+     */
+    public function render(QrCode $qrCode)
+    {
+        $textCode = parent::render($qrCode);
+
+        $result = '<pre'
+                . ' style="' . htmlspecialchars($this->style, ENT_QUOTES, 'utf-8') . '"'
+                . ' class="' . htmlspecialchars($this->class, ENT_QUOTES, 'utf-8') . '"'
+                . '>' . $textCode . '</pre>';
+
+        return $result;
+    }
+}

--- a/includes/BaconQrCode/Renderer/Text/Html.php
+++ b/includes/BaconQrCode/Renderer/Text/Html.php
@@ -7,9 +7,9 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Text;
+namespace TwoFactor\BaconQrCode\Renderer\Text;
 
-use BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
 
 /**
  * Html renderer.

--- a/includes/BaconQrCode/Renderer/Text/Plain.php
+++ b/includes/BaconQrCode/Renderer/Text/Plain.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode\Renderer\Text;
+
+use BaconQrCode\Exception;
+use BaconQrCode\Encoder\QrCode;
+use BaconQrCode\Renderer\RendererInterface;
+
+/**
+ * Plaintext renderer.
+ */
+class Plain implements RendererInterface
+{
+    /**
+     * Margin around the QR code, also known as quiet zone.
+     *
+     * @var integer
+     */
+    protected $margin = 1;
+
+    /**
+     * Char used for full block.
+     *
+     * UTF-8 FULL BLOCK (U+2588)
+     *
+     * @var  string
+     * @link http://www.fileformat.info/info/unicode/char/2588/index.htm
+     */
+    protected $fullBlock = "\xE2\x96\x88";
+
+    /**
+     * Char used for empty space
+     *
+     * @var string
+     */
+    protected $emptyBlock = ' ';
+
+    /**
+     * Set char used as full block (occupied space, "black").
+     *
+     * @param string $fullBlock
+     */
+    public function setFullBlock($fullBlock)
+    {
+        $this->fullBlock = $fullBlock;
+    }
+
+    /**
+     * Get char used as full block (occupied space, "black").
+     *
+     * @return string
+     */
+    public function getFullBlock()
+    {
+        return $this->fullBlock;
+    }
+
+    /**
+     * Set char used as empty block (empty space, "white").
+     *
+     * @param string $emptyBlock
+     */
+    public function setEmptyBlock($emptyBlock)
+    {
+        $this->emptyBlock = $emptyBlock;
+    }
+
+    /**
+     * Get char used as empty block (empty space, "white").
+     *
+     * @return string
+     */
+    public function getEmptyBlock()
+    {
+        return $this->emptyBlock;
+    }
+
+    /**
+     * Sets the margin around the QR code.
+     *
+     * @param  integer $margin
+     * @return AbstractRenderer
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setMargin($margin)
+    {
+        if ($margin < 0) {
+            throw new Exception\InvalidArgumentException('Margin must be equal to greater than 0');
+        }
+
+        $this->margin = (int) $margin;
+
+        return $this;
+    }
+
+    /**
+     * Gets the margin around the QR code.
+     *
+     * @return integer
+     */
+    public function getMargin()
+    {
+        return $this->margin;
+    }
+
+    /**
+     * render(): defined by RendererInterface.
+     *
+     * @see    RendererInterface::render()
+     * @param  QrCode $qrCode
+     * @return string
+     */
+    public function render(QrCode $qrCode)
+    {
+        $result = '';
+        $matrix = $qrCode->getMatrix();
+        $width  = $matrix->getWidth();
+
+        // Top margin
+        for ($x = 0; $x < $this->margin; $x++) {
+            $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
+        }
+
+        // Body
+        $array = $matrix->getArray();
+
+        foreach ($array as $row) {
+            $result .= str_repeat($this->emptyBlock, $this->margin); // left margin
+            foreach ($row as $byte) {
+                $result .= $byte ? $this->fullBlock : $this->emptyBlock;
+            }
+            $result .= str_repeat($this->emptyBlock, $this->margin); // right margin
+            $result .= "\n";
+        }
+
+        // Bottom margin
+        for ($x = 0; $x < $this->margin; $x++) {
+            $result .= str_repeat($this->emptyBlock, $width + 2 * $this->margin)."\n";
+        }
+
+        return $result;
+    }
+}

--- a/includes/BaconQrCode/Renderer/Text/Plain.php
+++ b/includes/BaconQrCode/Renderer/Text/Plain.php
@@ -7,11 +7,11 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode\Renderer\Text;
+namespace TwoFactor\BaconQrCode\Renderer\Text;
 
-use BaconQrCode\Exception;
-use BaconQrCode\Encoder\QrCode;
-use BaconQrCode\Renderer\RendererInterface;
+use TwoFactor\BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Encoder\QrCode;
+use TwoFactor\BaconQrCode\Renderer\RendererInterface;
 
 /**
  * Plaintext renderer.

--- a/includes/BaconQrCode/Writer.php
+++ b/includes/BaconQrCode/Writer.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * BaconQrCode
+ *
+ * @link      http://github.com/Bacon/BaconQrCode For the canonical source repository
+ * @copyright 2013 Ben 'DASPRiD' Scholzen
+ * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
+ */
+
+namespace BaconQrCode;
+
+use BaconQrCode\Common\ErrorCorrectionLevel;
+use BaconQrCode\Encoder\Encoder;
+use BaconQrCode\Exception;
+use BaconQrCode\Renderer\RendererInterface;
+
+/**
+ * QR code writer.
+ */
+class Writer
+{
+    /**
+     * Renderer instance.
+     *
+     * @var RendererInterface
+     */
+    protected $renderer;
+
+    /**
+     * Creates a new writer with a specific renderer.
+     *
+     * @param RendererInterface $renderer
+     */
+    public function __construct(RendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * Sets the renderer used to create a byte stream.
+     *
+     * @param  RendererInterface $renderer
+     * @return Writer
+     */
+    public function setRenderer(RendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+        return $this;
+    }
+
+    /**
+     * Gets the renderer used to create a byte stream.
+     *
+     * @return RendererInterface
+     */
+    public function getRenderer()
+    {
+        return $this->renderer;
+    }
+
+    /**
+     * Writes QR code and returns it as string.
+     *
+     * Content is a string which *should* be encoded in UTF-8, in case there are
+     * non ASCII-characters present.
+     *
+     * @param  string  $content
+     * @param  string  $encoding
+     * @param  integer $ecLevel
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
+    public function writeString(
+        $content,
+        $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
+        $ecLevel = ErrorCorrectionLevel::L
+    ) {
+        if (strlen($content) === 0) {
+            throw new Exception\InvalidArgumentException('Found empty contents');
+        }
+
+        $qrCode = Encoder::encode($content, new ErrorCorrectionLevel($ecLevel), $encoding);
+
+        return $this->getRenderer()->render($qrCode);
+    }
+
+    /**
+     * Writes QR code to a file.
+     *
+     * @see    Writer::writeString()
+     * @param  string  $content
+     * @param  string  $filename
+     * @param  string  $encoding
+     * @param  integer $ecLevel
+     * @return void
+     */
+    public function writeFile(
+        $content,
+        $filename,
+        $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING,
+        $ecLevel = ErrorCorrectionLevel::L
+    ) {
+        file_put_contents($filename, $this->writeString($content, $encoding, $ecLevel));
+    }
+}

--- a/includes/BaconQrCode/Writer.php
+++ b/includes/BaconQrCode/Writer.php
@@ -7,12 +7,12 @@
  * @license   http://opensource.org/licenses/BSD-2-Clause Simplified BSD License
  */
 
-namespace BaconQrCode;
+namespace TwoFactor\BaconQrCode;
 
-use BaconQrCode\Common\ErrorCorrectionLevel;
-use BaconQrCode\Encoder\Encoder;
-use BaconQrCode\Exception;
-use BaconQrCode\Renderer\RendererInterface;
+use TwoFactor\BaconQrCode\Common\ErrorCorrectionLevel;
+use TwoFactor\BaconQrCode\Encoder\Encoder;
+use TwoFactor\BaconQrCode\Exception;
+use TwoFactor\BaconQrCode\Renderer\RendererInterface;
 
 /**
  * QR code writer.

--- a/two-factor.php
+++ b/two-factor.php
@@ -29,6 +29,31 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TWO_FACTOR_VERSION', '0.7.0' );
 
 /**
+ * Set up the autoloader to handle classes in the includes directory.
+ */
+spl_autoload_register(function ($class) {
+	$class = str_replace('\\', '/', $class);
+
+	// First check that the class is one in our namespace
+	if (strpos($class, 'TwoFactor/') !== 0) {
+		return false;
+	}
+
+	// Then check if the corresponding file exists
+	$class = str_replace('TwoFactor/', '', $class);
+	$path = __DIR__ . '/includes/' . $class . '.php';
+
+	// If the file exists, include it
+	// Otherwise tell the autoloader we don't know about it
+	if (file_exists($path)) {
+		include $path;
+		return true;
+	} else {
+		return false;
+	}
+});
+
+/**
  * Include the base class here, so that other plugins can also extend it.
  */
 require_once TWO_FACTOR_DIR . 'providers/class-two-factor-provider.php';


### PR DESCRIPTION
These commits generate QR codes via PHP instead of via the Google Chart API. This stops sending sensitive data to a third party.

Resolves: https://github.com/WordPress/two-factor/issues/42

Note that this uses the [endroid/qr-code](https://github.com/endroid/qr-code) composer library, so to test this please run `composer install` after checking this branch out.

I suspect there's a standard WordPress way of including dependencies but I'm not sure what it is. I can update the PR if you let me know.

I would suggest storing the `otpauth://` URI in the database instead of allowing passing arbitrary strings to the QR code generator. Just in case. But I haven't done that in this PR. Let me know if that's something you'd want to see before approving this, or if it ought to be raised as a separate PR.

Thanks.