### PR TITLE
Standardise on `int|WP_User` input to the "for user" functions

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -347,12 +347,18 @@ class Two_Factor_Core {
 	/**
 	 * Get all Two-Factor Auth providers that are enabled for the specified|current user.
 	 *
-	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @param int|string|WP_User $user WP_User object of the logged-in user.
 	 * @return array
 	 */
 	public static function get_enabled_providers_for_user( $user = null ) {
-		if ( empty( $user ) || ! is_a( $user, 'WP_User' ) ) {
+		if ( null === $user ) {
 			$user = wp_get_current_user();
+		} else {
+			$user = new WP_User( $user );
+		}
+
+		if ( ! $user->exists() ) {
+			return array();
 		}
 
 		$providers         = self::get_providers();
@@ -374,12 +380,18 @@ class Two_Factor_Core {
 	/**
 	 * Get all Two-Factor Auth providers that are both enabled and configured for the specified|current user.
 	 *
-	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @param int|string|WP_User $user WP_User object of the logged-in user.
 	 * @return array
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
-		if ( empty( $user ) || ! is_a( $user, 'WP_User' ) ) {
+		if ( null === $user ) {
 			$user = wp_get_current_user();
+		} else {
+			$user = new WP_User( $user );
+		}
+
+		if ( ! $user->exists() ) {
+			return array();
 		}
 
 		$providers            = self::get_providers();
@@ -404,8 +416,12 @@ class Two_Factor_Core {
 	 * @return object|null
 	 */
 	public static function get_primary_provider_for_user( $user_id = null ) {
-		if ( empty( $user_id ) || ! is_numeric( $user_id ) ) {
+		if ( null === $user_id ) {
 			$user_id = get_current_user_id();
+		}
+
+		if ( ! $user_id || ! is_numeric( $user_id ) ) {
+			return null;
 		}
 
 		$providers           = self::get_providers();

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -463,11 +463,11 @@ class Two_Factor_Core {
 	 *
 	 * @since 0.1-dev
 	 *
-	 * @param int $user_id Optional. User ID. Default is 'null'.
+	 * @param int|WP_User $user Optonal. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return bool
 	 */
-	public static function is_user_using_two_factor( $user_id = null ) {
-		$provider = self::get_primary_provider_for_user( $user_id );
+	public static function is_user_using_two_factor( $user = null ) {
+		$provider = self::get_primary_provider_for_user( $user );
 		return ! empty( $provider );
 	}
 
@@ -560,7 +560,7 @@ class Two_Factor_Core {
 	/**
 	 * If the current user can login via API requests such as XML-RPC and REST.
 	 *
-	 * @param  integer $user_id User ID.
+	 * @param integer $user_id User ID.
 	 *
 	 * @return boolean
 	 */

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -345,12 +345,15 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Get all Two-Factor Auth providers that are enabled for the specified|current user.
+	 * Fetch the WP_User object for a provided input.
 	 *
-	 * @param int|WP_User $user Optonal. User ID, or WP_User object of the the user. Defaults to current user.
-	 * @return array
+	 * @since 0.8.0
+	 *
+	 * @param int|WP_User $user Optional. The WP_User or user ID. Defaults to current user.
+	 *
+	 * @return false|WP_User WP_User on success, false on failure.
 	 */
-	public static function get_enabled_providers_for_user( $user = null ) {
+	public static function fetch_user( $user = null ) {
 		if ( null === $user ) {
 			$user = wp_get_current_user();
 		} elseif ( ! ( $user instanceof WP_User ) ) {
@@ -358,6 +361,21 @@ class Two_Factor_Core {
 		}
 
 		if ( ! $user || ! $user->exists() ) {
+			return false;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Get all Two-Factor Auth providers that are enabled for the specified|current user.
+	 *
+	 * @param int|WP_User $user Optonal. User ID, or WP_User object of the the user. Defaults to current user.
+	 * @return array
+	 */
+	public static function get_enabled_providers_for_user( $user = null ) {
+		$user = self::fetch_user( $user );
+		if ( ! $user ) {
 			return array();
 		}
 
@@ -384,13 +402,8 @@ class Two_Factor_Core {
 	 * @return array
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
-		if ( null === $user ) {
-			$user = wp_get_current_user();
-		} elseif ( ! ( $user instanceof WP_User ) ) {
-			$user = get_user_by( 'id', $user );
-		}
-
-		if ( ! $user || ! $user->exists() ) {
+		$user = self::fetch_user( $user );
+		if ( ! $user ) {
 			return array();
 		}
 
@@ -416,13 +429,8 @@ class Two_Factor_Core {
 	 * @return object|null
 	 */
 	public static function get_primary_provider_for_user( $user = null ) {
-		if ( null === $user ) {
-			$user = wp_get_current_user();
-		} elseif ( ! ( $user instanceof WP_User ) ) {
-			$user = get_user_by( 'id', $user );
-		}
-
-		if ( ! $user || ! $user->exists() ) {
+		$user = self::fetch_user( $user );
+		if ( ! $user ) {
 			return null;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -347,17 +347,17 @@ class Two_Factor_Core {
 	/**
 	 * Get all Two-Factor Auth providers that are enabled for the specified|current user.
 	 *
-	 * @param int|string|WP_User $user WP_User object of the logged-in user.
+	 * @param int|WP_User $user Optonal. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return array
 	 */
 	public static function get_enabled_providers_for_user( $user = null ) {
 		if ( null === $user ) {
 			$user = wp_get_current_user();
-		} else {
-			$user = new WP_User( $user );
+		} elseif ( ! ( $user instanceof WP_User ) ) {
+			$user = get_user_by( 'id', $user );
 		}
 
-		if ( ! $user->exists() ) {
+		if ( ! $user || ! $user->exists() ) {
 			return array();
 		}
 
@@ -380,18 +380,18 @@ class Two_Factor_Core {
 	/**
 	 * Get all Two-Factor Auth providers that are both enabled and configured for the specified|current user.
 	 *
-	 * @param int|string|WP_User $user WP_User object of the logged-in user.
+	 * @param int|WP_User $user Optonal. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return array
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
 		if ( null === $user ) {
 			$user = wp_get_current_user();
-		} else {
-			$user = new WP_User( $user );
+		} elseif ( ! ( $user instanceof WP_User ) ) {
+			$user = get_user_by( 'id', $user );
 		}
 
-		if ( ! $user->exists() ) {
-			return array();
+		if ( ! $user || ! $user->exists() ) {
+			return null;
 		}
 
 		$providers            = self::get_providers();

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -174,7 +174,33 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
 		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
 
+		// Revert back to the previous user
 		wp_set_current_user( $this->old_user_id );
+
+		// Verify the counts are still correct for that user ID.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		$this->clean_dummy_user();
+	}
+
+	/**
+	 * Verify enabled providers for invalid input is empty.
+	 *
+	 * @covers Two_Factor_Core::get_enabled_providers_for_user
+	 * @covers Two_Factor_Core::get_available_providers_for_user
+	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 */
+	public function test_get_enabled_providers_for_user_bad_input() {
+		$user = $this->get_dummy_user();
+
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		// Check that checking for an invalid input returns 0.
+		$this->assertCount( 0, Two_Factor_Core::get_available_providers_for_user( 'bad-input' ) );
+		$this->assertCount( 0, Two_Factor_Core::get_enabled_providers_for_user( 'bad-input' ) );
+
 		$this->clean_dummy_user();
 	}
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -138,6 +138,27 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers Two_Factor_Core::fetch_user
+	 */
+	public function test_fetch_user() {
+		$this->assertFalse( Two_Factor_Core::fetch_user( null ) );
+
+		$logged_in = self::factory()->user->create_and_get();
+		wp_set_current_user( $logged_in->ID );
+
+		$fetched = Two_Factor_Core::fetch_user( null );
+		$this->assertSame( $logged_in->ID, $fetched->ID );
+
+		$logged_out = self::factory()->user->create_and_get();
+
+		$fetched = Two_Factor_Core::fetch_user( $logged_out->ID );
+		$this->assertSame( $logged_out->ID, $fetched->ID );
+
+		$fetched = Two_Factor_Core::fetch_user( $logged_out );
+		$this->assertSame( $logged_out->ID, $fetched->ID );
+	}
+
+	/**
 	 * Verify enabled providers for non-logged-in user.
 	 *
 	 * @covers Two_Factor_Core::get_enabled_providers_for_user

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -188,6 +188,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * @covers Two_Factor_Core::get_enabled_providers_for_user
 	 * @covers Two_Factor_Core::get_available_providers_for_user
 	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 * @covers Two_Factor_Core::fetch_user
 	 */
 	public function test_get_enabled_providers_for_user_logged_in_and_set_provider() {
 		$user = $this->get_dummy_user();
@@ -211,6 +212,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * @covers Two_Factor_Core::get_enabled_providers_for_user
 	 * @covers Two_Factor_Core::get_available_providers_for_user
 	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 * @covers Two_Factor_Core::fetch_user
 	 */
 	public function test_get_enabled_providers_for_user_bad_input() {
 		$user = $this->get_dummy_user();


### PR DESCRIPTION
Currently the various API-level functions accept two main inputs: `ID` or `WP_User`, and assumes that if not provided the function should operate on the current user.

Accepts `WP_User`:
 - `Two_Factor_Core::get_enabled_providers_for_user()`
 - `Two_Factor_Core::get_available_providers_for_user()`

Accepts `ID`:
 - `Two_Factor_Core::get_primary_provider_for_user()`
 - `Two_Factor_Core::is_user_using_two_factor()`

When a WP_User is passed in place of an ID, or an ID in place of a WP_User, the functions operate on the current user, which could lead to unexpected responses.


This PR standardises the above 4 functions to:
 - Accept `int|WP_User`
 - Only default to the current user when no parameters are passed / `null` is passed (The default value for the function param)
 - Uses the same user validation logic via a helper method, rather than duplicating logic.


For example, currently:
```php
wp_set_current_user( 1 );
$incorrect = Two_Factor_Core::get_enabled_providers_for_user( 2 );
$correct = Two_Factor_Core::get_enabled_providers_for_user( get_user_by( 'id', 2 ) );

// $incorrect is for user_id 1, despite 2 being passed in.
// $correct is correct, because a WP_User was passed
```

After this PR, both `$incorrect` and `$correct` in the above would contain the details for user 2.

I'll note that `is_user_api_login_enabled()` has not been touched, as the `$user_id` is not used for any logic within the function, and the onus is on the filtering functions to check the value of `$user_id` passed.