### PR TITLE
TOTP: Enforce single-use of TOTP one-time passwords.

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -11,11 +11,18 @@
 class Two_Factor_Totp extends Two_Factor_Provider {
 
 	/**
-	 * The user meta token key.
+	 * The user meta key for the TOTP Secret key.
 	 *
 	 * @var string
 	 */
 	const SECRET_META_KEY = '_two_factor_totp_key';
+
+	/**
+	 * The user meta key for the last successful TOTP token timestamp logged in with.
+	 *
+	 * @var string
+	 */
+	const LAST_SUCCESSFUL_LOGIN_META_KEY = '_two_factor_totp_last_successful_login';
 
 	const DEFAULT_KEY_BIT_SIZE        = 160;
 	const DEFAULT_CRYPTO              = 'sha1';
@@ -408,6 +415,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return boolean If the key was deleted successfully.
 	 */
 	public function delete_user_totp_key( $user_id ) {
+		delete_user_meta( $user_id, self::LAST_SUCCESSFUL_LOGIN_META_KEY );
 		return delete_user_meta( $user_id, self::SECRET_META_KEY );
 	}
 
@@ -434,29 +442,70 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 *
 	 * @return bool Whether the user gave a valid code
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function validate_authentication( $user ) {
-		if ( ! empty( $_REQUEST['authcode'] ) ) {
-			return $this->is_valid_authcode(
-				$this->get_user_totp_key( $user->ID ),
-				sanitize_text_field( $_REQUEST['authcode'] )
-			);
+		if ( empty( $_REQUEST['authcode'] ) ) {
+			return false;
 		}
 
-		return false;
+		return $this->validate_code_for_user(
+			$user,
+			sanitize_text_field( $_REQUEST['authcode'] )
+		);
 	}
 
 	/**
-	 * Checks if a given code is valid for a given key, allowing for a certain amount of time drift
+	 * Validates a authentication code for a given user, preventing re-use and older TOTP keys.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @param int     $code The TOTP token to validate.
+	 *
+	 * @return bool Whether the code is valid for the user and a newer code has not been used.
+	 */
+	public function validate_code_for_user( $user, $code ) {
+		$valid_timestamp = $this->get_authcode_valid_ticktime(
+			$this->get_user_totp_key( $user->ID ),
+			$code,
+		);
+
+		if ( ! $valid_timestamp ) {
+			return false;
+		}
+
+		$last_totp_login = (int) get_user_meta( $user->ID, self::LAST_SUCCESSFUL_LOGIN_META_KEY, true );
+
+		// The TOTP authentication is not valid, if we've seen the same or newer code.
+		if ( $last_totp_login && $last_totp_login >= $valid_timestamp ) {
+			return false;
+		}
+
+		update_user_meta( $user->ID, self::LAST_SUCCESSFUL_LOGIN_META_KEY, $valid_timestamp );
+
+		return true;
+	}
+
+
+	/**
+	 * Checks if a given code is valid for a given key, allowing for a certain amount of time drift.
 	 *
 	 * @param string $key      The share secret key to use.
 	 * @param string $authcode The code to test.
 	 *
-	 * @return bool Whether the code is valid within the time frame
+	 * @return bool Whether the code is valid within the time frame.
 	 */
 	public static function is_valid_authcode( $key, $authcode ) {
+		return (bool) self::get_authcode_valid_ticktime( $key, $authcode );
+	}
+
+	/**
+	 * Checks if a given code is valid for a given key, allowing for a certain amount of time drift.
+	 *
+	 * @param string $key      The share secret key to use.
+	 * @param string $authcode The code to test.
+	 *
+	 * @return false|int Returns the timestamp of the authcode on success, False otherwise.
+	 */
+	public static function get_authcode_valid_ticktime( $key, $authcode ) {
 		/**
 		 * Filter the maximum ticks to allow when checking valid codes.
 		 *
@@ -478,10 +527,12 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 		foreach ( $ticks as $offset ) {
 			$log_time = $time + $offset;
-			if ( hash_equals(self::calc_totp( $key, $log_time ), $authcode ) ) {
-				return true;
+			if ( hash_equals( self::calc_totp( $key, $log_time ), $authcode ) ) {
+				// Return the tick timestamp.
+				return $log_time * self::DEFAULT_TIME_STEP_SEC;
 			}
 		}
+
 		return false;
 	}
 

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -523,7 +523,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$ticks = range( - $max_ticks, $max_ticks );
 		usort( $ticks, array( __CLASS__, 'abssort' ) );
 
-		$time = time() / self::DEFAULT_TIME_STEP_SEC;
+		$time = floor( time() / self::DEFAULT_TIME_STEP_SEC );
 
 		foreach ( $ticks as $offset ) {
 			$log_time = $time + $offset;

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -455,7 +455,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Validates a authentication code for a given user, preventing re-use and older TOTP keys.
+	 * Validates an authentication code for a given user, preventing re-use and older TOTP keys.
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 * @param int     $code The TOTP token to validate.

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -465,7 +465,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	public function validate_code_for_user( $user, $code ) {
 		$valid_timestamp = $this->get_authcode_valid_ticktime(
 			$this->get_user_totp_key( $user->ID ),
-			$code,
+			$code
 		);
 
 		if ( ! $valid_timestamp ) {

--- a/tests/providers/class-two-factor-totp.php
+++ b/tests/providers/class-two-factor-totp.php
@@ -227,7 +227,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 
 		$authcode = $this->provider->calc_totp( $key );
 
-		// Validate that no key doesn't suceed.
+		// Validate that a missing key results in failure.
 		unset( $_REQUEST['authcode'] );
 		$this->assertFalse( $this->provider->validate_authentication( $user ) );
 

--- a/tests/providers/class-two-factor-totp.php
+++ b/tests/providers/class-two-factor-totp.php
@@ -140,6 +140,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 * Verify authcode validation.
 	 *
 	 * @covers Two_Factor_Totp::is_valid_authcode
+	 * @covers Two_Factor_Totp::get_authcode_valid_ticktime
 	 * @covers Two_Factor_Totp::generate_key
 	 * @covers Two_Factor_Totp::calc_totp
 	 * @covers Two_Factor_Totp::pack64
@@ -157,6 +158,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 * Verify authcode rejection.
 	 *
 	 * @covers Two_Factor_Totp::is_valid_authcode
+	 * @covers Two_Factor_Totp::get_authcode_valid_ticktime
 	 */
 	public function test_invalid_authcode_rejected() {
 		$key = $this->provider->generate_key();
@@ -207,5 +209,73 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 		$this->assertFalse( $this->provider->is_valid_key( '' ), 'Empty string is invalid' );
 		$this->assertFalse( $this->provider->is_valid_key( 'abc233' ), 'Lowercase chars are invalid' );
 		$this->assertFalse( $this->provider->is_valid_key( 'has a space' ), 'Spaces not allowed' );
+	}
+
+	/**
+	 * Test that the validation function works.
+	 *
+	 * @covers Two_Factor_Totp::validate_authentication
+	 * @covers Two_Factor_Totp::validate_code_for_user
+	 * @covers Two_Factor_Totp::get_authcode_valid_ticktime
+	 */
+	function test_validate_authentication() {
+		$user = new WP_User( self::factory()->user->create() );
+		$key  = $this->provider->generate_key();
+
+		// Configure secret for the user.
+		$this->provider->set_user_totp_key( $user->ID, $key );
+
+		$authcode = $this->provider->calc_totp( $key );
+
+		// Validate that no key doesn't suceed.
+		unset( $_REQUEST['authcode'] );
+		$this->assertFalse( $this->provider->validate_authentication( $user ) );
+
+		// Validate that an invalid key doesn't succeed.
+		$_REQUEST['authcode'] = '123456'; // Okay, that's valid once in a blue moon.
+		$this->assertFalse( $this->provider->validate_authentication( $user ) );
+
+		// Validate that the login would succeed using the current authcode.
+		$_REQUEST['authcode'] = $authcode;
+		$this->assertTrue( $this->provider->validate_authentication( $user ) );
+
+		// Validate that a second attempt with the same authcode will fail.
+		$this->assertFalse( $this->provider->validate_authentication( $user ) );
+	}
+
+	/**
+	 * Test that the validation function works.
+	 *
+	 * @covers Two_Factor_Totp::validate_code_for_user
+	 * @covers Two_Factor_Totp::get_authcode_valid_ticktime
+	 */
+	function test_validate_code_for_user() {
+		$user = new WP_User( self::factory()->user->create() );
+		$key  = $this->provider->generate_key();
+
+		// Configure secret for the user.
+		$this->provider->set_user_totp_key( $user->ID, $key );
+
+		$oldcode  = $this->provider->calc_totp( $key, floor( time() / Two_Factor_Totp::DEFAULT_TIME_STEP_SEC ) - 2 );
+		$prevcode = $this->provider->calc_totp( $key, floor( time() / Two_Factor_Totp::DEFAULT_TIME_STEP_SEC ) - 1 );
+		$authcode = $this->provider->calc_totp( $key );
+		$nextcode = $this->provider->calc_totp( $key, floor( time() / Two_Factor_Totp::DEFAULT_TIME_STEP_SEC ) + 1 );
+
+		// Validate that the login would succeed using the previous authcode.
+		$this->assertTrue( $this->provider->validate_code_for_user( $user, $prevcode ) );
+
+		// Validate that the login would succeed using the current authcode.
+		$this->assertTrue( $this->provider->validate_code_for_user( $user, $authcode ) );
+
+		// Validate that a second attempt with the same authcode will fail.
+		$this->assertFalse( $this->provider->validate_code_for_user( $user, $authcode ) );
+
+		// Validate that the future authcode will succeed (but not more than once)
+		$this->assertTrue( $this->provider->validate_code_for_user( $user, $nextcode ) );
+		$this->assertFalse( $this->provider->validate_code_for_user( $user, $nextcode ) );
+
+		// Validate that the older unused authcode will not succeed.
+		$this->assertFalse( $this->provider->validate_code_for_user( $user, $oldcode ) );
+
 	}
 }

--- a/tests/providers/class-two-factor-totp.php
+++ b/tests/providers/class-two-factor-totp.php
@@ -285,12 +285,7 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 * @covers Two_Factor_Totp::get_authcode_valid_ticktime
 	 */
 	function test_get_authcode_valid_ticktime() {
-		$user = new WP_User( self::factory()->user->create() );
-		$key  = $this->provider->generate_key();
-
-		// Configure secret for the user.
-		$this->provider->set_user_totp_key( $user->ID, $key );
-
+		$key              = $this->provider->generate_key();
 		$max_grace_period = Two_Factor_Totp::DEFAULT_TIME_STEP_ALLOWANCE;
 
 		foreach ( range( - $max_grace_period, $max_grace_period ) as $tick ) {


### PR DESCRIPTION
Per the [TOTP spec, section 5.2](https://www.rfc-editor.org/rfc/rfc6238#section-5.2):
>    Note that a prover may send the same OTP inside a given time-step
   window multiple times to a verifier.  The verifier MUST NOT accept
   the second attempt of the OTP after the successful validation has
   been issued for the first OTP, which ensures one-time only use of an
   OTP.

Once a TOTP token is entered, it should not be able to be re-used, it's one-time.
This is a hardening ticket, making the TOTP provider comply with the spec.

For example:
 - have two unique browser sessions open
 - generate a TOTP code, CODE1
 - Login with user/password/CODE1 on window 1
 - Login with user/password/CODE1 on window 2

Per spec, both windows logging in successfully shouldn't be allowed, window 2 should fail the TOTP code and be forced to wait for the next generated one.

For a an example of why this protection exists, If someone were to be looking over your shoulder as you type in your password and authcode, they should not be able to repeat the same on their own device and succeed at logging in, because you've already used your one-time code.

This PR takes it a step further, mostly out of convenience, by making any TOTP codes for previous-timestamp-ticks be invalid once you use the future code.

In this next scenario, both windows are logging in with unique TOTP codes, but with this change window 2 will be rejected as window 1 has already logged in with a newer one-time password. 
 - have two unique browser sessions open
 - generate a TOTP code, note it down as CODE1
 - generate the next TOTP code, note it down as CODE2
 - In window 1: Login with user/password/CODE2
 - In window 2: Login with user/password/CODE1

That means if someone were standing beside you, saw the first TOTP code (with 5s remaining on it), and you waited 
 and entered the next code generated, they should still not be able to login during the grace period with that now "old" code.

In this next scenario, both logins will proceed and login:
 - have two unique browser sessions open
 - generate a TOTP code, note it down as CODE1
 - generate the next TOTP code, note it down as CODE2
 - In window 1: Login with user/pass/CODE1
 - In window 2: Login with user/pass/CODE2
 
There is no minimum wait between successful logins, only that the next login must be using a later-generated code.

There are edge-cases which this does break, but I don't believe is a concern. For example, if there is a shared user account, with multiple TOTP generators, and their clocks are out of sync, and multiple people try to login at the same time, some will fail. 

Note: The login nonce prevents you having two windows open on the 2FA screen, you must start each test of the flow from the user/pass login screen.

See https://github.com/WordPress/wporg-two-factor/issues/3