### PR TITLE
Document the TOTP Filters, add Issuer filter

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -215,9 +215,15 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	public static function generate_qr_code_url( $user, $secret_key ) {
 		$site_name = get_bloginfo( 'name', 'display' );
 
-		// Must follow TOTP format for a "label":
-		// https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label
-		// Do not URL encode, that will be done later.
+		/**
+		 * Filter the Label for the TOTP.
+		 * 
+		 * Must follow the TOTP format for a "label". Do not URL Encode.
+		 *
+		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label
+		 * @param string  $totp_title The label for the TOTP.
+		 * @param WP_User $user       The User object.
+		 */
 		$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login, $user );
 
 		$totp_url = add_query_arg(
@@ -228,8 +234,15 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			'otpauth://totp/' . rawurlencode( $totp_title )
 		);
 
-		// Must follow TOTP format:
-		// https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+		/**
+		 * Filter the TOTP generated URL.
+		 *
+		 * Must follow the TOTP format. Do not URL Encode.
+		 *
+		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+		 * @param string  $totp_url The TOTP URL.
+		 * @param WP_User $user     The user object.
+		 */
 		$totp_url = apply_filters( 'two_factor_totp_url', $totp_url, $user );
 		$totp_url = esc_url( $totp_url, array( 'otpauth' ) );
 

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -220,7 +220,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		 *
 		 * Must follow the TOTP format for a "issuer". Do not URL Encode.
 		 *
-		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label
+		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#issuer
 		 * @param string $issuer The issuer for TOTP.
 		 */
 		$issuer = apply_filters( 'two_factor_totp_issuer', $issuer );

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -216,7 +216,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$issuer = get_bloginfo( 'name', 'display' );
 
 		/**
-		 * Filter the Issuer for the TOTP. Do not URL Encode.
+		 * Filter the Issuer for the TOTP.
 		 *
 		 * Must follow the TOTP format for a "issuer". Do not URL Encode.
 		 *

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -213,7 +213,17 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public static function generate_qr_code_url( $user, $secret_key ) {
-		$site_name = get_bloginfo( 'name', 'display' );
+		$issuer = get_bloginfo( 'name', 'display' );
+
+		/**
+		 * Filter the Issuer for the TOTP. Do not URL Encode.
+		 *
+		 * Must follow the TOTP format for a "issuer". Do not URL Encode.
+		 *
+		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label
+		 * @param string $issuer The issuer for TOTP.
+		 */
+		$issuer = apply_filters( 'two_factor_totp_issuer', $issuer );
 
 		/**
 		 * Filter the Label for the TOTP.
@@ -223,13 +233,14 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label
 		 * @param string  $totp_title The label for the TOTP.
 		 * @param WP_User $user       The User object.
+		 * @param string  $issuer     The issuer of the TOTP. This should be the prefix of the result.
 		 */
-		$totp_title = apply_filters( 'two_factor_totp_title', $site_name . ':' . $user->user_login, $user );
+		$totp_title = apply_filters( 'two_factor_totp_title', $issuer . ':' . $user->user_login, $user, $issuer );
 
 		$totp_url = add_query_arg(
 			array(
 				'secret' => rawurlencode( $secret_key ),
-				'issuer' => rawurlencode( $site_name ),
+				'issuer' => rawurlencode( $issuer ),
 			),
 			'otpauth://totp/' . rawurlencode( $totp_title )
 		);


### PR DESCRIPTION
In https://github.com/WordPress/wporg-two-factor/issues/69 it's been realised that the TOTP plugin has a `two_factor_totp_title` filter for the label, but doesn't have one for the `issuer`.

The label is supposed to be in the format of `Issuer: $user` but others may incorrectly only change the prefix of the label without also changing the issuer details.

This PR does two things:
 - Documents the existing filters
 - Adds a `two_factor_totp_issuer` filter to change the Site name that's then used as part of the label.