### PR TITLE
Support login-by-email in maybe_show_reset_password_notice().

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -661,7 +661,20 @@ class Two_Factor_Core {
 			return $errors;
 		}
 
-		$attempted_user     = get_user_by( 'login', $_POST['log'] );
+		if ( ! isset( $_POST['log'] ) ) {
+			return $errors;
+		}
+
+		$user_name      = sanitize_user( wp_unslash( $_POST['log'] ) );
+		$attempted_user = get_user_by( 'login', $user_name );
+		if ( ! $attempted_user && str_contains( $user_name, '@' ) ) {
+			$attempted_user = get_user_by( 'email', $user_name );
+		}
+
+		if ( ! $attempted_user ) {
+			return $errors;
+		}
+		
 		$password_was_reset = get_user_meta( $attempted_user->ID, self::USER_PASSWORD_WAS_RESET_KEY, true );
 
 		if ( ! $password_was_reset ) {


### PR DESCRIPTION
The new reset-password code added in #482 / #477 fails to take into consideration that the user may have logged in with an email.

This PR does two things:
 - Defensive checks, which is especially relevant if a non-username/email login handler is in play
 - Fetches a user by email if required

The code here was copied from [here](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-login.php#L1212-L1227) with the addition of replacing `strpos` with `str_contains` for readability.

The code currently triggers a PHP notice such as this during login with a bad password, if email is used:
```
E_NOTICE: Trying to get property 'ID' of non-object in wp-content/plugins/two-factor/class-two-factor-core.php:665
```

