### PR TITLE
Add filter two_factor_email_token_length

### DIFF
--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -77,7 +77,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function generate_token( $user_id ) {
-		$token = $this->get_code($this->get_token_length());
+		$token = $this->get_code( $this->get_token_length() );
 
 		update_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, time() );
 		update_user_meta( $user_id, self::TOKEN_META_KEY, wp_hash( $token ) );
@@ -165,7 +165,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 	public function get_token_length() {
 		$token_length = 8;
-		return (int) apply_filters( 'two_factor_email_token_length', $token_length);
+		return (int) apply_filters( 'two_factor_email_token_length', $token_length );
 	}
 
 	/**

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -77,7 +77,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function generate_token( $user_id ) {
-		$token = $this->get_code();
+		$token = $this->get_code($this->get_token_length());
 
 		update_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, time() );
 		update_user_meta( $user_id, self::TOKEN_META_KEY, wp_hash( $token ) );
@@ -155,6 +155,17 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		 * @param integer $user_id User ID.
 		 */
 		return (int) apply_filters( 'two_factor_token_ttl', $token_ttl, $user_id );
+	}
+
+	/**
+	 * Return the number of digits of the token.
+	 *
+	 * @return integer
+	 */
+
+	public function get_token_length() {
+		$token_length = 8;
+		return (int) apply_filters( 'two_factor_email_token_length', $token_length);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
+- `two_factor_email_token_length` filter overrides default number of digits (8) of the email token.
 
 == Screenshots ==
 


### PR DESCRIPTION
The length of the email token (code) can be set with filter two_factor_email_token_length
The default is 8, like before