### PR TITLE
Allow TOTP keys to be filterable

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -420,7 +420,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function get_user_totp_key( $user_id ) {
-		return (string) get_user_meta( $user_id, self::SECRET_META_KEY, true );
+		$meta = (string) get_user_meta( $user_id, self::SECRET_META_KEY, true );
+		return apply_filters( 'two_factor_totp_get_user_totp_key', $meta, $user_id );
 	}
 
 	/**
@@ -432,6 +433,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @return boolean If the key was stored successfully.
 	 */
 	public function set_user_totp_key( $user_id, $key ) {
+		$key = apply_filters( 'two_factor_totp_set_user_totp_key', $key, $user_id );
 		return update_user_meta( $user_id, self::SECRET_META_KEY, $key );
 	}
 


### PR DESCRIPTION
## What?

Allow TOTP keys to be filtered on save/retrieval.

## Why?
Since the discussion in https://github.com/WordPress/two-factor/pull/389 seems to be on-going, the following should allow users of the plugin to decide how they would like to approach the encryption part.

## How?
Adds filters on save and retrieval.

## Testing Instructions
Test adding filters, and making sure they are saved.

## Changelog Entry
Added - filters to TOTP keys.
