### PR TITLE
Block sending authentication cookies upon 2FA login

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -495,6 +495,10 @@ class Two_Factor_Core {
 	 * @return WP_User|WP_Error
 	 */
 	public static function filter_authenticate_block_cookies( $user ) {
+		/*
+		 * NOTE: The `login_init` action is checked for here to ensure we're within the regular login flow,
+		 * rather than through an unsupported 3rd-party login process which this plugin doesn't support.
+		 */
 		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) && did_action( 'login_init' ) ) {
 			add_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 		}
@@ -919,6 +923,11 @@ class Two_Factor_Core {
 			$rememberme = true;
 		}
 
+		/*
+		 * NOTE: This filter removal is not normally required, this is included for protection against
+		 * a plugin/two factor provider which runs the `authenticate` filter during it's validation.
+		 * Such a plugin would cause self::filter_authenticate_block_cookies() to run and add this filter.
+		 */
 		remove_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 		wp_set_auth_cookie( $user->ID, $rememberme );
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -90,7 +90,7 @@ class Two_Factor_Core {
 		// Run only after the core wp_authenticate_username_password() check.
 		add_filter( 'authenticate', array( __CLASS__, 'filter_authenticate' ), 50 );
 
-		// Run as late as possible to disable sending authentication cookies.
+		// Run as late as possible to prevent other plugins from unintentionally bypassing.
 		add_filter( 'authenticate', array( __CLASS__, 'filter_authenticate_block_cookies' ), PHP_INT_MAX );
 
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -486,6 +486,8 @@ class Two_Factor_Core {
 	/**
 	 * Prevent login cookies being set on login for Two Factor users.
 	 *
+	 * This makes it so that Core never sends the auth cookies. `login_form_validate_2fa()` will send them manually once the 2nd factor has been verified.
+	 *
 	 * @param  WP_User|WP_Error $user Valid WP_User only if the previous filters
 	 *                                have verified and confirmed the
 	 *                                authentication credentials.


### PR DESCRIPTION
Based on the feedback in #406 and limited interest on changing how the login flow works in #490, this PR is a minimal patch which prevents sending the authentication cookies upon hitting the 2FA interstitial page.

As there's limited changes in this PR, this should be easier for others to review and approve.