### PR TITLE
Release plugin version 0.7.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: two factor, two step, authentication, login, totp, fido u2f, u2f, email, b
 Requires at least: 4.3
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 0.7.2
+Stable tag: 0.7.3
 
 Enable Two-Factor Authentication using time-based one-time passwords (OTP, Google Authenticator), Universal 2nd Factor (FIDO U2F, YubiKey), email and backup verification codes.
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author: Plugin Contributors
- * Version: 0.7.2
+ * Version: 0.7.3
  * Author URI: https://github.com/wordpress/two-factor/graphs/contributors
  * Network: True
  * Text Domain: two-factor
@@ -26,7 +26,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.7.2' );
+define( 'TWO_FACTOR_VERSION', '0.7.3' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
Covers https://github.com/WordPress/two-factor/compare/0.7.2...79c364169e4e7fc430c4ed05c9cc81402955785c

- https://github.com/WordPress/two-factor/pull/478
- https://github.com/WordPress/two-factor/pull/458 (security improvement)
- https://github.com/WordPress/two-factor/pull/428
- https://github.com/WordPress/two-factor/pull/465
- https://github.com/WordPress/two-factor/pull/466
- https://github.com/WordPress/two-factor/pull/387
- https://github.com/WordPress/two-factor/pull/420

## Changelog

Includes the following changes https://github.com/WordPress/two-factor/compare/0.7.2...79c364169e4e7fc430c4ed05c9cc81402955785c

- Make `wp_login_failed` action call compatible with the WP core argument count and types. Reported in [#471](https://github.com/WordPress/two-factor/issues/471) by @dziudek and fixed in [#478](https://github.com/WordPress/two-factor/pull/478) by @dd32.
- Use `hash_equals()` for nonce comparison to improve security. Reported in [#458](https://github.com/WordPress/two-factor/pull/458) and fixed in [#458](https://github.com/WordPress/two-factor/pull/458) by @calvinalkan.
- Improve compatibility with PHP 8.1 by replacing all instances of `FILTER_SANITIZE_STRING` usage. Reported and fixed in [#428](https://github.com/WordPress/two-factor/pull/428) by @sjinks. 
- Add automated checks for PHP 8 compatibility in [#465](https://github.com/WordPress/two-factor/pull/465) and [#466](https://github.com/WordPress/two-factor/pull/466) by @kasparsd.
- Improve accessibility of two-factor settings in the user profile by introducing a label that links the method names with the associated checkboxes. Reported and fixed in [#387](https://github.com/WordPress/two-factor/pull/387) by @r-a-y.
- Improve TOTP autocomplete behaviour by setting the `autocomplete` attribute [to `one-time-code`](https://web.dev/sms-otp-form/). Reported and fixed in [#420](https://github.com/WordPress/two-factor/pull/420) by @squaredpx.