### PR TITLE
Add/repo templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,72 @@
+name: "Bug report"
+description: "Report a bug with the Two-Factor plugin for WordPress."
+labels: "Bug"
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!  Please fill in as much of the template below as you can.  If this is a security issue, please report it in HackerOne instead: https://hackerone.com/wordpress.
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please write a clear and concise description of the bug, including what you expect to happen and what is currently happening.
+          placeholder: |
+              Feature '...' is not working properly. I expect '...' to happen, but '...' happens instead.
+      validations:
+          required: true
+          
+    - type: textarea
+      attributes:
+          label: Steps to Reproduce
+          description: Please write the steps needed to reproduce the bug.
+          placeholder: |
+              1. Go to '...'.
+              2. Click on '...'.
+              3. Scroll down to '...'.
+              4. See error.
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Screenshots, screen recording, code snippet
+          description: |
+              If possible, please upload a screenshot or screen recording which demonstrates the bug. You can use LIEcap to create a GIF screen recording: https://www.cockos.com/licecap/
+              Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+              For small snippets paste it directly here, or you can use GitHub Gist to share multiple code files: https://gist.github.com
+              Please ensure the shared code can be used by a developer to reproduce the issue—ideally it can be copied into a local development environment or executed in a browser console to help debug the issue
+      validations:
+          required: false
+          
+    - type: textarea
+      attributes:
+          label: Environment information
+          placeholder: |
+             - WordPress version and active Theme you are using.
+             - Browser(s) are you seeing the problem on.
+             - Device you are using and operating system (e.g. "Desktop with Windows 10", "iPhone with iOS 14", etc.).
+      validations:
+          required: false
+
+    - type: dropdown
+      id: existing
+      attributes:
+          label: Please confirm that you have searched existing issues in this repository.
+          description: You can do this by searching https://github.com/WordPress/two-factor/issues and making sure the bug is not related to another plugin.
+          multiple: true
+          options:
+              - 'Yes'
+              - 'No'
+      validations:
+          required: true
+
+    - type: dropdown
+      id: plugins
+      attributes:
+          label: Please confirm that you have tested with all plugins deactivated except Two-Factor.
+          multiple: true
+          options:
+              - 'Yes'
+              - 'No'
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,55 @@
+name: "Enhancement"
+description: "Suggest an idea for a feature or enhancement to the Two-Factor plugin for WordPress."
+labels: "type:enhancement"
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thank you for suggesting an idea to make things better.  Please fill in as much of the template below as you can.
+    - type: textarea
+      attributes:
+          label: Is your enhancement related to a problem? Please describe.
+          description: Please describe the problem you are trying to solve.
+          placeholder: |
+              "I'm always frustrated when ..." or "It is currently difficult to ...".
+      validations:
+          required: true
+
+    - type: textarea
+      attributes:
+          label: Proposed Solution
+          description: |
+              Please outline the feature or enhancement that you want and how it addresses any problem identified above.
+      validations:
+          required: false
+
+    - type: textarea
+      attributes:
+          label: Designs
+          description: |
+              If applicable, add mockups/screenshots/etc. to help explain your idea.
+              Tip: You can attach images or videos by clicking this area to highlight it and then dragging files in.
+      validations:
+          required: false
+
+    - type: textarea
+      attributes:
+          label: Describe alternatives you've considered
+          description: |
+              Please describe alternative solutions or features you have considered.
+          placeholder: |
+             I have also considered `...describe alternative...`, however I feel that my solution described above is better because of `...reason...`.
+      validations:
+          required: false
+
+    - type: dropdown
+      id: existing
+      attributes:
+          label: Please confirm that you have searched existing issues in this repository.
+          description: You can do this by searching https://github.com/WordPress/two-factor/issues and making sure the bug is not related to another plugin.
+          multiple: true
+          options:
+              - 'Yes'
+              - 'No'
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: General help request
+      url: https://wordpress.org/support/plugin/two-factor/
+      about: For general help requests, create a new topic in the Two-Factor support forum on WordPress.org.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->
+
+## What?
+<!-- In a few words, what is the PR actually doing? -->
+
+## Why?
+<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
+
+## How?
+<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->
+
+## Testing Instructions
+<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
+
+## Screenshots or screencast
+<!-- if applicable -->
+
+## Changelog Entry
+<!--
+Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
+> Added - New feature.
+> Changed - Existing functionality.
+> Deprecated - Soon-to-be removed feature.
+> Removed - Feature.
+> Fixed - Bug fix.
+> Security - Vulnerability.


### PR DESCRIPTION
This PR adds Issue Templates and a PR Template to try and ensure a common input on new issues and PRs here.  Also, in researching items going into the 0.8.0 release it became apparent that generating the changelog was going to take some time to assess what was being done in some of the PRs, so including a request for a Changelog Entry in future PRs will help significantly simplify that task.

Note that these templates are based off a blend of ones in https://github.com/10up/.github/tree/trunk/.github and https://github.com/WordPress/gutenberg/tree/trunk/.github.