### PR TITLE
Sync two-factor session meta to newly created sessions

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1945,9 +1945,11 @@ class Two_Factor_Core {
 		}
 
 		$current_session = self::get_current_user_session();
-		foreach ( $current_session as $key => $value ) {
-			if ( str_starts_with( $key, 'two-factor-' ) ) {
-				$session[ $key ] = $value;
+		if ( $current_session ) {
+			foreach ( $current_session as $key => $value ) {
+				if ( str_starts_with( $key, 'two-factor-' ) ) {
+					$session[ $key ] = $value;
+				}
 			}
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -124,6 +124,8 @@ class Two_Factor_Core {
 		// Run as late as possible to prevent other plugins from unintentionally bypassing.
 		add_filter( 'authenticate', array( __CLASS__, 'filter_authenticate_block_cookies' ), PHP_INT_MAX );
 
+		add_filter( 'attach_session_information', array( __CLASS__, 'filter_session_information' ), 10, 2 );
+		
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
@@ -1924,5 +1926,31 @@ class Two_Factor_Core {
 		}
 
 		return (bool) apply_filters( 'two_factor_rememberme', $rememberme );
+	}
+
+	/**
+	 * Sync the Two-Factor session data from the current session to newly created sessions.
+	 *
+	 * This is required as WordPress creates a new session when the user password is changed.
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/58427
+	 *
+	 * @param array $session The Session information.
+	 * @param int   $user_id The User ID for the session.
+	 * @return array
+	 */
+	public static function filter_session_information( $session, $user_id ) {
+		if ( $user_id !== get_current_user_id() ) {
+			return $session;
+		}
+
+		$current_session = self::get_current_user_session();
+		foreach ( $current_session as $key => $value ) {
+			if ( str_starts_with( $key, 'two-factor-' ) ) {
+				$session[ $key ] = $value;
+			}
+		}
+
+		return $session;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Copies two-factor session information from the current session to newly created sessions.

Fixes #573

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

WordPress creates a new session when the user changes their password, for no particular reason.

See https://core.trac.wordpress.org/ticket/58427
See https://github.com/WordPress/wporg-two-factor/issues/191

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

See screen recording. The debug shown is from this change:
```diff
diff --git a/class-two-factor-core.php b/class-two-factor-core.php
index 53fa43b..ce5b197 100644
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1718,6 +1718,11 @@ class Two_Factor_Core {
                        $show_2fa_options ? '' : 'disabled="disabled"',
                );

+       echo '<pre>'; var_dump( [
+               'token' => wp_get_session_token(),
+               'session' => Two_Factor_Core::get_current_user_session(),
+       ] ); echo '</pre>';
+
                wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
                ?>
                <input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
```

## Screenshots or screencast
<!-- if applicable -->

See the Issue for the before.

Note that in the recording the Session token changes, but the metadata remains.

https://github.com/WordPress/two-factor/assets/767313/34042555-b896-4de6-87a4-7aef7522da83


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
N/A - Fix for an unreleased change: #528
