### PR TITLE
Disable the deployment for now

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,5 +41,6 @@ jobs:
           DEPLOY_TRUNK: ${{ contains( github.ref_name, 'master' ) }}
           DEPLOY_TAG: ${{ contains( github.ref_type, 'tag' ) }}
           DEPLOY_SKIP_CONFIRMATION: true
-        if: env.DEPLOY_SVN_USERNAME
+        # Disable deployments while they are failing for unknown reason.
+        if: env.DEPLOY_SVN_USERNAME && false
         run: npm run deploy


### PR DESCRIPTION
The automatic deployments introduced in #438 are failing at the last commit step for unknown reason. Disable the attempts until this is fixed.