### PR TITLE
PHP 8.1 compatibility: replace FILTER_SANITIZE_STRING

### DIFF
--- a/class-two-factor-compat.php
+++ b/class-two-factor-compat.php
@@ -35,7 +35,7 @@ class Two_Factor_Compat {
 	 * @return boolean
 	 */
 	public function jetpack_rememberme( $rememberme ) {
-		$action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+		$action = filter_input( INPUT_GET, 'action', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
 
 		if ( 'jetpack-sso' === $action && $this->jetpack_is_sso_active() ) {
 			return true;

--- a/class-two-factor-compat.php
+++ b/class-two-factor-compat.php
@@ -35,7 +35,7 @@ class Two_Factor_Compat {
 	 * @return boolean
 	 */
 	public function jetpack_rememberme( $rememberme ) {
-		$action = filter_input( INPUT_GET, 'action', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
+		$action = filter_input( INPUT_GET, 'action', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
 
 		if ( 'jetpack-sso' === $action && $this->jetpack_is_sso_active() ) {
 			return true;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -244,7 +244,7 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_SANITIZE_STRING );
+		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
 
 		return wp_verify_nonce(
 			$request_nonce,
@@ -277,7 +277,7 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function trigger_user_settings_action() {
-		$action  = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_SANITIZE_STRING );
+		$action  = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
 		$user_id = self::current_user_being_edited();
 
 		if ( ! empty( $action ) && self::is_valid_user_action( $user_id, $action ) ) {
@@ -537,8 +537,8 @@ class Two_Factor_Core {
 	 */
 	public static function backup_2fa() {
 		$wp_auth_id = filter_input( INPUT_GET, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_SANITIZE_STRING );
-		$provider   = filter_input( INPUT_GET, 'provider', FILTER_SANITIZE_STRING );
+		$nonce      = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
+		$provider   = filter_input( INPUT_GET, 'provider', FILTER_CALLBACK, [ 'options' => 'sanitize_text_field' ] );
 
 		if ( ! $wp_auth_id || ! $nonce || ! $provider ) {
 			return;
@@ -794,7 +794,7 @@ class Two_Factor_Core {
 	 */
 	public static function login_form_validate_2fa() {
 		$wp_auth_id = filter_input( INPUT_POST, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_POST, 'wp-auth-nonce', FILTER_SANITIZE_STRING );
+		$nonce      = filter_input( INPUT_POST, 'wp-auth-nonce', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
 
 		if ( ! $wp_auth_id || ! $nonce ) {
 			return;
@@ -810,7 +810,7 @@ class Two_Factor_Core {
 			exit;
 		}
 
-		$provider = filter_input( INPUT_POST, 'provider', FILTER_SANITIZE_STRING );
+		$provider = filter_input( INPUT_POST, 'provider', FILTER_CALLBACK, [ 'options' => 'sanitize_text_field' ] );
 		if ( $provider ) {
 			$providers = self::get_available_providers_for_user( $user );
 			if ( isset( $providers[ $provider ] ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -244,7 +244,7 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
+		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
 
 		return wp_verify_nonce(
 			$request_nonce,
@@ -277,7 +277,7 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function trigger_user_settings_action() {
-		$action  = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
+		$action  = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
 		$user_id = self::current_user_being_edited();
 
 		if ( ! empty( $action ) && self::is_valid_user_action( $user_id, $action ) ) {
@@ -537,8 +537,8 @@ class Two_Factor_Core {
 	 */
 	public static function backup_2fa() {
 		$wp_auth_id = filter_input( INPUT_GET, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
-		$provider   = filter_input( INPUT_GET, 'provider', FILTER_CALLBACK, [ 'options' => 'sanitize_text_field' ] );
+		$nonce      = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
+		$provider   = filter_input( INPUT_GET, 'provider', FILTER_CALLBACK, array( 'options' => 'sanitize_text_field' ) );
 
 		if ( ! $wp_auth_id || ! $nonce || ! $provider ) {
 			return;
@@ -794,7 +794,7 @@ class Two_Factor_Core {
 	 */
 	public static function login_form_validate_2fa() {
 		$wp_auth_id = filter_input( INPUT_POST, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_POST, 'wp-auth-nonce', FILTER_CALLBACK, [ 'options' => 'sanitize_key' ] );
+		$nonce      = filter_input( INPUT_POST, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
 
 		if ( ! $wp_auth_id || ! $nonce ) {
 			return;
@@ -810,7 +810,7 @@ class Two_Factor_Core {
 			exit;
 		}
 
-		$provider = filter_input( INPUT_POST, 'provider', FILTER_CALLBACK, [ 'options' => 'sanitize_text_field' ] );
+		$provider = filter_input( INPUT_POST, 'provider', FILTER_CALLBACK, array( 'options' => 'sanitize_text_field' ) );
 		if ( $provider ) {
 			$providers = self::get_available_providers_for_user( $user );
 			if ( isset( $providers[ $provider ] ) ) {

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -304,8 +304,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function validate_authentication( $user ) {
-		$backup_code = isset( $_POST['two-factor-backup-code'] ) ? sanitize_text_field( wp_unslash( $_POST['two-factor-backup-code'] ) ) : false;
-		return $this->validate_code( $user, filter_var( $backup_code, FILTER_SANITIZE_STRING ) );
+		$backup_code = isset( $_POST['two-factor-backup-code'] ) ? sanitize_text_field( wp_unslash( $_POST['two-factor-backup-code'] ) ) : '';
+		return $this->validate_code( $user, $backup_code );
 	}
 
 	/**


### PR DESCRIPTION
PHP 8.1 [deprecated](https://www.php.net/manual/en/filter.filters.sanitize.php) `FILTER_SANITIZE_STRING`. This PR replaces it with other alternatives.

Ref: Automattic/vip-go-mu-plugins#2667
