### PR TITLE
Bump tested up to version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:              two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
 Requires at least: 4.3
-Tested up to:      6.0
+Tested up to:      6.2
 Requires PHP:      5.6
 Stable tag:        0.8.1
 


### PR DESCRIPTION
## What?
Update the "Tested up to" tag in the readme.txt file.

## Why?
If the tag does not match the current WordPress version, the "This plugin has not been tested with your current version of WordPress." warning is displayed when viewing the plugin details in wp-admin. Also, when searching for the plugin in wp-admin of a site, the notice "Untested with your version of WordPress" is shown.

## How?
The "Tested up to" tag has been set to 6.2 in the readme.txt file.
Validated:
- Email
- Time Based One-Time Password (TOTP)
- Backup Verification Codes (Single Use)
- Dummy Method

## Tickets
Fixes #540 
