### PR TITLE
Tests: Migrate config to 9.5 format

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,15 +14,15 @@
 			<directory suffix=".php">tests</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
+	<coverage processUncoveredFiles="false">
+		<include>
 			<directory suffix=".php">providers</directory>
 			<file>class-two-factor-compat.php</file>
 			<file>class-two-factor-core.php</file>
 			<file>two-factor.php</file>
-		</whitelist>
-	</filter>
-	<logging>
-		<log type="coverage-clover" target="tests/logs/clover.xml" />
-	</logging>
+		</include>
+		<report>
+			<clover outputFile="tests/logs/clover.xml" />
+		</report>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
I missed this in #472, and this was being shown when running tests:

> Warning:       Your XML configuration validates against a deprecated schema.
> Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

I haven't tested Coveralls since it doesn't seem to be configured (#364, #467), but I verified that the log file is still being generated.