### PR TITLE
Release version 0.8.2

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -159,6 +159,9 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public function user_options( $user ) {
+		wp_enqueue_script( 'wp-api-request' );
+		wp_enqueue_script( 'jquery' );
+
 		$count = self::codes_remaining_for_user( $user );
 		?>
 		<p id="two-factor-backup-codes">

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -75,7 +75,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 				'args'                => array(
 					'user_id' => array(
 						'required' => true,
-						'type'     => 'number',
+						'type'     => 'integer',
 					),
 					'enable_provider' => array(
 						'required' => false,

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -83,7 +83,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 					),
 				),
@@ -96,7 +96,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					'args'                => array(
 						'user_id' => array(
 							'required' => true,
-							'type'     => 'number',
+							'type'     => 'integer',
 						),
 						'key'     => array(
 							'type'              => 'string',
@@ -227,7 +227,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 		/**
 		 * Filter the Label for the TOTP.
-		 * 
+		 *
 		 * Must follow the TOTP format for a "label". Do not URL Encode.
 		 *
 		 * @see https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -276,6 +276,8 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$key = $this->get_user_totp_key( $user->ID );
 
 		wp_enqueue_script( 'two-factor-qr-code-generator' );
+		wp_enqueue_script( 'wp-api-request' );
+		wp_enqueue_script( 'jquery' );
 
 		?>
 		<div id="two-factor-totp-options">

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:              two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
 Requires at least: 4.3
-Tested up to:      6.0
+Tested up to:      6.2
 Requires PHP:      5.6
 Stable tag:        0.8.2
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags:              two factor, two step, authentication, login, totp, fido u2f, 
 Requires at least: 4.3
 Tested up to:      6.0
 Requires PHP:      5.6
-Stable tag:        0.8.1
+Stable tag:        0.8.2
 
 Enable Two-Factor Authentication using time-based one-time passwords (OTP, Google Authenticator), Universal 2nd Factor (FIDO U2F, YubiKey), email and backup verification codes.
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -27,6 +27,8 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 */
 	public static function wpSetUpBeforeClass() {
 		set_error_handler( array( 'Test_ClassTwoFactorCore', 'error_handler' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		add_action( 'set_auth_cookie', [ __CLASS__, 'set_auth_cookie' ] );
+		add_action( 'set_logged_in_cookie', [ __CLASS__, 'set_logged_in_cookie' ] );
 	}
 
 	/**
@@ -36,6 +38,17 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		restore_error_handler();
+		remove_action( 'set_auth_cookie', [ __CLASS__, 'set_auth_cookie' ] );
+		remove_action( 'set_logged_in_cookie', [ __CLASS__, 'set_logged_in_cookie' ] );
+	}
+
+	/**
+	 * Cleanup after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset( $_COOKIE[ AUTH_COOKIE ], $_COOKIE[ LOGGED_IN_COOKIE ] );
 	}
 
 	/**
@@ -54,6 +67,20 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Simulate the auth cookie having being sent.
+	 */
+	public static function set_auth_cookie( $auth_cookie ) {
+		$_COOKIE[ AUTH_COOKIE ] = $auth_cookie;
+	}
+
+	/**
+	 * Simulate the logged_in cookie having being sent.
+	 */
+	public static function set_logged_in_cookie( $logged_in_cookie ) {
+		$_COOKIE[ LOGGED_IN_COOKIE ] = $logged_in_cookie;
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -801,6 +801,149 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Validate that other sessions are destroyed once Two-Factor is enabled.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 */
+	public function test_other_sessions_destroyed_when_enabling_2fa() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'username',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$user = new WP_User( $user_id );
+
+		$session_manager = WP_Session_Tokens::get_instance( $user->ID );
+
+		$this->assertCount( 0, $session_manager->get_all(), 'No user sessions are present first' );
+
+		// Generate multiple existing sessions.
+		$session_manager->create( time() + HOUR_IN_SECONDS );
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Can fetch active sessions' );
+
+		$user_authenticated = wp_signon(
+			array(
+				'user_login'    => 'username',
+				'user_password' => 'password',
+			)
+		);
+		$this->assertEquals( $user_authenticated, $user, 'User can authenticate' );
+
+		// Enable Two-Factor for the user.
+		wp_set_current_user( $user->ID );
+
+		$key              = '_nonce_user_two_factor_options';
+		$nonce            = wp_create_nonce( 'user_two_factor_options' );
+		$_POST[ $key ]    = $nonce;
+		$_REQUEST[ $key ] = $nonce;
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy'
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		// Validate that only the current session still exists.
+		$this->assertCount( 1, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Create another session, activate another provider, verify sessions are still valid.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Failed to create another session' );
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy',
+			'Two_Factor_Email' => 'Two_Factor_Email',
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled with two providers.
+		$this->assertCount( 2, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 2, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		$this->assertCount( 1, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Create another session, disable a provider, verify both sessions still exist.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Failed to create another session' );
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy',
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled with two providers.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		$this->assertCount( 2, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+	}
+
+	/**
+	 * Validate the administrators sessions are not modified when modifying another user.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 */
+	public function test_all_sessions_destroyed_when_enabling_2fa_by_admin() {
+		$admin_id = self::factory()->user->create(
+			array(
+				'role' => 'administrator'
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		// Create an admin session,.
+		$admin_session_manager = WP_Session_Tokens::get_instance( $admin_id );
+
+		$admin_session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 1, $admin_session_manager->get_all(), 'No admin sessions are present first' );
+
+		// Create the target user.
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'username',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$session_manager = WP_Session_Tokens::get_instance( $user_id );
+
+		$this->assertCount( 0, $session_manager->get_all(), 'No user sessions are present first' );
+
+		// Generate multiple existing sessions.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 1, $session_manager->get_all(), 'Can fetch active sessions' );
+
+		$key              = '_nonce_user_two_factor_options';
+		$nonce            = wp_create_nonce( 'user_two_factor_options' );
+		$_POST[ $key ]    = $nonce;
+		$_REQUEST[ $key ] = $nonce;
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array( 'Two_Factor_Dummy' => 'Two_Factor_Dummy' );
+
+		Two_Factor_Core::user_two_factor_options_update( $user_id );
+
+		// Validate that Two-Factor is now enabled.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user_id ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) );
+
+		// Validate the User has no sessions.
+		$this->assertCount( 0, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Validate that the Admin still has a session.
+		$this->assertCount( 1, $admin_session_manager->get_all(), 'No admin sessions are present first' );
+	}
+
+	/**
 	 * @covers Two_Factor_Core::show_password_reset_error
 	 */
 	public function test_show_password_reset_error() {

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI:  https://wordpress.org/plugins/two-factor/
  * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
  * Author:      Plugin Contributors
- * Version:     0.8.1
+ * Version:     0.8.2
  * Author URI:  https://github.com/wordpress/two-factor/graphs/contributors
  * Network:     True
  * Text Domain: two-factor
@@ -26,7 +26,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.8.1' );
+define( 'TWO_FACTOR_VERSION', '0.8.2' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
Some issues have been identified since 0.8 + 0.8.1 was released, 0.9.0 is a little ways off still so let's release 0.8.2 to resolve those issues for now:

 - #558 
 - #557
 - #559
 - #552
   - Not an issue, but should be bumped on WordPress.org)
 - #578


## Release instructions

- [x] Branch: Starting from `tags/0.8.1`, create a branch named `release/0.8.2` for the release-related changes.
- [x] Version bump: Bump the version number in `readme.txt` and `two-factor.php` if it does not already reflect the version being released.  Update both the plugin "Version:" header value and the plugin `TWO_FACTOR_VERSION` constant in `two-factor.php`.
- [ ] ~~Changelog: Add/update the changelog in `readme.txt`.~~
- [ ] ~~New files: Check to be sure any new files/paths that are unnecessary in the production version are included in [.distignore](https://github.com/WordPress/two-factor/blob/master/.distignore).~~
- [x] Readme updates: Make any other readme changes as necessary. `readme.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content. The two are slightly different.
- [x] Create Release PR: Push any local changes in `release/0.8.2` to origin, create a release PR, and request review to ensure all CI checks pass and ensure master branch changes are limited to merges only.
- [ ] ~~Merge: After review approval, merge the release pull request (or make a non-fast-forward merge from your release branch to `master`).  `master` contains the latest stable release.~~
- [x] Release: Create a [new release](https://github.com/WordPress/two-factor/releases/new), naming the tag and the release with the new version number, and targeting the `release/0.8.2` branch.  ~~Paste the changelog from `readme.txt` into the body of the release and include a link to the [closed items on the milestone](https://github.com/WordPress/two-factor/milestone/23?closed=1).~~
- [x] SVN: Wait for the [GitHub Action: Deploy](https://github.com/WordPress/two-factor/actions/workflows/deploy.yml) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
- [x] Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/two-factor/. This may take a few minutes.
- [ ] ~~Mark any included PRs / Issues as 0.8.2 from 0.9.0 if appropriate~~
- [ ] Close the milestone: Edit the [milestone](https://github.com/WordPress/two-factor/milestone/27) with the release date (in the `Due date (optional)` field) and link to the GitHub release (in the `Description` field), then close the milestone.
- [x] ~~Punt incomplete items: If any open issues or PRs which were milestoned for `0.8.2` do not make it into the release, update their milestone to `0.9.0` or `Future Release`.`~~
- [x] Cherry pick the version bump commit to `master` -- #588