### PR TITLE
Fixing bug where Super Admins cannot setup Time Based One-Time Password as first Two Factor option on WP VIP

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -61,7 +61,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				'args'                => array(
 					'user_id' => array(
 						'required' => true,
-						'type'     => 'number',
+						'type'     => 'integer',
 					),
 					'enable_provider' => array(
 						'required' => false,

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -70,7 +70,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 					),
 				),
@@ -83,7 +83,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 						'key'     => array(
 							'type'              => 'string',
@@ -223,7 +223,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 		/**
 		 * Filter the Label for the TOTP.
-		 * 
+		 *
 		 * Must follow the TOTP format for a "label". Do not URL Encode.
 		 *
 		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label


### PR DESCRIPTION
## What
Fixing bug where WP VIP Super Admins and WooCommerce shop_manager cannot setup Time Based One-Time Password as their first Two Factor option. Please have a look at #559 for more detailed information.

## Why
Fixes #559
Fixes #557

## How?
I am setting the controller parameter configuration to have user_id as an integer instead of a number because strict comparison requires matching types.

## Steps to Test

1. Setup a multisite
2. Create a new user that is a super_admin
3. Log in as the new super_admin
4. Go to `wp-admin` > `Edit Profile`
5. Submit an authentication code

## Changelog Entry
Fixing bug where WP VIP Super Admins and WooCommerce shop_manager cannot setup Time Based One-Time Password as their first Two Factor option

## Notes
Original PR: [https://github.com/Automattic/vip-go-mu-plugins/pull/4410](https://github.com/Automattic/vip-go-mu-plugins/pull/4410)
