### PR TITLE
Move inline JS to external scripts

### DIFF
--- a/js/admin-backup-codes.js
+++ b/js/admin-backup-codes.js
@@ -1,28 +1,38 @@
-(function($){
+(function(){
+	const backupCodes = document.getElementById( 'two-factor-backup-codes' ),
+		generateCodesButton = backupCodes.querySelector( '.button-two-factor-backup-codes-generate' ),
+		userId = backupCodes.dataset.userid || 0;
 
 	// Backup Codes generation
-	$( '.button-two-factor-backup-codes-generate' ).click( function() {
+	generateCodesButton.addEventListener( 'click', function(e) {
+		const codesCountDiv = backupCodes.querySelector( '.two-factor-backup-codes-count' ),
+			codeWrapper = backupCodes.querySelector( '.two-factor-backup-codes-wrapper' ),
+			codeList = backupCodes.querySelector( '.two-factor-backup-codes-unused-codes' ),
+			downloadButton = backupCodes.querySelector( '.button-two-factor-backup-codes-download' );
+
 		wp.apiRequest( {
 			method: 'POST',
-			path: <?php echo wp_json_encode( Two_Factor_Core::REST_NAMESPACE . '/generate-backup-codes' ); ?>,
+			path: 'two-factor/1.0/generate-backup-codes',
 			data: {
-				user_id: <?php echo wp_json_encode( $user->ID ); ?>
+				user_id: userId
 			}
 		} ).then( function( response ) {
-			var $codesList = $( '.two-factor-backup-codes-unused-codes' );
-
-			$( '.two-factor-backup-codes-wrapper' ).show();
-			$codesList.html( '' );
+			codeList.innerHTML = '';
 
 			// Append the codes.
 			for ( i = 0; i < response.codes.length; i++ ) {
-				$codesList.append( '<li>' + response.codes[ i ] + '</li>' );
+				codeList.innerHTML += '<li>' + response.codes[ i ] + '</li>';
 			}
 
+			// Display the section.
+			codeWrapper.style.display = 'block';
+
 			// Update counter.
-			$( '.two-factor-backup-codes-count' ).html( response.i18n.count );
-			$( '#two-factor-backup-codes-download-link' ).attr( 'href', response.download_link );
+			codesCountDiv.innerHTML = response.i18n.count;
+
+			// Update link.
+			downloadButton.href = response.download_link;
 		} );
 	} );
 
-})(jQuery);
+})();

--- a/js/admin-backup-codes.js
+++ b/js/admin-backup-codes.js
@@ -1,0 +1,28 @@
+(function($){
+
+	// Backup Codes generation
+	$( '.button-two-factor-backup-codes-generate' ).click( function() {
+		wp.apiRequest( {
+			method: 'POST',
+			path: <?php echo wp_json_encode( Two_Factor_Core::REST_NAMESPACE . '/generate-backup-codes' ); ?>,
+			data: {
+				user_id: <?php echo wp_json_encode( $user->ID ); ?>
+			}
+		} ).then( function( response ) {
+			var $codesList = $( '.two-factor-backup-codes-unused-codes' );
+
+			$( '.two-factor-backup-codes-wrapper' ).show();
+			$codesList.html( '' );
+
+			// Append the codes.
+			for ( i = 0; i < response.codes.length; i++ ) {
+				$codesList.append( '<li>' + response.codes[ i ] + '</li>' );
+			}
+
+			// Update counter.
+			$( '.two-factor-backup-codes-count' ).html( response.i18n.count );
+			$( '#two-factor-backup-codes-download-link' ).attr( 'href', response.download_link );
+		} );
+	} );
+
+})(jQuery);

--- a/js/admin-totp.js
+++ b/js/admin-totp.js
@@ -1,0 +1,76 @@
+(function($){
+
+	// TOTP QR Setup
+	var qr_generator = function() {
+		var link = document.querySelector( '#two-factor-qr-code a' );
+		if ( ! link ) {
+			return;
+		}
+
+		/*
+		* 0 = Automatically select the version, to avoid going over the limit of URL
+		*     length.
+		* L = Least amount of error correction, because it's not needed when scanning
+		*     on a monitor, and it lowers the image size.
+		*/
+		var qr = qrcode( 0, 'L' );
+
+		qr.addData( link.href );
+		qr.make();
+
+		link.innerHTML = qr.createSvgTag( 5 );
+	};
+
+	// Run now if the document is loaded, otherwise on DOMContentLoaded.
+	if ( document.readyState === 'complete' ) {
+		qr_generator();
+	} else {
+		window.addEventListener( 'DOMContentLoaded', qr_generator );
+	}
+
+	// TOTP Setup
+	$('.totp-submit').click( function( e ) {
+		e.preventDefault();
+		var key = $('#two-factor-totp-key').val(),
+			code = $('#two-factor-totp-authcode').val();
+
+		wp.apiRequest( {
+			method: 'POST',
+			path: <?php echo wp_json_encode( Two_Factor_Core::REST_NAMESPACE . '/totp' ); ?>,
+			data: {
+				user_id: <?php echo wp_json_encode( $user->ID ); ?>,
+				key: key,
+				code: code,
+			}
+		} ).fail( function( response, status ) {
+			var errorMessage = response.responseJSON.message || status,
+				$error = $( '#totp-setup-error' );
+
+			if ( ! $error.length ) {
+				$error = $('<div class="error" id="totp-setup-error"><p></p></div>').insertAfter( $('.totp-submit') );
+			}
+
+			$error.find('p').text( errorMessage );
+
+			$('#two-factor-totp-authcode').val('');
+		} ).then( function( response ) {
+			$( '#two-factor-totp-options' ).html( response.html );
+		} );
+	} );
+
+	// TOTP Reset
+	$( '.button.reset-totp-key' ).click( function( e ) {
+		e.preventDefault();
+
+		wp.apiRequest( {
+			method: 'DELETE',
+			path: <?php echo wp_json_encode( Two_Factor_Core::REST_NAMESPACE . '/totp' ); ?>,
+			data: {
+				user_id: <?php echo wp_json_encode( $user->ID ); ?>,
+			}
+		} ).then( function( response ) {
+			$( '#two-factor-totp-options' ).html( response.html );
+		} );
+	} );
+
+})(jQuery);

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -176,7 +176,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		$count = self::codes_remaining_for_user( $user );
 		?>
-		<div id="two-factor-backup-codes">
+		<div id="two-factor-backup-codes" data-userid="<?php echo esc_attr( $user->ID ); ?>">
 			<p class="two-factor-backup-codes-count">
 			<?php
 				echo esc_html(
@@ -197,7 +197,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				<ol class="two-factor-backup-codes-unused-codes"></ol>
 				<p class="description"><?php esc_html_e( 'Write these down! Once you navigate away from this page, you will not be able to view these codes again.', 'two-factor' ); ?></p>
 				<p>
-					<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
+					<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
 				<p>
 			</div>
 		</div>

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -142,7 +142,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		wp_register_script(
 			'two-factor-backup-codes',
 			plugins_url( 'js/admin-backup-codes.js', __DIR__ ),
-			array( 'jquery', 'wp-api-request' ),
+			array( 'wp-api-request' ),
 			TWO_FACTOR_VERSION,
 			true
 		);

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -40,6 +40,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		add_action( 'two_factor_user_options_' . __CLASS__, array( $this, 'user_options' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
 		return parent::__construct();
 	}
 
@@ -131,6 +134,21 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	/**
+	 * Enqueue scripts
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function enqueue_assets( $hook_suffix ) {
+		wp_register_script(
+			'two-factor-backup-codes',
+			plugins_url( 'js/admin-backup-codes.js', __DIR__ ),
+			array( 'jquery', 'wp-api-request' ),
+			TWO_FACTOR_VERSION,
+			true
+		);
+	}
+
+	/**
 	 * Whether this Two Factor provider is configured and codes are available for the user specified.
 	 *
 	 * @since 0.1-dev
@@ -154,6 +172,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public function user_options( $user ) {
+		wp_enqueue_script( 'two-factor-backup-codes' );
+
 		$count = self::codes_remaining_for_user( $user );
 		?>
 		<p id="two-factor-backup-codes">
@@ -181,33 +201,6 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
 			<p>
 		</div>
-		<script type="text/javascript">
-			( function( $ ) {
-				$( '.button-two-factor-backup-codes-generate' ).click( function() {
-					wp.apiRequest( {
-						method: 'POST',
-						path: <?php echo wp_json_encode( Two_Factor_Core::REST_NAMESPACE . '/generate-backup-codes' ); ?>,
-						data: {
-							user_id: <?php echo wp_json_encode( $user->ID ); ?>
-						}
-					} ).then( function( response ) {
-						var $codesList = $( '.two-factor-backup-codes-unused-codes' );
-
-						$( '.two-factor-backup-codes-wrapper' ).show();
-						$codesList.html( '' );
-
-						// Append the codes.
-						for ( i = 0; i < response.codes.length; i++ ) {
-							$codesList.append( '<li>' + response.codes[ i ] + '</li>' );
-						}
-
-						// Update counter.
-						$( '.two-factor-backup-codes-count' ).html( response.i18n.count );
-						$( '#two-factor-backup-codes-download-link' ).attr( 'href', response.download_link );
-					} );
-				} );
-			} )( jQuery );
-		</script>
 		<?php
 	}
 

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -176,7 +176,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		$count = self::codes_remaining_for_user( $user );
 		?>
-		<p id="two-factor-backup-codes">
+		<div id="two-factor-backup-codes">
 			<p class="two-factor-backup-codes-count">
 			<?php
 				echo esc_html(
@@ -193,13 +193,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 					<?php esc_html_e( 'Generate new recovery codes', 'two-factor' ); ?>
 				</button>
 			</p>
-		</p>
-		<div class="two-factor-backup-codes-wrapper" style="display:none;">
-			<ol class="two-factor-backup-codes-unused-codes"></ol>
-			<p class="description"><?php esc_html_e( 'Write these down! Once you navigate away from this page, you will not be able to view these codes again.', 'two-factor' ); ?></p>
-			<p>
-				<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
-			<p>
+			<div class="two-factor-backup-codes-wrapper" style="display:none;">
+				<ol class="two-factor-backup-codes-unused-codes"></ol>
+				<p class="description"><?php esc_html_e( 'Write these down! Once you navigate away from this page, you will not be able to view these codes again.', 'two-factor' ); ?></p>
+				<p>
+					<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
+				<p>
+			</div>
 		</div>
 		<?php
 	}

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -141,7 +141,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		wp_register_script(
 			'two-factor-totp',
 			plugins_url( 'js/admin-totp.js', __DIR__ ),
-			array( 'two-factor-qr-code-generator', 'jquery', 'wp-api-request' ),
+			array( 'two-factor-qr-code-generator', 'wp-api-request' ),
 			TWO_FACTOR_VERSION,
 			true
 		);

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -282,7 +282,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		wp_enqueue_script( 'two-factor-totp' );
 
 		?>
-		<div id="two-factor-totp-options">
+		<div id="two-factor-totp-options" data-userid="<?php echo esc_attr( $user->ID ); ?>">
 		<?php
 		if ( empty( $key ) ) :
 
@@ -296,7 +296,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 			</p>
 			<p id="two-factor-qr-code">
 				<a href="<?php echo $totp_url; ?>">
-					Loading...
+					<?php esc_html_e( 'Loading...', 'two-factor' ); ?>
 					<img src="<?php echo esc_url( admin_url( 'images/spinner.gif' ) ); ?>" alt="" />
 				</a>
 			</p>
@@ -322,7 +322,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					?>
 					<input type="tel" name="two-factor-totp-authcode" id="two-factor-totp-authcode" class="input" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $placeholder ); ?>" />
 				</label>
-				<input type="submit" class="button totp-submit" name="two-factor-totp-submit" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
+				<input type="submit" class="button totp-submit" value="<?php esc_attr_e( 'Submit', 'two-factor' ); ?>" />
 			</p>
 
 		<?php else : ?>


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #558 

## What?
<!-- In a few words, what is the PR actually doing? -->

This migrates all inline JS from being inline and using jQuery to using Vanilla JS and external .js files.

This is not perfect JS, I'm no expert.

I've used dataset to pass the userId through, this should likely be replaced with a global JS object instead that contains it and the two-factor rest-api namespace.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Other than getting proper dependency loading as per #558, there's benefits in the code maintainability by splitting the HTML from the JS.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
