### PR TITLE
Switch to using `$_REQUEST` directly instead of `filter_input()` and remove `backup_2fa` 

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -267,7 +267,11 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) ? sanitize_key( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) : '';
+		$request_nonce = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) ? wp_unslash( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) : '';
+
+		if ( ! $user_id || ! $action || ! $request_nonce ) {
+			return false;
+		}
 
 		return wp_verify_nonce(
 			$request_nonce,
@@ -300,10 +304,10 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function trigger_user_settings_action() {
-		$action  = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) ? sanitize_key( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) : '';
+		$action  = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) ? wp_unslash( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) : '';
 		$user_id = self::current_user_being_edited();
 
-		if ( ! empty( $action ) && self::is_valid_user_action( $user_id, $action ) ) {
+		if ( self::is_valid_user_action( $user_id, $action ) ) {
 			/**
 			 * This action is triggered when a valid Two Factor settings
 			 * action is detected and it passes the nonce validation.
@@ -945,9 +949,9 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function login_form_validate_2fa() {
-		$wp_auth_id = ! empty( $_REQUEST['wp-auth-id'] )    ? absint( $_REQUEST['wp-auth-id'] )                          : 0;
-		$nonce      = ! empty( $_REQUEST['wp-auth-nonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['wp-auth-nonce'] ) )   : '';
-		$provider   = ! empty( $_REQUEST['provider'] )      ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false;
+		$wp_auth_id = ! empty( $_REQUEST['wp-auth-id'] )    ? absint( $_REQUEST['wp-auth-id'] )        : 0;
+		$nonce      = ! empty( $_REQUEST['wp-auth-nonce'] ) ? wp_unslash( $_REQUEST['wp-auth-nonce'] ) : '';
+		$provider   = ! empty( $_REQUEST['provider'] )      ? wp_unslash( $_REQUEST['provider'] )      : false;
 
 		if ( ! $wp_auth_id || ! $nonce ) {
 			return;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -267,7 +267,7 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG, FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
+		$request_nonce = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) ? sanitize_key( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) : '';
 
 		return wp_verify_nonce(
 			$request_nonce,
@@ -300,7 +300,7 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function trigger_user_settings_action() {
-		$action  = filter_input( INPUT_GET, self::USER_SETTINGS_ACTION_QUERY_VAR, FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
+		$action  = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) ? sanitize_key( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) : '';
 		$user_id = self::current_user_being_edited();
 
 		if ( ! empty( $action ) && self::is_valid_user_action( $user_id, $action ) ) {
@@ -945,8 +945,9 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function login_form_validate_2fa() {
-		$wp_auth_id = filter_input( INPUT_POST, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_POST, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
+		$wp_auth_id = ! empty( $_REQUEST['wp-auth-id'] )    ? absint( $_REQUEST['wp-auth-id'] )                          : 0;
+		$nonce      = ! empty( $_REQUEST['wp-auth-nonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['wp-auth-nonce'] ) )   : '';
+		$provider   = ! empty( $_REQUEST['provider'] )      ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false;
 
 		if ( ! $wp_auth_id || ! $nonce ) {
 			return;
@@ -962,7 +963,6 @@ class Two_Factor_Core {
 			exit;
 		}
 
-		$provider = filter_input( INPUT_POST, 'provider', FILTER_CALLBACK, array( 'options' => 'sanitize_text_field' ) );
 		if ( $provider ) {
 			$providers = self::get_available_providers_for_user( $user );
 			if ( isset( $providers[ $provider ] ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -90,7 +90,6 @@ class Two_Factor_Core {
 		add_action( 'init', array( __CLASS__, 'get_providers' ) );
 		add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 		add_action( 'login_form_validate_2fa', array( __CLASS__, 'login_form_validate_2fa' ) );
-		add_action( 'login_form_backup_2fa', array( __CLASS__, 'backup_2fa' ) );
 		add_action( 'show_user_profile', array( __CLASS__, 'user_two_factor_options' ) );
 		add_action( 'edit_user_profile', array( __CLASS__, 'user_two_factor_options' ) );
 		add_action( 'personal_options_update', array( __CLASS__, 'user_two_factor_options_update' ) );
@@ -578,43 +577,6 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Display the Backup code 2fa screen.
-	 *
-	 * @since 0.1-dev
-	 */
-	public static function backup_2fa() {
-		$wp_auth_id = filter_input( INPUT_GET, 'wp-auth-id', FILTER_SANITIZE_NUMBER_INT );
-		$nonce      = filter_input( INPUT_GET, 'wp-auth-nonce', FILTER_CALLBACK, array( 'options' => 'sanitize_key' ) );
-		$provider   = filter_input( INPUT_GET, 'provider', FILTER_CALLBACK, array( 'options' => 'sanitize_text_field' ) );
-
-		if ( ! $wp_auth_id || ! $nonce || ! $provider ) {
-			return;
-		}
-
-		$user = get_userdata( $wp_auth_id );
-		if ( ! $user ) {
-			return;
-		}
-
-		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
-			wp_safe_redirect( home_url() );
-			exit;
-		}
-
-		$providers = self::get_available_providers_for_user( $user );
-		if ( isset( $providers[ $provider ] ) ) {
-			$provider = $providers[ $provider ];
-		} else {
-			wp_die( esc_html__( 'Cheatin&#8217; uh?', 'two-factor' ), 403 );
-		}
-
-		$redirect_to = filter_input( INPUT_GET, 'redirect_to', FILTER_SANITIZE_URL );
-		self::login_html( $user, $nonce, $redirect_to, '', $provider );
-
-		exit;
-	}
-
-	/**
 	 * Displays a message informing the user that their account has had failed login attempts.
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
@@ -699,7 +661,7 @@ class Two_Factor_Core {
 			$backup_provider  = $backup_providers[ $backup_classname ];
 			$login_url        = self::login_url(
 				array(
-					'action'        => 'backup_2fa',
+					'action'        => 'validate_2fa',
 					'provider'      => $backup_classname,
 					'wp-auth-id'    => $user->ID,
 					'wp-auth-nonce' => $login_nonce,
@@ -735,7 +697,7 @@ class Two_Factor_Core {
 					foreach ( $backup_providers as $backup_classname => $backup_provider ) :
 						$login_url = self::login_url(
 							array(
-								'action'        => 'backup_2fa',
+								'action'        => 'validate_2fa',
 								'provider'      => $backup_classname,
 								'wp-auth-id'    => $user->ID,
 								'wp-auth-nonce' => $login_nonce,

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -113,13 +113,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 				array( 'Two_Factor_Core', 'login_form_validate_2fa' )
 			)
 		);
-		$this->assertGreaterThan(
-			0,
-			has_action(
-				'login_form_backup_2fa',
-				array( 'Two_Factor_Core', 'backup_2fa' )
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
Currently there's two different routes into the 2FA credentials window, `action=validate_2fa` and `action=backup_2fa`, these are exactly the same, except that the former uses POST and the latter uses GET.

This is partially caused by the usage of `filter_input()` which has other problems for us, such as being unable to be unit tested.

This PR simplifies it by combining `action=validate_2fa` and `action=backup_2fa` and simplifying the resulting code.

This is part of an initial work towards #484.