### PR TITLE
Block creating authentication cookies when inappropriate to do so.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -497,7 +497,7 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Keep track of the last user a cookie was generated for.
+	 * Reset the last user a cookie was generated for.
 	 *
 	 * When clearing cookies, there is not user context.
 	 */

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -601,7 +601,7 @@ class Two_Factor_Core {
 	public static function login_form_show_2fa() {
 		$wp_auth_id  = filter_input( INPUT_GET, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
 		$nonce       = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
-		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : wp_get_referer();
+		$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : wp_get_referer();
 		$user        = get_user_by( 'id', $wp_auth_id );
 
 		if ( ! $wp_auth_id || ! $nonce ) {
@@ -617,7 +617,6 @@ class Two_Factor_Core {
 			wp_safe_redirect( home_url() );
 			exit;
 		}
-
 
 		self::login_html( $user, $nonce, $redirect_to );
 		exit;
@@ -636,7 +635,7 @@ class Two_Factor_Core {
 			wp_die( esc_html__( 'Failed to create a login nonce.', 'two-factor' ) );
 		}
 
-		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : admin_url();
+		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
 
 		wp_safe_redirect( self::login_url(
 			array(

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -73,9 +73,10 @@ class Two_Factor_Core {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_textdomain' ) );
 		add_action( 'init', array( __CLASS__, 'get_providers' ) );
 		add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
-		add_action( 'clear_auth_cookie', array( __CLAS__, 'clear_auth_cookie' ) );
+		add_action( 'clear_auth_cookie', array( __CLASS__, 'clear_auth_cookie' ) );
 		add_action( 'set_auth_cookie', array( __CLASS__, 'set_auth_cookie' ), 10, 4 );
 		add_action( 'send_auth_cookies', array( __CLASS__, 'send_auth_cookies' ) );
+		add_action( 'login_form_show_2fa', array( __CLASS__, 'login_form_show_2fa' ) );
 		add_action( 'login_form_validate_2fa', array( __CLASS__, 'login_form_validate_2fa' ) );
 		add_action( 'login_form_backup_2fa', array( __CLASS__, 'backup_2fa' ) );
 		add_action( 'show_user_profile', array( __CLASS__, 'user_two_factor_options' ) );
@@ -461,6 +462,13 @@ class Two_Factor_Core {
 			self::is_user_using_two_factor( self::$last_auth_cookie_user )
 		) {
 			$send_cookies = false;
+
+			// If we're not on wp-login.php, redirect there. This is for when `wp_set_auth_cookie()` is called outside of wp-login.php.
+			if ( ! did_action( 'login_init' ) ) {
+				$user = get_userdata( self::$last_auth_cookie_user );
+				self::redirect_to_two_factor( $user );
+				exit;
+			}
 		}
 
 		return $send_cookies;
@@ -565,6 +573,61 @@ class Two_Factor_Core {
 
 		self::login_html( $user, $login_nonce['key'], $redirect_to );
 	}
+
+	/**
+	 * Display the Two Factor login.
+	 */
+	public static function login_form_show_2fa() {
+		$wp_auth_id  = filter_input( INPUT_GET, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
+		$nonce       = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
+		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : wp_get_referer();
+		$user        = get_user_by( 'id', $wp_auth_id );
+
+		if ( ! $wp_auth_id || ! $nonce ) {
+			return;
+		}
+
+		$user = get_userdata( $wp_auth_id );
+		if ( ! $user ) {
+			return;
+		}
+
+		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
+
+
+		self::login_html( $user, $nonce, $redirect_to );
+		exit;
+	}
+
+	/**
+	 * Redirect the user to the two-factor authentication.
+	 */
+	public static function redirect_to_two_factor( $user ) {
+		if ( ! $user ) {
+			$user = wp_get_current_user();
+		}
+
+		$login_nonce = self::create_login_nonce( $user->ID );
+		if ( ! $login_nonce ) {
+			wp_die( esc_html__( 'Failed to create a login nonce.', 'two-factor' ) );
+		}
+
+		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : admin_url();
+
+		wp_safe_redirect( self::login_url(
+			array(
+				'action'        => 'show_2fa',
+				'wp-auth-id'    => $user->ID,
+				'wp-auth-nonce' => $login_nonce['key'],
+				'redirect_to'   => $redirect_to,
+			)
+		) );
+		exit;
+	}
+
 
 	/**
 	 * Display the Backup code 2fa screen.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -456,7 +456,7 @@ class Two_Factor_Core {
 	 *
 	 * @param bool $send_cookies Whether to send the authentication cookies.
 	 * @param int  $user_id      The User ID having cookies sent for. WordPress 6.2+.
-	 * @return Filtered `$send_cookies`.
+	 * @return bool Filtered `$send_cookies`.
 	 */
 	public static function send_auth_cookies( $send_cookies, $user_id = null ) {
 		if ( ! $send_cookies ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -458,8 +458,7 @@ class Two_Factor_Core {
 		if (
 			$send_cookies &&
 			self::$last_auth_cookie_user &&
-			self::is_user_using_two_factor( self::$last_auth_cookie_user ) &&
-			! apply_filters( 'two_factor_authentication_succeeded', false )
+			self::is_user_using_two_factor( self::$last_auth_cookie_user )
 		) {
 			$send_cookies = false;
 		}
@@ -934,8 +933,8 @@ class Two_Factor_Core {
 			$rememberme = true;
 		}
 
-		// TODO.
-		add_filter( 'two_factor_authentication_succeeded', '__return_true' );
+		// Allow authentication cookies to be set for this user.
+		remove_action( 'send_auth_cookies', array( __CLASS__, 'send_auth_cookies' ) );
 
 		wp_set_auth_cookie( $user->ID, $rememberme );
 


### PR DESCRIPTION
As noted in #406 and #385 it's possible for plugins to accidentally bypass the two-factor requirement by setting cookies directly. 

See https://github.com/WordPress/two-factor/issues/406#issuecomment-1301651343 for more detailed reasonings.

Fixes #406, #385