### PR TITLE
Tests: Generate an HTML coverage report when running tests locally.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,10 @@
   "scripts": {
     "lint": "phpcs",
     "lint-php8": "phpcs -p --standard=PHPCompatibilityWP --runtime-set testVersion 8.0- --extensions=php --ignore='vendor/,wordpress/,node_modules/' .",
-    "test": "phpunit",
+    "test": "php -d xdebug.mode=coverage vendor/bin/phpunit",
     "test:watch": [
       "Composer\\Config::disableProcessTimeout",
-      "phpunit-watcher watch"
+      "phpunit-watcher watch --no-coverage"
     ],
     "format": "phpcbf"
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,7 @@
 		</exclude>
 		<report>
 			<clover outputFile="tests/logs/clover.xml" />
+			<html outputDirectory="tests/logs/html" />
 		</report>
 	</coverage>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,27 @@ See `package.json` for other available scripts you might want to use during deve
 
 When you're ready, open [a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) with the suggested changes.
 
+## Testing
+
+### Running tests in Docker
+
+1. Run `npm run env start`
+1. Run `npm run test` or `npm run test:watch`.
+
+### Running tests locally
+
+1. Create a MySQL database for the tests. Don't reuse an existing database, because all of the data will be deleted every time the tests are run.
+1. Add the following to your `~/.bashrc`, with the values for the database you created above:
+	```
+	export WORDPRESS_DB_NAME=wp_tests
+	export WORDPRESS_DB_USER=wp_tests
+	export WORDPRESS_DB_PASSWORD=wp_tests
+	```
+1. `source ~/.bashrc`
+1. Run `composer run test` or `composer run test:watch`.
+
+To view the code coverage report, you can open a web browser, go to `File > Open file...`, and then select `{path to two-factor}/tests/logs/html/index.html`.
+
 ## Deployments
 
 Deployments [to WP.org plugin repository](https://wordpress.org/plugins/two-factor/) are handled automatically by the GitHub action [.github/workflows/deploy.yml](.github/workflows/deploy.yml). All merges to the `master` branch are commited to the [`trunk` directory](https://plugins.trac.wordpress.org/browser/two-factor/trunk) while all [Git tags](https://github.com/WordPress/two-factor/tags) are pushed as versioned releases [under the `tags` directory](https://plugins.trac.wordpress.org/browser/two-factor/tags).


### PR DESCRIPTION
This makes it convenient to check coverage locally, instead of having to go to Coveralls.

This does part of the documentation for #467 , but only the local part. Docs will still need to be added for Coveralls when #364 is done.