### PR TITLE
Store the two-factor details in the user session at login time

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1089,9 +1089,9 @@ class Two_Factor_Core {
 	 * @return int|false The last time the two-factor was validated on success, false if not currently using a 2FA session.
 	 */
 	public static function is_current_user_session_two_factor() {
-		$user    = wp_get_current_user();
-		$manager = WP_Session_Tokens::get_instance( $user->ID );
+		$user_id = get_current_user_id();
 		$token   = wp_get_session_token();
+		$manager = WP_Session_Tokens::get_instance( $user_id );
 		$session = $manager->get( $token );
 
 		if ( empty( $session['two-factor-login'] ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1234,7 +1234,7 @@ class Two_Factor_Core {
 		$session_information_callback = function( $session, $user_id ) use( $provider, $user ) {
 			if ( $user->ID === $user_id ) {
 				$session['two-factor-login']    = time();
-				$session['two-factor-provider'] = get_class( $provider );
+				$session['two-factor-provider'] = $provider->get_key();
 			}
 
 			return $session;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1082,6 +1082,26 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Determine if the current user session is logged in with 2FA.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @return int|false The last time the two-factor was validated on success, false if not currently using a 2FA session.
+	 */
+	public static function is_current_user_session_two_factor() {
+		$user    = wp_get_current_user();
+		$manager = WP_Session_Tokens::get_instance( $user->ID );
+		$token   = wp_get_session_token();
+		$session = $manager->get( $token );
+
+		if ( empty( $session['two-factor-login'] ) ) {
+			return false;
+		}
+
+		return (int) $session['two-factor-login'];
+	}
+
+	/**
 	 * Login form validation.
 	 *
 	 * @since 0.1-dev

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1109,7 +1109,7 @@ class Two_Factor_Core {
 	public static function login_form_validate_2fa() {
 		$wp_auth_id      = ! empty( $_REQUEST['wp-auth-id'] )    ? absint( $_REQUEST['wp-auth-id'] )        : 0;
 		$nonce           = ! empty( $_REQUEST['wp-auth-nonce'] ) ? wp_unslash( $_REQUEST['wp-auth-nonce'] ) : '';
-		$provider        = ! empty( $_REQUEST['provider'] )      ? wp_unslash( $_REQUEST['provider'] )      : false;
+		$provider        = ! empty( $_REQUEST['provider'] )      ? wp_unslash( $_REQUEST['provider'] )      : '';
 		$redirect_to     = ! empty( $_REQUEST['redirect_to'] )   ? wp_unslash( $_REQUEST['redirect_to'] )   : '';
 		$is_post_request = ( 'POST' === strtoupper( $_SERVER['REQUEST_METHOD'] ) );
 		$user            = get_user_by( 'id', $wp_auth_id );
@@ -1130,14 +1130,14 @@ class Two_Factor_Core {
 	 *
 	 * @since x.x
 	 *
-	 * @param WP_User     $user            The WP_User instance.
-	 * @param string      $nonce           The nonce provided.
-	 * @param string|bool $provider        The provider to use, if known.
-	 * @param string      $redirect_to     The redirection location.
-	 * @param bool        $is_post_request Whether the incoming request was a POST request or not.
+	 * @param WP_User $user            The WP_User instance.
+	 * @param string  $nonce           The nonce provided.
+	 * @param string  $provider        The provider to use, if known.
+	 * @param string  $redirect_to     The redirection location.
+	 * @param bool    $is_post_request Whether the incoming request was a POST request or not.
 	 * @return void
 	 */
-	public static function _login_form_validate_2fa( $user, $nonce = '', $provider = false, $redirect_to = '', $is_post_request = false ) {
+	public static function _login_form_validate_2fa( $user, $nonce = '', $provider = '', $redirect_to = '', $is_post_request = false ) {
 		// Validate the request.
 		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
 			wp_safe_redirect( home_url() );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1233,7 +1233,7 @@ class Two_Factor_Core {
 			$rememberme = true;
 		}
 
-		$session_information_callback = function( $session, $user_id ) use( $provider, $user ) {
+		$session_information_callback = static function( $session, $user_id ) use( $provider, $user ) {
 			if ( $user->ID === $user_id ) {
 				$session['two-factor-login']    = time();
 				$session['two-factor-provider'] = $provider->get_key();

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1198,6 +1198,19 @@ class Two_Factor_Core {
 			$rememberme = true;
 		}
 
+		// Create a new User session
+		$expiration = time() + apply_filters( 'auth_cookie_expiration', ( $rememberme ? 14 : 2 ) * DAY_IN_SECONDS, $user->ID, $rememberme );
+		$manager    = WP_Session_Tokens::get_instance( $user->ID );
+		$token      = $manager->create( $expiration );
+		$session    = $manager->get( $token );
+
+		// Append the Two Factor session data
+		$session['two-factor-login']    = time();
+		$session['two-factor-provider'] = get_class( $provider );
+
+		// Save it in the session and create the cookie with it.
+		$manager->update( $token, $session );
+
 		/*
 		 * NOTE: This filter removal is not normally required, this is included for protection against
 		 * a plugin/two factor provider which runs the `authenticate` filter during it's validation.
@@ -1205,25 +1218,9 @@ class Two_Factor_Core {
 		 */
 		remove_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 
-		// Attach two-factor status to the session.
-		add_filter( 'attach_session_information',
-			function( $session, $user_id ) use( $user, $provider ) {
-				if ( $user_id !== $user->ID ) {
-					return $session;
-				}
+		wp_set_auth_cookie( $user->ID, $rememberme, '', $token );
 
-				$session['two-factor-timestamp'] = time();
-				$session['two-factor-provider']  = get_class( $provider );
-
-				return $session;
-			},
-			10,
-			2
-		);
-
-		wp_set_auth_cookie( $user->ID, $rememberme );
-
-		do_action( 'two_factor_user_authenticated', $user );
+		do_action( 'two_factor_user_authenticated', $user, $provider, $token );
 
 		// Must be global because that's how login_header() uses it.
 		global $interim_login;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1107,7 +1107,8 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function login_form_validate_2fa() {
-		if ( self::_login_form_validate_2fa() ) {
+		$should_exit = self::_login_form_validate_2fa();
+		if ( $should_exit ) {
 			exit;
 		}
 	}
@@ -1118,6 +1119,7 @@ class Two_Factor_Core {
 	 * This function exists for unit testing, as `exit` prevents testing.
 	 *
 	 * @since x.x
+	 * @return bool True if the request should exit, false otherwise.
 	 */
 	public static function _login_form_validate_2fa() {
 		$wp_auth_id      = ! empty( $_REQUEST['wp-auth-id'] )    ? absint( $_REQUEST['wp-auth-id'] )        : 0;
@@ -1126,12 +1128,12 @@ class Two_Factor_Core {
 		$is_post_request = ( 'POST' === strtoupper( $_SERVER['REQUEST_METHOD'] ) );
 
 		if ( ! $wp_auth_id || ! $nonce ) {
-			return;
+			return false;
 		}
 
 		$user = get_userdata( $wp_auth_id );
 		if ( ! $user ) {
-			return;
+			return false;
 		}
 
 		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1204,6 +1204,23 @@ class Two_Factor_Core {
 		 * Such a plugin would cause self::filter_authenticate_block_cookies() to run and add this filter.
 		 */
 		remove_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
+
+		// Attach two-factor status to the session.
+		add_filter( 'attach_session_information',
+			function( $session, $user_id ) use( $user, $provider ) {
+				if ( $user_id !== $user->ID ) {
+					return $session;
+				}
+
+				$session['two-factor-timestamp'] = time();
+				$session['two-factor-provider']  = get_class( $provider );
+
+				return $session;
+			},
+			10,
+			2
+		);
+
 		wp_set_auth_cookie( $user->ID, $rememberme );
 
 		do_action( 'two_factor_user_authenticated', $user );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1084,7 +1084,7 @@ class Two_Factor_Core {
 	/**
 	 * Determine if the current user session is logged in with 2FA.
 	 *
-	 * @since 0.8.0
+	 * @since 0.9.0
 	 *
 	 * @return int|false The last time the two-factor was validated on success, false if not currently using a 2FA session.
 	 */
@@ -1126,9 +1126,9 @@ class Two_Factor_Core {
 	 * Login form validation.
 	 *
 	 * This function exists for unit testing, as `exit` prevents testing.
-	 * This function intends on the caller exiting after calling.
+	 * This function expects the caller exiting after calling.
 	 *
-	 * @since x.x
+	 * @since 0.9.0
 	 *
 	 * @param WP_User $user            The WP_User instance.
 	 * @param string  $nonce           The nonce provided.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -852,7 +852,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * Validate that a simulated 2fa login sets the session two-factor data.
 	 *
 	 * @covers Two_Factor_Core::is_current_user_session_two_factor()
-	 * @covers Two_Factor_Core::login_form_validate_2fa()
+	 * @covers Two_Factor_Core::_login_form_validate_2fa()
 	 */
 	public function test_is_current_user_session_two_factor_with_two_factor() {
 		$user = $this->get_dummy_user( array( 'Two_Factor_Dummy' => 'Two_Factor_Dummy' ) );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -820,7 +820,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * Validate that a non-2fa login doesn't set the session two-factor data.
 	 *
 	 * @covers Two_Factor_Core::is_current_user_session_two_factor()
-	 * @covers Two_Factor_Core::login_form_validate_2fa()
 	 */
 	public function test_is_current_user_session_two_factor_without_two_factor() {
 		$user = $this->get_dummy_user();

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -864,14 +864,8 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertNotFalse( $login_nonce );
 
-		$_REQUEST['wp-auth-id']    = $user->ID;
-		$_REQUEST['wp-auth-nonce'] = $login_nonce['key'];
-		$_REQUEST['provider']      = 'Two_Factor_Dummy';
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_REQUEST['redirect_to']   = '';
-
 		ob_start();
-		Two_Factor_Core::_login_form_validate_2fa();
+		Two_Factor_Core::_login_form_validate_2fa( $user, $login_nonce['key'], 'Two_Factor_Dummy', '', true );
 		ob_end_clean();
 
 		$this->assertNotEmpty( $_COOKIE[ AUTH_COOKIE ] );


### PR DESCRIPTION
This PR is part of some larger work for #484.

This PR causes the two-factor timestamp and provider to be stored in the user session, which can be later used to validate that the user session is two-factor authenticated.

|Before|After|
|---|---|
| <img width="791" alt="Screenshot 2023-02-20 at 2 45 59 pm" src="https://user-images.githubusercontent.com/767313/220011599-86bc00df-6ecb-4534-8a7b-6c9142720522.png"> | <img width="782" alt="Screenshot 2023-02-20 at 2 45 46 pm" src="https://user-images.githubusercontent.com/767313/220011622-bcbcdd63-34e8-4629-ab55-5ebbc19983f2.png"> |

Code Notes:
 - The 'attach_session_information' hook is poorly designed for this case, requiring the usage of an anonymous function so as to retrieve the details from the current-scope of the class.
 - It's possible not to use the callback (See the commit history where I've gone back and forth) by creating the session token yourself and passing that into `wp_set_auth_cookie()`, but that requires the caller to duplicate significantly more code than this option.
 - Note: The screenshots were taken with 0749b4adc0f483bd2c44e05d63f783786281b59c which places the extra array fields at the end, with dbee8261096062aa08cf49299eabb642f8ffdb7c the fields are placed at the start of the array. This has no meaningful effect.
 - Unit testing this should be possible, but has not been included at time of PR creation.

To test, you can use something like `$session = WP_Session_Tokens::get_instance( $user->ID )->get( wp_get_session_token() );` on an admin page to inspect the current sessions session, this is what's used in the above screenshots.