### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Install NPM dependencies
         run: npm install
 
+      - name: Build plugin
+        run: npm run build
       - name: WordPress Plugin Deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           generate-zip: true
         env:
+          BUILD_DIR: dist
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,7 @@
 name: Deploy
 
-# Run deploy only on tag and master builds.
+# Run deploy only on publised releases.
 on:
-  push:
-    branches:
-      - master
   release:
     types: [published]
 
@@ -32,15 +29,21 @@ jobs:
       - name: Install NPM dependencies
         run: npm install
 
-      - name: Authenticate with WordPress.org SVN
-        run: svn info --non-interactive --username "${{ secrets.SVN_USERNAME }}" --password "${{ secrets.SVN_PASSWORD }}" https://plugins.svn.wordpress.org/two-factor/
-
-      - name: Deploy to WordPress.org SVN
+      - name: WordPress Plugin Deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: true
         env:
-          DEPLOY_SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          DEPLOY_TRUNK: ${{ contains( github.ref_name, 'master' ) }}
-          DEPLOY_TAG: ${{ contains( github.ref_type, 'tag' ) }}
-          DEPLOY_SKIP_CONFIRMATION: true
-        # Disable deployments while they are failing for unknown reason.
-        if: env.DEPLOY_SVN_USERNAME && false
-        run: npm run deploy
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.deploy.outputs.zip-path }}
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Updates the [current deploy.yml file](https://github.com/WordPress/two-factor/blob/c0eae28ce5c83d28bdf810dc940f33febe38a0b7/.github/workflows/deploy.yml) by swapping in https://github.com/10up/action-wordpress-plugin-deploy for the steps to deploy to SVN.

## Why?
Deploys to SVN are disabled as they're currently failing, see: https://github.com/WordPress/two-factor/blob/c0eae28ce5c83d28bdf810dc940f33febe38a0b7/.github/workflows/deploy.yml#L44.

## How?
Replaces the previous `Authenticate with WordPress.org SVN` and `Deploy to WordPress.org SVN` steps with `WordPress Plugin Deploy` and `Upload release asset` steps utilizing the https://github.com/10up/action-wordpress-plugin-deploy GitHub Action.

Note that this also ONLY deploys on published releases and no longer on ANY merge to `master` which means that only newly released versions will be deployed to SVN and any individual merges to `master` on GitHub will no longer be deployed to `trunk` on SVN.

## Testing Instructions
This is a tough one, pretty much need to YOLO into a published release and 🤞🏼 that the Action processes correctly (e.g., that `SVN_USERNAME`, `SVN_PASSWORD`, and `GITHUB_TOKEN` are accurate).

## Screenshots or screencast
n/a

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Deploy workflow uses `10up/action-wordpress-plugin-deploy` instead of a manual connection to SVN.