### PR TITLE
Harden login nonces

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -749,7 +749,7 @@ class Two_Factor_Core {
 	 */
 	public static function create_login_nonce( $user_id ) {
 		$login_nonce = array(
-			'expiration' => time() + HOUR_IN_SECONDS,
+			'expiration' => time() + ( 10 * MINUTE_IN_SECONDS ),
 		);
 
 		try {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -731,12 +731,20 @@ class Two_Factor_Core {
 	/**
 	 * Get the hash of a nonce for storage and comparison.
 	 *
-	 * @param string $nonce Nonce value to be hashed.
+	 * @param array $nonce Nonce array to be hashed. ⚠️ This must contain user ID and expiration,
+	 *                     to guarantee the nonce only works for the intended user during the
+	 *                     intended time window.
 	 *
-	 * @return string
+	 * @return string|false
 	 */
 	protected static function hash_login_nonce( $nonce ) {
-		return wp_hash( $nonce, 'nonce' );
+		$message = wp_json_encode( $nonce );
+
+		if ( ! $message ) {
+			return false;
+		}
+
+		return wp_hash( $message, 'nonce' );
 	}
 
 	/**
@@ -745,10 +753,11 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 *
 	 * @param int $user_id User ID.
-	 * @return array
+	 * @return array|false
 	 */
 	public static function create_login_nonce( $user_id ) {
 		$login_nonce = array(
+			'user_id'    => $user_id,
 			'expiration' => time() + ( 10 * MINUTE_IN_SECONDS ),
 		);
 
@@ -759,14 +768,20 @@ class Two_Factor_Core {
 		}
 
 		// Store the nonce hashed to avoid leaking it via database access.
-		$login_nonce_stored        = $login_nonce;
-		$login_nonce_stored['key'] = self::hash_login_nonce( $login_nonce['key'] );
+		$hashed_key = self::hash_login_nonce( $login_nonce );
 
-		if ( ! update_user_meta( $user_id, self::USER_META_NONCE_KEY, $login_nonce_stored ) ) {
-			return false;
+		if ( $hashed_key ) {
+			$login_nonce_stored = array(
+				'expiration' => $login_nonce['expiration'],
+				'key'        => $hashed_key,
+			);
+
+			if ( update_user_meta( $user_id, self::USER_META_NONCE_KEY, $login_nonce_stored ) ) {
+				return $login_nonce;
+			}
 		}
 
-		return $login_nonce;
+		return false;
 	}
 
 	/**
@@ -797,7 +812,16 @@ class Two_Factor_Core {
 			return false;
 		}
 
-		if ( hash_equals( $login_nonce['key'], self::hash_login_nonce( $nonce ) ) && time() < $login_nonce['expiration'] ) {
+		$unverified_nonce = array(
+			'user_id'    => $user_id,
+			'expiration' => $login_nonce['expiration'],
+			'key'        => $nonce,
+		);
+
+		$unverified_hash = self::hash_login_nonce( $unverified_nonce );
+		$hashes_match    = $unverified_hash && hash_equals( $login_nonce['key'], $unverified_hash );
+
+		if ( $hashes_match && time() < $login_nonce['expiration'] ) {
 			return true;
 		}
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -454,8 +454,10 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 	/**
 	 * Invalid nonce deletes the valid nonce.
+	 *
+	 * @covers Two_Factor_Core::verify_login_nonce()
 	 */
-	public function test_login_nonce_can_be_used_only_once() {
+	public function test_invalid_nonce_deletes_valid_nonce() {
 		$user_id = 123456;
 		$nonce   = Two_Factor_Core::create_login_nonce( $user_id );
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -390,7 +390,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertNotEmpty( $nonce['expiration'], 'Nonce expiration is set' );
 
 		$this->assertGreaterThan( time(), $nonce['expiration'], 'Nonce expiration is in the future' );
-		$this->assertLessThan( time() + HOUR_IN_SECONDS + 1, $nonce['expiration'], 'Nonce expiration is not more than an hour' );
+		$this->assertLessThan( time() + ( 10 * MINUTE_IN_SECONDS ) + 1, $nonce['expiration'], 'Nonce expiration is not more than 10 minutes' );
 
 		$this->assertTrue(
 			Two_Factor_Core::verify_login_nonce( $user_id, $nonce['key'] ),


### PR DESCRIPTION
I noticed a few comments on a closed PR and didn't want them to fall through the cracks:

* [Shorten expiration to ~10 minutes](https://github.com/WordPress/two-factor/pull/453/files#r965622814)
* [Include user ID and expiration in HMAC](https://github.com/WordPress/two-factor/pull/453#issuecomment-1244171674) - cc @calvinalkan 
* ~~It also looks like a valid nonce can be reused many times. IMO it should be deleted once it's been successfully used once. The unit test [says that it checks for this](https://github.com/WordPress/two-factor/blob/be268ba1644d8f5b35761fce790c3b1de1ce86a2/tests/class-two-factor-core.php#L422), but actually checks that an invalid nonce deletes a valid one.~~

I'd appreciate some extra eyes on this one to make sure everything with the HMAC is correct.