### PR TITLE
Tests: Explicitly ignore directories for performance

### DIFF
--- a/phpunit-watcher.yml.dist
+++ b/phpunit-watcher.yml.dist
@@ -2,7 +2,12 @@ watch:
   directories:
     - ./
   exclude:
+    - .github
     - assets
+    - dist
+    - node_modules
+    - vendor
+    - wordpress
   fileMask: '*.php'
   ignoreDotFiles: true
   ignoreVCS: true


### PR DESCRIPTION
These should be implicitly ignored because of the `ignoreDotFiles`, `ignoreVCS`, and `ignoreVCSIgnored` settings, but some of them weren't for some reason. That was causing a noticable delay between when a file was saved and when the tests relaunched.

Previously #472