### PR TITLE
Improve TOTP autocomplete behaviour

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -459,7 +459,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		</p>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
-			<input type="tel" autocomplete="off" name="authcode" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
+			<input type="tel" autocomplete="one-time-code" name="authcode" id="authcode" class="input" value="" size="20" pattern="[0-9]*" />
 		</p>
 		<script type="text/javascript">
 			setTimeout( function(){


### PR DESCRIPTION
Hi! This is a little improvement over #373 that included the autocomplete attribute. I've set it attribute to 'one-time-code' so browsers and password managers can autocomplete the code if necessary/possible. I've tested it on the latest versions of 1Password and Safari, Chrome, Firefox & Edge and it autocompletes the TOTP code (previously it only worked on Safari)

Great job with the plugin by the way, thanks!