### PR TITLE
Register the TOTP QR generation script on the front-end.

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -51,6 +51,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	protected function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'two_factor_user_options_' . __CLASS__, array( $this, 'user_two_factor_options' ) );
 		add_action( 'personal_options_update', array( $this, 'user_two_factor_options_update' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'user_two_factor_options_update' ) );


### PR DESCRIPTION
This allows for the renderer to enqueue the TOTP generation on the front-end - Such as within the bbPress settings panel.

Without this, the JS is never loaded and you just see a spinner.

See 70ba42e3bac72597a5b98785b6f11273f2830cb4 & #487