### PR TITLE
Feature/ Frontend TOTP activation shortcode

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -64,7 +64,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Output for the two-factor-set-topt shortcode
+	 * Output for the two-factor-set-topt shortcode.
 	 *
 	 * @param array $atts Array of attributes.
 	 *
@@ -133,7 +133,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 
 	/**
-	 * Save the options after submitting the shortcode topt form.
+	 * Save the options after submitting the shortcode totp form. Enables the totp provider and sets it as primary provider.
 	 *
 	 * @param integer $user_id The user ID whose options are being updated.
 	 *

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -53,7 +53,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		add_action( 'edit_user_profile_update', array( $this, 'user_two_factor_options_update' ) );
 		add_action( 'two_factor_user_settings_action', array( $this, 'user_settings_action' ), 10, 2 );
 
-		add_shortcode( 'two-factor-set-topt', array( $this, 'topt_shortcode' ) );
+		add_shortcode( 'two-factor-set-totp', array( $this, 'topt_shortcode' ) );
 
 		// Save options if shortcode form is submitted.
 		if ( isset( $_REQUEST['_nonce_user_two_factor_totp_options_shortcode'] ) ) {


### PR DESCRIPTION
This implements a [two-factor-set-totp] shortcode which can be used for front-end TOTP 2fa activation.

I looked into making all provider settings available frontend, but that would require extensive modifications to the whole plugin. So I took a rather straightforward approach. I created specific functions for generating the shortcode output and saving the input because outputting to frontend and saving options from a frontend request demands a different approach than backend, but I tried to reuse as much of the backend functions as possible.  I think this brings a much wanted feature in a relatively clean approach. 

Notes:
- Currently only first time activation is possible. Reset of the key has to be done via the user profile. Allowing users to reset via frontend requires a global setting on admin level in my opinion, but two-factor currently doesn't have a global settings page yet.
- The shortcode doesn't use wp-admin urls, which is handy for sites where wp-admin is blocked for non-admin users.
- After using the frontend settings the TOTP provider is enabled and set as primary.


