### PR TITLE
Fix: Backup code generate notice not visible.

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -77,7 +77,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			<p>
 				<span>
 					<?php
-					wp_kses(
+					echo wp_kses(
 						sprintf(
 						/* translators: %s: URL for code regeneration */
 							__( 'Two-Factor: You are out of backup codes and need to <a href="%s">regenerate!</a>', 'two-factor' ),


### PR DESCRIPTION
Two-Factor Backup Codes generated like below:

E.g.

1. 26056637
2. 34800832
3. 68473048
4. 28263149
5. 68946117
6. 73912621
7. 70914813
8. 59360534
9. 82345347
10. 59028553

When using all of them then the notice appears. But due to the missing `echo`, it was not displayed.

Now, This displayed as below:

![Error Message](https://i.imgur.com/EzN4Zcj.png)