### PR TITLE
Unset session data when disabling all providers to prevent fatal

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1828,7 +1828,9 @@ class Two_Factor_Core {
 				update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, $new_provider );
 			}
 
-			self::update_current_session( $enabled_providers );
+			if ( $user_id === get_current_user_id() ) {
+				self::update_current_session( $enabled_providers );
+			}
 		}
 	}
 
@@ -1854,8 +1856,7 @@ class Two_Factor_Core {
 				// does it matter that they were existing? is it enough to just say "if there are some, then..."
 				// test still pass w/ this commented out
 			$enabled_providers &&
-			! self::is_current_user_session_two_factor() &&
-			$user_id === get_current_user_id()
+			! self::is_current_user_session_two_factor()
 		) {
 			$session['two-factor-provider'] = ''; // Set the key, but not the provider, as no provider has been used yet.
 			$session['two-factor-login']    = time();

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1830,23 +1830,23 @@ class Two_Factor_Core {
 				update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, $new_provider );
 			}
 
-			// Have we enabled new providers? Set this as a 2FA session, so they can continue to edit.
-			if (
-				! $existing_providers &&
-				$enabled_providers &&
-				! self::is_current_user_session_two_factor() &&
-				$user_id === get_current_user_id()
-			) {
-				$token = wp_get_session_token();
-				if ( $token ) {
-					$manager = WP_Session_Tokens::get_instance( $user_id );
-					$session = $manager->get( $token );
+			$token = wp_get_session_token();
+			if ( $token ) {
+				$manager = WP_Session_Tokens::get_instance( $user_id );
+				$session = $manager->get( $token );
 
+				// Have we enabled new providers? Set this as a 2FA session, so they can continue to edit.
+				if (
+					! $existing_providers &&
+					$enabled_providers &&
+					! self::is_current_user_session_two_factor() &&
+					$user_id === get_current_user_id()
+				) {
 					$session['two-factor-provider'] = ''; // Set the key, but not the provider, as no provider has been used yet.
 					$session['two-factor-login']    = time();
-
-					$manager->update( $token, $session );
 				}
+
+				$manager->update( $token, $session );
 			}
 		}
 	}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1100,6 +1100,11 @@ class Two_Factor_Core {
 		$manager = WP_Session_Tokens::get_instance( $user_id );
 		$session = $manager->get( $token );
 
+		// this works, but leaves the raw session data still indicating that it's a 2fa session. that feels wrong.
+		// if ( ! self::get_available_providers_for_user( $user_id ) ) {
+		// 	return false;
+		// }
+
 		if ( empty( $session['two-factor-login'] ) ) {
 			return false;
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1846,6 +1846,12 @@ class Two_Factor_Core {
 					$session['two-factor-login']    = time();
 				}
 
+				// Have we disabled all providers? Unset the 2FA session.
+				if ( ! $enabled_providers ) {
+					unset( $session['two-factor-provider'] );
+					unset( $session['two-factor-login'] );
+				}
+
 				$manager->update( $token, $session );
 			}
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1100,11 +1100,6 @@ class Two_Factor_Core {
 		$manager = WP_Session_Tokens::get_instance( $user_id );
 		$session = $manager->get( $token );
 
-		// this works, but leaves the raw session data still indicating that it's a 2fa session. that feels wrong.
-		// if ( ! self::get_available_providers_for_user( $user_id ) ) {
-		// 	return false;
-		// }
-
 		if ( empty( $session['two-factor-login'] ) ) {
 			return false;
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1828,17 +1828,18 @@ class Two_Factor_Core {
 				update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, $new_provider );
 			}
 
-			self::update_session( $user_id, $enabled_providers );
+			self::update_current_session( $enabled_providers );
 		}
 	}
 
 	/**
 	 * Update the user session.
 	 */
-	public static function update_session( $user_id, $enabled_providers ) {
+	public static function update_current_session( $enabled_providers ) {
 		// maybe rename to something more specific to updating the providers? see if this is only used when enabling/disabling, or also used when logging in, revalidating, etc
 
-		$token = wp_get_session_token();
+		$user_id = get_current_user_id();
+		$token   = wp_get_session_token();
 
 		if ( ! $token ) {
 			return false;

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -150,6 +150,11 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$user    = get_user_by( 'id', $user_id );
 
 		$this->delete_user_totp_key( $user_id );
+		// this doesn't call user_two_factor_options_update()
+		// maybe the custom ui should do that? well i guess it cant
+		// it's probably appropriate for this func to do that
+
+		// same for other rest api endpoints that update providers
 
 		ob_start();
 		$this->user_two_factor_options( $user );
@@ -189,6 +194,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		if ( $request->get_param( 'enable_provider' ) && ! Two_Factor_Core::enable_provider_for_user( $user_id, 'Two_Factor_Totp' ) ) {
 			return new WP_Error( 'db_error', __( 'Unable to enable TOTP provider for this user.', 'two-factor' ), array( 'status' => 500 ) );
 		}
+
+		// does this need to do something to update the session?
 
 		ob_start();
 		$this->user_two_factor_options( $user );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -886,7 +886,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertNotFalse( Two_Factor_Core::is_current_user_session_two_factor() );
 
-		// Disable all providers, and test that the session is invalidated.
+		// Disable all providers, and test that the 2FA session is invalidated.
 		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = [];
 		Two_Factor_Core::user_two_factor_options_update( $user->ID );
 


### PR DESCRIPTION
Fixes #565

Unsets the 2FA session data when all providers are disabled, so that the user's current session is no longer considered a 2FA session. That avoids the fatal error, and allows them to enable a provider again.


## Testing Instructions

Repeat the reproduction steps from #565.

## Changelog Entry

None needed, because #529 has not been released yet.
