### PR TITLE
Disable U2F Interface unless already configured.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1719,7 +1719,7 @@ class Two_Factor_Core {
 		$providers = self::get_providers();
 
 		// Disable U2F unless already configured.
-		if ( isset( $providers['Two_Factor_FIDO_U2F'] ) && ! $providers['Two_Factor_FIDO_U2F']->is_available_for_user( $user ) ) {
+		if ( isset( $providers['Two_Factor_FIDO_U2F'] ) && ! $providers['Two_Factor_FIDO_U2F']->is_available_for_user( $user ) && apply_filters( 'two_factor_u2f_disabled', true ) ) {
 			unset( $providers['Two_Factor_FIDO_U2F'] );
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1716,6 +1716,13 @@ class Two_Factor_Core {
 			$show_2fa_options ? '' : 'disabled="disabled"',
 		);
 
+		$providers = self::get_providers();
+
+		// Disable U2F unless already configured.
+		if ( isset( $providers['Two_Factor_FIDO_U2F'] ) && ! $providers['Two_Factor_FIDO_U2F']->is_available_for_user( $user ) ) {
+			unset( $providers['Two_Factor_FIDO_U2F'] );
+		}
+
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
 		?>
 		<input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
@@ -1734,7 +1741,7 @@ class Two_Factor_Core {
 							</tr>
 						</thead>
 						<tbody>
-						<?php foreach ( self::get_providers() as $provider_key => $object ) : ?>
+						<?php foreach ( $providers as $provider_key => $object ) : ?>
 							<tr>
 								<th scope="row"><input id="enabled-<?php echo esc_attr( $provider_key ); ?>" type="checkbox" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php echo esc_attr( $provider_key ); ?>" <?php checked( in_array( $provider_key, $enabled_providers, true ) ); ?> /></th>
 								<th scope="row"><input type="radio" name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>" value="<?php echo esc_attr( $provider_key ); ?>" <?php checked( $provider_key, $primary_provider_key ); ?> /></th>

--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -62,7 +62,7 @@ class Two_Factor_FIDO_U2F_Admin {
 		$security_keys = Two_Factor_FIDO_U2F::get_security_keys( $user_id );
 
 		// Disabled interface if there's no keys.
-		if ( ! $security_keys ) {
+		if ( ! $security_keys && apply_filters( 'two_factor_u2f_disabled', true ) ) {
 			return;
 		}
 
@@ -170,7 +170,7 @@ class Two_Factor_FIDO_U2F_Admin {
 	 */
 	public static function show_user_profile( $user ) {
 		// Don't display if the user cannot configure it.
-		if ( ! Two_Factor_FIDO_U2F::get_instance()->is_available_for_user( $user ) ) {
+		if ( ! Two_Factor_FIDO_U2F::get_instance()->is_available_for_user( $user ) && apply_filters( 'two_factor_u2f_disabled', true ) ) {
 			return;
 		}
 

--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -61,6 +61,11 @@ class Two_Factor_FIDO_U2F_Admin {
 
 		$security_keys = Two_Factor_FIDO_U2F::get_security_keys( $user_id );
 
+		// Disabled interface if there's no keys.
+		if ( ! $security_keys ) {
+			return;
+		}
+
 		// @todo Ensure that scripts don't fail because of missing u2fL10n.
 		try {
 			$data              = Two_Factor_FIDO_U2F::$u2f->getRegisterData( $security_keys );
@@ -164,6 +169,11 @@ class Two_Factor_FIDO_U2F_Admin {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function show_user_profile( $user ) {
+		// Don't display if the user cannot configure it.
+		if ( ! Two_Factor_FIDO_U2F::get_instance()->is_available_for_user( $user ) ) {
+			return;
+		}
+
 		wp_nonce_field( "user_security_keys-{$user->ID}", '_nonce_user_security_keys' );
 		$new_key = false;
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === Two-Factor ===
 Contributors:      georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
-Tags:              two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
+Tags:              two factor, two step, authentication, login, totp email, backup codes, 2fa, yubikey
 Requires at least: 4.3
 Tested up to:      6.2
 Requires PHP:      5.6
 Stable tag:        0.8.1
 
-Enable Two-Factor Authentication using time-based one-time passwords (OTP, Google Authenticator), Universal 2nd Factor (FIDO U2F, YubiKey), email and backup verification codes.
+Enable Two-Factor Authentication using time-based one-time passwords (OTP, Google Authenticator), email and backup verification codes.
 
 == Description ==
 
@@ -14,7 +14,6 @@ Use the "Two-Factor Options" section under "Users" → "Your Profile" to enable 
 
 - Email codes
 - Time Based One-Time Passwords (TOTP)
-- FIDO Universal 2nd Factor (U2F)
 - Backup Codes
 - Dummy Method (only for testing purposes)
 


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR disables the U2F / Fido interface, unless keys are already configured for the user.

Fixes #511

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

U2F / FIDO no longer works in modern browsers, until #423 is resolved having this provider enabled only causes confusion to end users (See #511)

Ideally, we wouldn't need to do this, as we've been assuming that #423 would be resolved, but 6+ months later it's no closer to being merged.  **I'd like to merge this into a 0.8.2.**

## Alternatives

Alternatively, the Javascript could be updated to detect FIDO/U2F not being viable, and displaying an error message about the browser not supporting it too..

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

This simply disables the UI by:
 - Removing it from the Providers array when disabling the table, if the provider says it's not available.
 - Returning early when displaying the Security keys table, if the provider says it's not available.
 - Returning early when enqueuing assets when no keys are registered.

If for some reason, it needs to be re-enabled a filter is included:
> `add_filter( 'two_factor_u2f_disabled', '__return_false' );`

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1018" alt="Screenshot 2023-05-25 at 6 12 46 pm" src="https://github.com/WordPress/two-factor/assets/767313/e18d3795-671d-48b3-9709-42aa748ff759"> |<img width="1016" alt="Screenshot 2023-05-25 at 6 13 04 pm" src="https://github.com/WordPress/two-factor/assets/767313/e5885375-706c-4b44-a9ef-8e96d984276f"> |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Deprecated: The FIDO/U2F integration has been hidden unless already configured. This is because modern browsers no longer support the standard, and we've not yet finalised our WebAuthn implementation.