### PR TITLE
ReAuth: resolve fatal, code cleanup

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -455,13 +455,21 @@ class Two_Factor_Core {
 	 * @return null|object The provider
 	 */
 	public static function get_provider_for_user( $user = null, $preferred_provider = null ) {
-		if ( $preferred_provider && $preferred_provider instanceof Two_Factor_Provider ) {
-			return $preferred_provider;
-		}
-
 		$user = self::fetch_user( $user );
 		if ( ! $user ) {
 			return null;
+		}
+
+		// If a specific provider is requested, verify it's valid.
+		if ( $preferred_provider && $preferred_provider instanceof Two_Factor_Provider ) {
+			$providers = self::get_available_providers_for_user( $user );
+			if ( isset( $providers[ $preferred_provider->get_key() ] ) ) {
+				// Return the specific instance passed in.
+				return $preferred_provider;
+			}
+
+			// Unset, fall through to the session or primary.
+			$preferred_provider = false;
 		}
 
 		// Default to the currently logged in provider.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -770,7 +770,7 @@ class Two_Factor_Core {
 	public static function login_html( $user, $login_nonce, $redirect_to, $error_msg = '', $provider = null, $action = 'validate_2fa' ) {
 		$provider = self::get_provider_for_user( $user, $provider );
 		if ( ! $provider ) {
-			wp_die( "No provider" );
+			wp_die( __( 'Cheatin&#8217; uh?', 'two-factor' ) );
 		}
 
 		$provider_key        = $provider->get_key();
@@ -1257,7 +1257,7 @@ class Two_Factor_Core {
 
 		$provider = self::get_provider_for_user( $user, $provider );
 		if ( ! $provider ) {
-			wp_die( "No provider" );
+			wp_die( __( 'Cheatin&#8217; uh?', 'two-factor' ) );
 		}
 
 		// Run the provider processing.
@@ -1379,7 +1379,7 @@ class Two_Factor_Core {
 		$user     = wp_get_current_user();
 		$provider = self::get_provider_for_user( $user, $provider );
 		if ( ! $provider ) {
-			wp_die( "No provider" );
+			wp_die( __( 'Cheatin&#8217; uh?', 'two-factor' ) );
 		}
 
 		// Run the provider processing.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1867,7 +1867,9 @@ class Two_Factor_Core {
 	/**
 	 * Update the current user session metadata.
 	 *
-	 * @param array $data The data to append/remove from the current session. Null value keys are removed from the user session.
+	 * Any values set in $data that are null will be removed from the user session metadata.
+	 *
+	 * @param array $data The data to append/remove from the current session.
 	 * @return bool
 	 */
 	public static function update_current_user_session( $data = array() ) {
@@ -1892,7 +1894,7 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Fetch the current user session.
+	 * Fetch the current user session metadata.
 	 *
 	 * @return false|array The session array, false on error.
 	 */

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -455,7 +455,7 @@ class Two_Factor_Core {
 	 * @return null|object The provider
 	 */
 	public static function get_provider_for_user( $user = null, $preferred_provider = null ) {
-		if ( $preferred_provider && $preferred_provider instanceOf Two_Factor_Provider ) {
+		if ( $preferred_provider && $preferred_provider instanceof Two_Factor_Provider ) {
 			return $preferred_provider;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1873,12 +1873,12 @@ class Two_Factor_Core {
 	public static function update_current_user_session( $data = array() ) {
 		$user_id = get_current_user_id();
 		$token   = wp_get_session_token();
-		$manager = WP_Session_Tokens::get_instance( $user_id );
-		$session = $manager->get( $token );
-
 		if ( ! $user_id || ! $token ) {
 			return false;
 		}
+
+		$manager = WP_Session_Tokens::get_instance( $user_id );
+		$session = $manager->get( $token );
 
 		// Add any session data.
 		$session = array_merge( $session, $data );
@@ -1899,11 +1899,11 @@ class Two_Factor_Core {
 	public static function get_current_user_session() {
 		$user_id = get_current_user_id();
 		$token   = wp_get_session_token();
-		$manager = WP_Session_Tokens::get_instance( $user_id );
-
 		if ( ! $user_id || ! $token ) {
 			return false;
 		}
+
+		$manager = WP_Session_Tokens::get_instance( $user_id );
 
 		return $manager->get( $token );
 	}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1851,7 +1851,7 @@ class Two_Factor_Core {
 					// We've enabled two-factor, set the key but not the provider, as no provider has been used yet.
 					self::update_current_user_session( array(
 						'two-factor-provider' => '',
-						'two-factor-login' => time(),
+						'two-factor-login'    => time(),
 					) );
 				} elseif ( $existing_providers && ! $enabled_providers ) {
 					// We've disabled two-factor, remove session metadata.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1847,8 +1847,8 @@ class Two_Factor_Core {
 			// Have we changed the two-factor settings for the current user? Alter their session metadata.
 			if ( $user_id === get_current_user_id() ) {
 
-				if ( $enabled_providers && ! $existing_providers ) {
-					// We've enabled two-factor, set the key but not the provider, as no provider has been used yet.
+				if ( $enabled_providers && ! $existing_providers && ! self::is_current_user_session_two_factor() ) {
+					// We've enabled two-factor from a non-two-factor session, set the key but not the provider, as no provider has been used yet.
 					self::update_current_user_session( array(
 						'two-factor-provider' => '',
 						'two-factor-login'    => time(),

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1154,8 +1154,8 @@ class Two_Factor_Core {
 			return false;
 		}
 
-		// If the current user is not a two-factor user, not having a two-factor session is okay.
-		if ( ! self::is_user_using_two_factor( $user_id ) && ! $is_two_factor_session ) {
+		// If the current user is not using two-factor, they can adjust the settings.
+		if ( ! self::is_user_using_two_factor( $user_id ) ) {
 			return true;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -460,16 +460,9 @@ class Two_Factor_Core {
 			return null;
 		}
 
-		// If a specific provider is requested, verify it's valid.
+		// If a specific provider instance is passed, process it just as the key.
 		if ( $preferred_provider && $preferred_provider instanceof Two_Factor_Provider ) {
-			$providers = self::get_available_providers_for_user( $user );
-			if ( isset( $providers[ $preferred_provider->get_key() ] ) ) {
-				// Return the specific instance passed in.
-				return $preferred_provider;
-			}
-
-			// Unset, fall through to the session or primary.
-			$preferred_provider = false;
+			$preferred_provider = $preferred_provider->get_key();
 		}
 
 		// Default to the currently logged in provider.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1184,20 +1184,14 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			'two-factor-login'    => time()
 		) );
 
-		$secure_dummy = Two_Factor_Dummy_Secure::get_instance();
-		$email        = Two_Factor_Email::get_instance();
+		$dummy = Two_Factor_Dummy::get_instance();
+		$email = Two_Factor_Email::get_instance();
 
 		// Ensure the provider returned is the primary for the user.
 		$this->assertEquals(
 			'Two_Factor_Dummy',
 			// Using get_class() to verify the actual class, rather than the provider key.
 			get_class( Two_Factor_Core::get_provider_for_user( $user ) )
-		);
-
-		// Ensure that passing a specific provider class in comes back out.
-		$this->assertSame(
-			$secure_dummy,
-			Two_Factor_Core::get_provider_for_user( $user, $secure_dummy )
 		);
 
 		// Validate that upon requesting an invalid provider, valid data comes back.
@@ -1240,6 +1234,16 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertEquals(
 			'Two_Factor_Email',
 			Two_Factor_Core::get_provider_for_user( $user )->get_key()
+		);
+
+		// Ensure that passing a specific provider class in comes back out.
+		$this->assertSame(
+			$dummy,
+			Two_Factor_Core::get_provider_for_user( $user, $dummy )
+		);
+		$this->assertSame(
+			$email,
+			Two_Factor_Core::get_provider_for_user( $user, $email )
 		);
 
 		// Validate that the current user session doesn't affect fetching it for a different user.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -892,9 +892,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertFalse( Two_Factor_Core::is_current_user_session_two_factor() );
 
-		$manager = WP_Session_Tokens::get_instance( $user->ID );
-		$token   = wp_get_session_token();
-		$session = $manager->get( $token );
+		$session = Two_Factor_Core::get_current_user_session();
 
 		$this->assertArrayNotHasKey( 'two-factor-login', $session );
 		$this->assertArrayNotHasKey( 'two-factor-provider', $session );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1194,6 +1194,12 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			get_class( Two_Factor_Core::get_provider_for_user( $user ) )
 		);
 
+		// Validate that passing a specific provider that's not enabled, returns their primary provider.
+		$this->assertSame(
+			$dummy,
+			Two_Factor_Core::get_provider_for_user( $user, $email )
+		);
+
 		// Validate that upon requesting an invalid provider, valid data comes back.
 		$this->assertEquals(
 			'Two_Factor_Dummy',

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -863,7 +863,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Validate that disabling all providers [invalidate] the two-factor session.
+	 * Validate that disabling all providers results in a non-two-factor session.
 	 *
 	 * @covers Two_Factor_Core::current_user_can_update_two_factor_options()
 	 * @covers Two_Factor_Core::user_two_factor_options_update()


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See #565, #566

This centralises the provider selection into it's own method for clarity around it's logic, resolving a fatal error in the process, but replacing it with a dead-end `Cheating huh?` style error. This error condition should not be possible to be hit under normal circumstances.

More importantly, this adds Session metadata helpers (That should probably be provided by core) for retrieving/updating the current user session.

Through that, the 2fa-session flag is cleared upon the providers being disabled.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

In comparison to #566 this resolves the underlying fatal in a way that can't be reintroduced, fixes some merge bugs (ie. `get_class( $provider )` is replaced by `$provider->get_key()`), and reduces code duplication.
The unit test from #566 is included.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

See #565 #566

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

N/A - Bugfix for unreleased feature.
