### PR TITLE
Add a filter to filter the classname used for a provider

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -411,9 +411,9 @@ class Two_Factor_Core {
 		$enabled_providers    = self::get_enabled_providers_for_user( $user );
 		$configured_providers = array();
 
-		foreach ( $providers as $classname => $provider ) {
-			if ( in_array( $classname, $enabled_providers, true ) && $provider->is_available_for_user( $user ) ) {
-				$configured_providers[ $classname ] = $provider;
+		foreach ( $providers as $provider_name => $provider ) {
+			if ( in_array( $provider_name, $enabled_providers, true ) && $provider->is_available_for_user( $user ) ) {
+				$configured_providers[ $provider_name ] = $provider;
 			}
 		}
 
@@ -712,10 +712,10 @@ class Two_Factor_Core {
 			$provider = call_user_func( array( $provider, 'get_instance' ) );
 		}
 
-		$provider_class = get_class( $provider );
+		$provider_name = $provider->get_name();
 
 		$available_providers = self::get_available_providers_for_user( $user );
-		$backup_providers    = array_diff_key( $available_providers, array( $provider_class => null ) );
+		$backup_providers    = array_diff_key( $available_providers, array( $provider_name => null ) );
 		$interim_login       = isset( $_REQUEST['interim-login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$rememberme = intval( self::rememberme() );
@@ -735,7 +735,7 @@ class Two_Factor_Core {
 		?>
 
 		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( self::login_url( array( 'action' => 'validate_2fa' ), 'login_post' ) ); ?>" method="post" autocomplete="off">
-				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_class ); ?>" />
+				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_name ); ?>" />
 				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( $user->ID ); ?>" />
 				<input type="hidden" name="wp-auth-nonce" id="wp-auth-nonce" value="<?php echo esc_attr( $login_nonce ); ?>" />
 				<?php if ( $interim_login ) { ?>
@@ -1428,7 +1428,7 @@ class Two_Factor_Core {
 		$primary_provider  = self::get_primary_provider_for_user( $user->ID );
 
 		if ( ! empty( $primary_provider ) && is_object( $primary_provider ) ) {
-			$primary_provider_key = get_class( $primary_provider );
+			$primary_provider_key = $primary_provider->get_name();
 		} else {
 			$primary_provider_key = null;
 		}
@@ -1452,24 +1452,24 @@ class Two_Factor_Core {
 							</tr>
 						</thead>
 						<tbody>
-						<?php foreach ( self::get_providers() as $class => $object ) : ?>
+						<?php foreach ( self::get_providers() as $provider_name => $object ) : ?>
 							<tr>
-								<th scope="row"><input id="enabled-<?php echo esc_attr( $class ); ?>" type="checkbox" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php echo esc_attr( $class ); ?>" <?php checked( in_array( $class, $enabled_providers, true ) ); ?> /></th>
-								<th scope="row"><input type="radio" name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>" value="<?php echo esc_attr( $class ); ?>" <?php checked( $class, $primary_provider_key ); ?> /></th>
+								<th scope="row"><input id="enabled-<?php echo esc_attr( $provider_name ); ?>" type="checkbox" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php echo esc_attr( $provider_name ); ?>" <?php checked( in_array( $provider_name, $enabled_providers, true ) ); ?> /></th>
+								<th scope="row"><input type="radio" name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>" value="<?php echo esc_attr( $provider_name ); ?>" <?php checked( $provider_name, $primary_provider_key ); ?> /></th>
 								<td>
-									<label class="two-factor-method-label" for="enabled-<?php echo esc_attr( $class ); ?>"><?php echo esc_html( $object->get_label() ); ?></label>
+									<label class="two-factor-method-label" for="enabled-<?php echo esc_attr( $provider_name ); ?>"><?php echo esc_html( $object->get_label() ); ?></label>
 									<?php
 										/**
 										 * Fires after user options are shown.
 										 *
-										 * Use the {@see 'two_factor_user_options_' . $class } hook instead.
+										 * Use the {@see 'two_factor_user_options_' . $provider_name } hook instead.
 										 *
 										 * @deprecated 0.7.0
 										 *
 										 * @param WP_User $user The user.
 										 */
-										do_action_deprecated( 'two-factor-user-options-' . $class, array( $user ), '0.7.0', 'two_factor_user_options_' . $class );
-										do_action( 'two_factor_user_options_' . $class, $user );
+										do_action_deprecated( 'two-factor-user-options-' . $provider_name, array( $user ), '0.7.0', 'two_factor_user_options_' . $provider_name );
+										do_action( 'two_factor_user_options_' . $provider_name, $user );
 									?>
 								</td>
 							</tr>

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -182,6 +182,12 @@ class Two_Factor_Core {
 		foreach ( $providers as $provider_name => $path ) {
 			include_once $path;
 
+			/**
+			 * Filters the classname for a provider.
+			 *
+			 * @param string $provider_name The provider name, which is the default for the Classname.
+			 * @param string $path          The provided provider path to be included.
+			 */
 			$class = apply_filters( 'two_factor_provider_classname', $provider_name, $path );
 
 			/**

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -182,13 +182,15 @@ class Two_Factor_Core {
 		foreach ( $providers as $provider_key => $path ) {
 			include_once $path;
 
+			$class = $provider_key;
+
 			/**
-			 * Filters the classname for a provider.
+			 * Filters the classname for a provider. The dynamic portion of the filter is the defined providers key.
 			 *
-			 * @param string $provider_key The provider name, which is the default for the Classname.
-			 * @param string $path         The provided provider path to be included.
+			 * @param string $class The PHP Classname of the provider.
+			 * @param string $path  The provided provider path to be included.
 			 */
-			$class = apply_filters( 'two_factor_provider_classname', $provider_key, $path );
+			$class = apply_filters( "two_factor_provider_classname_{$provider_key}", $class, $path );
 
 			/**
 			 * Confirm that it's been successfully included before instantiating.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -179,17 +179,19 @@ class Two_Factor_Core {
 		/**
 		 * For each filtered provider,
 		 */
-		foreach ( $providers as $class => $path ) {
+		foreach ( $providers as $provider_name => $path ) {
 			include_once $path;
+
+			$class = apply_filters( 'two_factor_provider_classname', $provider_name, $path );
 
 			/**
 			 * Confirm that it's been successfully included before instantiating.
 			 */
 			if ( class_exists( $class ) ) {
 				try {
-					$providers[ $class ] = call_user_func( array( $class, 'get_instance' ) );
+					$providers[ $provider_name ] = call_user_func( array( $class, 'get_instance' ) );
 				} catch ( Exception $e ) {
-					unset( $providers[ $class ] );
+					unset( $providers[ $provider_name ] );
 				}
 			}
 		}

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -29,20 +29,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	const NUMBER_OF_CODES = 10;
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	public static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class();
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-dummy.php
+++ b/providers/class-two-factor-dummy.php
@@ -15,20 +15,6 @@
 class Two_Factor_Dummy extends Two_Factor_Provider {
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	public static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class();
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -36,20 +36,6 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	const INPUT_NAME_RESEND_CODE = 'two-factor-email-code-resend';
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @since 0.1-dev
-	 */
-	public static function get_instance() {
-		static $instance;
-		$class = __CLASS__;
-		if ( ! is_a( $instance, $class ) ) {
-			$instance = new $class();
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-fido-u2f.php
+++ b/providers/class-two-factor-fido-u2f.php
@@ -43,21 +43,6 @@ class Two_Factor_FIDO_U2F extends Two_Factor_Provider {
 	const U2F_ASSET_VERSION = '0.2.1';
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @return \Two_Factor_FIDO_U2F
-	 */
-	public static function get_instance() {
-		static $instance;
-
-		if ( ! isset( $instance ) ) {
-			$instance = new self();
-		}
-
-		return $instance;
-	}
-
-	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -42,6 +42,17 @@ abstract class Two_Factor_Provider {
 	}
 
 	/**
+	 * Retrieves the provider name.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return get_class( $this );
+	}
+
+	/**
 	 * Prints the form that prompts the user to authenticate.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -24,11 +24,11 @@ abstract class Two_Factor_Provider {
 
 		$class_name = static::class;
 
-		if ( ! isset( $instance[ $class_name ] ) ) {
-			$instance[ $class_name ] = new $class_name;
+		if ( ! isset( $instances[ $class_name ] ) ) {
+			$instances[ $class_name ] = new $class_name;
 		}
 
-		return $instance[ $class_name ];
+		return $instances[ $class_name ];
 	}
 
 	/**

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -15,6 +15,23 @@
 abstract class Two_Factor_Provider {
 
 	/**
+	 * Ensures only one instance of the provider class exists in memory at any one time.
+	 *
+	 * @since 0.1-dev
+	 */
+	public static function get_instance() {
+		static $instances = array();
+
+		$class_name = static::class;
+
+		if ( ! isset( $instance[ $class_name ] ) ) {
+			$instance[ $class_name ] = new $class_name;
+		}
+
+		return $instance[ $class_name ];
+	}
+
+	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -42,13 +42,13 @@ abstract class Two_Factor_Provider {
 	}
 
 	/**
-	 * Retrieves the provider name.
+	 * Retrieves the provider key / slug.
 	 *
 	 * @since 0.9.0
 	 *
 	 * @return string
 	 */
-	public function get_name() {
+	public function get_key() {
 		return get_class( $this );
 	}
 

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -38,19 +38,6 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	private static $base_32_chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
 	/**
-	 * Ensures only one instance of this class exists in memory at any one time.
-	 *
-	 * @codeCoverageIgnore
-	 */
-	public static function get_instance() {
-		static $instance;
-		if ( ! isset( $instance ) ) {
-			$instance = new self();
-		}
-		return $instance;
-	}
-
-	/**
 	 * Class constructor. Sets up hooks, etc.
 	 *
 	 * @codeCoverageIgnore

--- a/tests/class-secure-dummy.php
+++ b/tests/class-secure-dummy.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Class for creating a dummy provider that never passes.
+ *
+ * This is a mock for unit testing the provider class name filter, and where authentication should never pass.
+ *
+ * @package Two_Factor
+ */
+class Two_Factor_Dummy_Secure extends Two_Factor_Dummy {
+
+	/**
+	 * Pretend to be the Two_Factor_Dummy provider.
+	 */
+	public function get_key() {
+		return 'Two_Factor_Dummy';
+	}
+
+	/**
+	 * Validates the users input token.
+	 *
+	 * In this class we just return false.
+	 *
+	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @return boolean
+	 */
+	public function validate_authentication( $user ) {
+		return false;
+	}
+
+}

--- a/tests/providers/class-two-factor-dummy-secure.php
+++ b/tests/providers/class-two-factor-dummy-secure.php
@@ -71,9 +71,9 @@ class Tests_Two_Factor_Dummy_Secure extends WP_UnitTestCase {
 		$providers = Two_Factor_Core::get_providers();
 
 		// Add filter, fetch, and then validate.
-		add_filter( 'two_factor_provider_classname', array( $this, 'filter_change_provider' ) );
+		add_filter( 'two_factor_provider_classname_Two_Factor_Dummy', array( $this, 'filter_change_provider' ) );
 		$filtered = Two_Factor_Core::get_providers();
-		remove_filter( 'two_factor_provider_classname', array( $this, 'filter_change_provider' ) );
+		remove_filter( 'two_factor_provider_classname_Two_Factor_Dummy', array( $this, 'filter_change_provider' ) );
 
 		$this->assertEquals( 'Two_Factor_Dummy',        get_class( $providers['Two_Factor_Dummy'] ) );
 		$this->assertNotEquals( 'Two_Factor_Dummy',     get_class( $filtered['Two_Factor_Dummy'] ) );
@@ -84,11 +84,7 @@ class Tests_Two_Factor_Dummy_Secure extends WP_UnitTestCase {
 	}
 
 	public function filter_change_provider( $provider_key ) {
-		if ( 'Two_Factor_Dummy' === $provider_key ) {
-			$provider_key = 'Two_Factor_Dummy_Secure';
-		}
-
-		return $provider_key;
+		return 'Two_Factor_Dummy_Secure';
 	}
 
 }

--- a/tests/providers/class-two-factor-dummy-secure.php
+++ b/tests/providers/class-two-factor-dummy-secure.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Test Two Factor Dummy.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Tests_Two_Factor_Dummy
+ *
+ * @package Two_Factor
+ * @group providers
+ * @group dummy
+ */
+class Tests_Two_Factor_Dummy_Secure extends WP_UnitTestCase {
+
+	/**
+	 * Instance of our provider class.
+	 *
+	 * @var Two_Factor_Dummy_Secure
+	 */
+	protected $provider;
+
+	/**
+	 * Set up a test case.
+	 *
+	 * @see WP_UnitTestCase_Base::set_up()
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->provider = Two_Factor_Dummy_Secure::get_instance();
+	}
+
+	public function test_get_key() {
+		$this->assertEquals( 'Two_Factor_Dummy', $this->provider->get_key() );
+	}
+
+	/**
+	 * Verify the contents of the authentication page.
+	 *
+	 * @covers Two_Factor_Dummy::authentication_page
+	 */
+	public function test_authentication_page() {
+
+		ob_start();
+		$this->provider->authentication_page( false );
+		$contents = ob_get_clean();
+
+		$this->assertStringContainsString( 'Are you really you?', $contents );
+		$this->assertStringContainsString( '<p class="submit">', $contents );
+		$this->assertStringContainsString( 'Yup', $contents );
+
+	}
+
+	/**
+	 * Verify that dummy validation returns false.
+	 *
+	 * @covers Two_Factor_Dummy::validate_authentication
+	 */
+	public function test_validate_authentication() {
+
+		$this->assertFalse( $this->provider->validate_authentication( false ) );
+
+	}
+
+	/**
+	 * Replace the Dummy provider with our custom provider.
+	 */
+	public function test_provider_classname_filter() {
+		$providers = Two_Factor_Core::get_providers();
+
+		// Add filter, fetch, and then validate.
+		add_filter( 'two_factor_provider_classname', array( $this, 'filter_change_provider' ) );
+		$filtered = Two_Factor_Core::get_providers();
+		remove_filter( 'two_factor_provider_classname', array( $this, 'filter_change_provider' ) );
+
+		$this->assertEquals( 'Two_Factor_Dummy',        get_class( $providers['Two_Factor_Dummy'] ) );
+		$this->assertNotEquals( 'Two_Factor_Dummy',     get_class( $filtered['Two_Factor_Dummy'] ) );
+		$this->assertEquals( 'Two_Factor_Dummy_Secure', get_class( $filtered['Two_Factor_Dummy'] ) );
+
+		$this->assertEquals( 'Two_Factor_Dummy', $providers['Two_Factor_Dummy']->get_key() );
+		$this->assertEquals( 'Two_Factor_Dummy', $filtered['Two_Factor_Dummy']->get_key() );
+	}
+
+	public function filter_change_provider( $provider_key ) {
+		if ( 'Two_Factor_Dummy' === $provider_key ) {
+			$provider_key = 'Two_Factor_Dummy_Secure';
+		}
+
+		return $provider_key;
+	}
+
+}

--- a/tests/providers/class-two-factor-provider.php
+++ b/tests/providers/class-two-factor-provider.php
@@ -65,4 +65,15 @@ class Tests_Two_Factor_Provider extends WP_UnitTestCase {
 		];
 	}
 
+	/**
+	 * Validate that Two_Factor_Provider::get_instance() always returns the same instance.
+	 *
+	 * @covers Two_Factor_Provider::get_instance
+	 */
+	function test_get_instance() {
+		$instance_one = Two_Factor_Dummy::get_instance();
+		$instance_two = Two_Factor_Dummy::get_instance();
+
+		$this->assertSame( $instance_one, $instance_two );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows for the classname of a provider to differ from it's "key" that's used within the application.
This was spurred by an attempt to simply extend a core provider with a custom one to override certain functions (instead of #545 ).

This has resulted in several changes:
 - Filter addition
 - Removing variables like 'class' and replacing them with 'provider_key'
 - Addition of a `Two_Factor_Provider::get_key()` which returns the providers 'key', which defaults to the class name as present.
 - removing `get_instance()` from each individual provider and moving it to the abstract `Two_Factor_Provider`, each provider had a slightly different one, and the usage of `__CLASS__` meant children of the provider had to override the `get_instance()` method as well.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

This allows for users of the plugin to overload a provider with a custom variant of the provider, without having to register an entirely new provider and migrate users over to it.

For example:
```php

add_filter( 'two_factor_provider_classname_Two_Factor_Totp', function( $provider ) {
	return 'Secured_Two_Factor_Totp';
} );

// Stores TOTP keys securely rot13'd.
class Secured_Two_Factor_Totp extends Two_Factor_Totp {
	// Pretend to be the Two_Factor_Totp class in the UI.
	public function get_key() {
		return 'Two_Factor_Totp';
	}

	// When saving the key, ensure it's rot13'd
	public function set_user_totp_key( $user_id, $key ) {
		$key = str_rot13( $key );
		return parent::set_user_totp_key( $user_id, $key );
	}

	// When fetching the key, rot13 it back.
	public function get_user_totp_key( $user_id ) {
		return str_rot13( parent::get_user_totp_key( $user_id ) );
	}
}

```

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

By allowing the classname to be filtered, external code can overload core providers with customisations without needing to duplicate the entire provider.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

 - Unit tests: `npm run test`
 - Add the above code into an mu-plugin, verify that you can setup TOTP and login, but once code is removed, the key is invalid.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Added - Better compatibility to allow overloading core Two Factor providers without duplicating the entire provider.
