### PR TITLE
Fix Backup code download with quotes in translations

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -229,7 +229,12 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	public function ajax_generate_json() {
-		$user = get_user_by( 'id', filter_input( INPUT_POST, 'user_id', FILTER_SANITIZE_NUMBER_INT ) );
+		$user_id = 0;
+		if ( ! empty( $_POST['user_id'] ) ) {
+			$user_id = absint( $_POST['user_id'] );
+		}
+
+		$user = get_user_by( 'id', $user_id );
 		check_ajax_referer( 'two-factor-backup-codes-generate-json-' . $user->ID, 'nonce' );
 
 		// Setup the return data.

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -177,15 +177,23 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 							// Update counter.
 							$( '.two-factor-backup-codes-count' ).html( response.data.i18n.count );
 
-							// Build the download link.
-							var txt_data = 'data:application/text;charset=utf-8,' + '\n';
-							txt_data += response.data.i18n.title.replace( /%s/g, document.domain ) + '\n\n';
+							// Build the downloaded file contents.
+							var txt_data = response.data.i18n.title.replace( /%s/g, document.domain ) + '\n\n';
 
 							for ( i = 0; i < response.data.codes.length; i++ ) {
 								txt_data += i + 1 + '. ' + response.data.codes[ i ] + '\n';
 							}
 
-							$( '#two-factor-backup-codes-download-link' ).attr( 'href', encodeURI( txt_data ) );
+							txt_data = encodeURIComponent( txt_data );
+							// encodeURIComponent() Does not encode -_.!~*'()
+							txt_data = txt_data.replace(/[!'()~*]/g, function(c) {
+								return '%' + c.charCodeAt(0).toString(16);
+							} );
+
+							// Build the download link
+							txt_data = 'data:application/text;charset=utf-8,' + txt_data
+
+							$( '#two-factor-backup-codes-download-link' ).attr( 'href', txt_data );
 						}
 					} );
 				} );

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -247,7 +247,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		);
 
 		// Generate download content.
-		$download_link = 'data:application/text;charset=utf-8,';
+		$download_link  = 'data:application/text;charset=utf-8,';
 		$download_link .= rawurlencode( "{$title}\r\n\r\n" );
 
 		$i = 1;
@@ -256,7 +256,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			$i++;
 		}
 
-		$i18n  = array(
+		$i18n = array(
 			/* translators: %s: count */
 			'count' => esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count, 'two-factor' ), $count ) ),
 		);

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -243,11 +243,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Generate download content.
 		$download_link = 'data:application/text;charset=utf-8,';
-		$download_link .= rawurlencode( "{$title}\n\n" );
+		$download_link .= rawurlencode( "{$title}\r\n\r\n" );
 
 		$i = 1;
 		foreach ( $codes as $code ) {
-			$download_link .= rawurlencode( "{$i}. {$code}\n" );
+			$download_link .= rawurlencode( "{$i}. {$code}\r\n" );
 			$i++;
 		}
 

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -256,7 +256,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			/* translators: %s: count */
 			'count' => esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count, 'two-factor' ), $count ) ),
 			/* translators: %s: the site's domain */
-			'title' => esc_html__( 'Two-Factor Backup Codes for %s', 'two-factor' ),
+			'title' => __( 'Two-Factor Backup Codes for %s', 'two-factor' ), // not escaped as it's used within a downloaded file.
 		);
 
 		// Send the response.

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -178,7 +178,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 							$( '.two-factor-backup-codes-count' ).html( response.data.i18n.count );
 
 							// Build the downloaded file contents.
-							var txt_data = response.data.i18n.title.replace( /%s/g, document.domain ) + '\n\n';
+							var txt_data = response.data.i18n.title + '\n\n';
 
 							for ( i = 0; i < response.data.codes.length; i++ ) {
 								txt_data += i + 1 + '. ' + response.data.codes[ i ] + '\n';
@@ -255,8 +255,11 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$i18n  = array(
 			/* translators: %s: count */
 			'count' => esc_html( sprintf( _n( '%s unused code remaining.', '%s unused codes remaining.', $count, 'two-factor' ), $count ) ),
-			/* translators: %s: the site's domain */
-			'title' => __( 'Two-Factor Backup Codes for %s', 'two-factor' ), // not escaped as it's used within a downloaded file.
+			'title' => sprintf(
+				/* translators: %s: the site's domain */
+				__( 'Two-Factor Backup Codes for %s', 'two-factor' ),
+				home_url( '/' )
+			)
 		);
 
 		// Send the response.

--- a/tests/providers/class-two-factor-backup-codes-ajax.php
+++ b/tests/providers/class-two-factor-backup-codes-ajax.php
@@ -37,11 +37,9 @@ class Tests_Two_Factor_Backup_Codes_AJAX extends WP_Ajax_UnitTestCase {
 	 * @covers Two_Factor_Backup_Codes::validate_code
 	 */
 	public function test_generate_code_and_validate_in_download_file() {
-		$user = new WP_User( self::factory()->user->create() );
+		$this->_setRole( 'administrator' );
 
-		// Become that user.
-		wp_set_current_user( $user->ID );
-
+		$user             = wp_get_current_user();
 		$_POST['user_id'] = $user->ID;
 		$_POST['nonce']   = wp_create_nonce( 'two-factor-backup-codes-generate-json-' . $user->ID );
 

--- a/tests/providers/class-two-factor-backup-codes-ajax.php
+++ b/tests/providers/class-two-factor-backup-codes-ajax.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Test Two Factor Backup Codes.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Tests_Two_Factor_Backup_Codes_AJAX
+ *
+ * @package Two_Factor
+ * @group providers
+ */
+class Tests_Two_Factor_Backup_Codes_AJAX extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Instance of our provider class.
+	 *
+	 * @var Two_Factor_Backup_Codes
+	 */
+	protected $provider;
+
+	/**
+	 * Set up a test case.
+	 *
+	 * @see WP_UnitTestCase_Base::set_up()
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->provider = Two_Factor_Backup_Codes::get_instance();
+	}
+
+	/**
+	 * Verify that the downloaded file contains the codes.
+	 *
+	 * @covers Two_Factor_Backup_Codes::generate_codes
+	 * @covers Two_Factor_Backup_Codes::validate_code
+	 */
+	public function test_generate_code_and_validate_in_download_file() {
+		$user = new WP_User( self::factory()->user->create() );
+
+		// Become that user.
+		wp_set_current_user( $user->ID );
+
+		$_POST['user_id'] = $user->ID;
+		$_POST['nonce']   = wp_create_nonce( 'two-factor-backup-codes-generate-json-' . $user->ID );
+
+		try {
+			$this->_handleAjax( 'two_factor_backup_codes_generate' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'download_link', $this->_last_response );
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertTrue( $response->success );
+		$this->assertNotEmpty( $response->data->codes );
+		$this->assertTrue( $this->provider->validate_code( $user, $response->data->codes[0] ) );
+		$this->assertStringContainsString( $response->data->codes[0], $response->data->download_link );
+	}
+}

--- a/tests/providers/class-two-factor-backup-codes-ajax.php
+++ b/tests/providers/class-two-factor-backup-codes-ajax.php
@@ -104,7 +104,7 @@ class Tests_Two_Factor_Backup_Codes_AJAX extends WP_Ajax_UnitTestCase {
 		$this->assertTrue( $response->success );
 		$this->assertNotEmpty( $response->data->codes );
 
-		$this->assertTrue( $this->provider->validate_code( $user, $response->data->codes[0] ) );
 		$this->assertFalse( $this->provider->validate_code( $current_user, $response->data->codes[0] ) );
+		$this->assertTrue( $this->provider->validate_code( $user, $response->data->codes[0] ) );
 	}
 }

--- a/tests/providers/class-two-factor-backup-codes-ajax.php
+++ b/tests/providers/class-two-factor-backup-codes-ajax.php
@@ -33,8 +33,7 @@ class Tests_Two_Factor_Backup_Codes_AJAX extends WP_Ajax_UnitTestCase {
 	/**
 	 * Verify that the downloaded file contains the codes.
 	 *
-	 * @covers Two_Factor_Backup_Codes::generate_codes
-	 * @covers Two_Factor_Backup_Codes::validate_code
+	 * @covers Two_Factor_Backup_Codes::ajax_generate_json
 	 */
 	public function test_generate_code_and_validate_in_download_file() {
 		$this->_setRole( 'administrator' );
@@ -57,5 +56,55 @@ class Tests_Two_Factor_Backup_Codes_AJAX extends WP_Ajax_UnitTestCase {
 		$this->assertNotEmpty( $response->data->codes );
 		$this->assertTrue( $this->provider->validate_code( $user, $response->data->codes[0] ) );
 		$this->assertStringContainsString( $response->data->codes[0], $response->data->download_link );
+	}
+
+	/**
+	 * Verify that a different user cannot generate codes for another.
+	 *
+	 * @covers Two_Factor_Backup_Codes::ajax_generate_json
+	 */
+	public function test_cannot_generate_code_for_different_user() {
+		$this->_setRole( 'administrator' );
+
+		$user           = wp_get_current_user();
+		$_POST['nonce'] = wp_create_nonce( 'two-factor-backup-codes-generate-json-' . $user->ID );
+
+		// Create a new user
+		$user             = new WP_User( self::factory()->user->create() );
+		$_POST['user_id'] = $user->ID;
+
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'two_factor_backup_codes_generate' );
+	}
+
+	/**
+	 * Verify that an admin can create Backup codes for another user.
+	 *
+	 * @covers Two_Factor_Backup_Codes::ajax_generate_json
+	 */
+	public function test_generate_codes_for_other_users() {
+		$this->_setRole( 'administrator' );
+
+		$current_user     = wp_get_current_user();
+		$user             =  new WP_User( self::factory()->user->create() );
+		$_POST['user_id'] = $user->ID;
+		$_POST['nonce']   = wp_create_nonce( 'two-factor-backup-codes-generate-json-' . $user->ID );
+
+		try {
+			$this->_handleAjax( 'two_factor_backup_codes_generate' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$this->assertStringContainsString( 'codes', $this->_last_response );
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertTrue( $response->success );
+		$this->assertNotEmpty( $response->data->codes );
+
+		$this->assertTrue( $this->provider->validate_code( $user, $response->data->codes[0] ) );
+		$this->assertFalse( $this->provider->validate_code( $current_user, $response->data->codes[0] ) );
 	}
 }


### PR DESCRIPTION
Fixes #460

- `encodeURI()` doesn't encode enough characters for non-english languages.
- `encodeURIComponent()` doesn't encode enough characters for usage within `data:` uri's
- `i18n.title` should not be HTML escaped if it's not going to be used within a HTML context. This results in the translation string having HTML entities. An alternative would be to decode HTML entities client-side in JS and then use it that value, but encoding it in the first place here provides no security benefits.
