### PR TITLE
Release 0.7.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags: two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
 Requires at least: 4.3
-Tested up to: 5.9
+Tested up to: 6.0
 Requires PHP: 5.6
 Stable tag: trunk
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author: Plugin Contributors
- * Version: 0.7.1
+ * Version: 0.7.2
  * Author URI: https://github.com/wordpress/two-factor/graphs/contributors
  * Network: True
  * Text Domain: two-factor
@@ -26,7 +26,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.7.1' );
+define( 'TWO_FACTOR_VERSION', '0.7.2' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
Minor release.

Diff: https://github.com/WordPress/two-factor/compare/0.7.1...13c30418aa54640f739f59b23ed23897b76b4caf

## Changelog

- Security improvement: Store the second factor authentication step nonce hashed to prevent leaking it via database read access [#453](https://github.com/WordPress/two-factor/pull/453). Props to [@calvinalkan](https://github.com/calvinalkan) for reporting the issue.
- Fix: Add `wp_specialchars_decode()` to escape the HTML entity on the Email Subject line ([#412](https://github.com/WordPress/two-factor/issues/412)), props [@nbwpuk](https://github.com/nbwpuk).
- Fix: Use `hash_equals()` when comparing the email token ([#425](https://github.com/WordPress/two-factor/issues/425)), props [@Mati02K](https://github.com/Mati02K).
- Tooling: Introduce `@wordpress/env` for development tooling and move to GitHub actions for CI ([#436](https://github.com/WordPress/two-factor/pull/436)).