### PR TITLE
Require a nonce be present for revalidate POST requests.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -814,14 +814,12 @@ class Two_Factor_Core {
 
 		<?php if ( $backup_providers ) :
 			$backup_link_args = array(
-				'action' => $action,
+				'action'        => $action,
+				'wp-auth-id'    => $user->ID,
+				'wp-auth-nonce' => $login_nonce,
 			);
 			if ( $rememberme ) {
 				$backup_link_args['rememberme'] = $rememberme;
-			}
-			if ( $login_nonce ) {
-				$backup_link_args['wp-auth-id']    = $user->ID;
-				$backup_link_args['wp-auth-nonce'] = $login_nonce;
 			}
 			if ( $redirect_to ) {
 				$backup_link_args['redirect_to'] = $redirect_to;
@@ -1350,11 +1348,12 @@ class Two_Factor_Core {
 	 * @since 0.9.0
 	 */
 	public static function login_form_revalidate_2fa() {
-		$provider        = ! empty( $_REQUEST['provider'] )    ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false;
-		$redirect_to     = ! empty( $_REQUEST['redirect_to'] ) ? wp_unslash( $_REQUEST['redirect_to'] )                     : admin_url();
+		$nonce           = ! empty( $_REQUEST['wp-auth-nonce'] ) ? wp_unslash( $_REQUEST['wp-auth-nonce'] )                   : '';
+		$provider        = ! empty( $_REQUEST['provider'] )      ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false;
+		$redirect_to     = ! empty( $_REQUEST['redirect_to'] )   ? wp_unslash( $_REQUEST['redirect_to'] )                     : admin_url();
 		$is_post_request = ( 'POST' === strtoupper( $_SERVER['REQUEST_METHOD'] ) );
 
-		self::_login_form_revalidate_2fa( $provider, $redirect_to, $is_post_request );
+		self::_login_form_revalidate_2fa( $nonce, $provider, $redirect_to, $is_post_request );
 		exit;
 	}
 
@@ -1366,18 +1365,26 @@ class Two_Factor_Core {
 	 *
 	 * @since 0.9.0
 	 *
+	 * @param string  $nonce           The nonce passed with the request.
 	 * @param string  $provider        The provider to use, if known.
 	 * @param string  $redirect_to     The redirection location.
 	 * @param bool    $is_post_request Whether the incoming request was a POST request or not.
 	 * @return void
 	 */
-	public static function _login_form_revalidate_2fa( $provider = '', $redirect_to = '', $is_post_request = false ) {
+	public static function _login_form_revalidate_2fa( $nonce = '', $provider = '', $redirect_to = '', $is_post_request = false ) {
 		if ( ! is_user_logged_in() ) {
 			wp_safe_redirect( home_url() );
 			return;
 		}
 
-		$user     = wp_get_current_user();
+		$user = wp_get_current_user();
+
+		// Validate the nonce for POST requests. GET requests do not perform actions, and such do not require the nonce (such as the initial request).
+		if ( $is_post_request && ! wp_verify_nonce( $nonce, 'two_factor_revalidate_' . $user->ID ) ) {
+			wp_safe_redirect( home_url() );
+			return;
+		}
+
 		$provider = self::get_provider_for_user( $user, $provider );
 		if ( ! $provider ) {
 			wp_die( __( 'Cheatin&#8217; uh?', 'two-factor' ) );
@@ -1393,7 +1400,9 @@ class Two_Factor_Core {
 				$error = $result->get_error_message();
 			}
 
-			self::login_html( $user, '', $redirect_to, $error, $provider, 'revalidate_2fa' );
+			$nonce = wp_create_nonce( 'two_factor_revalidate_' . $user->ID );
+
+			self::login_html( $user, $nonce, $redirect_to, $error, $provider, 'revalidate_2fa' );
 			return;
 		}
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1049,15 +1049,26 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		// Revalidate.
 		// Simulate displaying it.
 		ob_start();
-		Two_Factor_Core::_login_form_revalidate_2fa( 'Two_Factor_Dummy', '', false );
+		Two_Factor_Core::_login_form_revalidate_2fa( '', 'Two_Factor_Dummy', '', false );
+		ob_end_clean();
+
+		// Check it's still expired.
+		$this->assertLessThan( time(), Two_Factor_Core::is_current_user_session_two_factor() );
+
+		// Simulate clicking it with an incorrect nonce.
+		$bad_nonce = '__BAD_NONCE__';
+		ob_start();
+		Two_Factor_Core::_login_form_revalidate_2fa( $bad_nonce, 'Two_Factor_Dummy', '', true );
 		ob_end_clean();
 
 		// Check it's still expired.
 		$this->assertLessThan( time(), Two_Factor_Core::is_current_user_session_two_factor() );
 
 		// Simulate clicking it.
+		$login_nonce = wp_create_nonce( 'two_factor_revalidate_' . $user->ID );
+
 		ob_start();
-		Two_Factor_Core::_login_form_revalidate_2fa( 'Two_Factor_Dummy', '', true );
+		Two_Factor_Core::_login_form_revalidate_2fa( $login_nonce, 'Two_Factor_Dummy', '', true );
 		ob_end_clean();
 
 		// Validate that the session is flagged as 2FA, and set to now-ish.


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Two-Factor includes a nonce during the validate_2fa callback, and while the fields are present in the POST request for the revalidate endpoint, it's not used.

Props @xknown for the report.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

A nonce should be present on all POST requests that perform actions, to prevent potential CSRF attacks.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

Due to the revalidation occurring with an authenticated session, `wp_create_nonce()` is used to validate the request. The Two-Factor login_nonce functionality is not used, to ensure that the revalidate nonce can't be used to login a new session.

The nonce is ignored during GET requests for the revalidate endpoint.
 - The initial load of the revalidate screen can be sans-nonce, this is not a concern IMHO. 
 - The change-provider link DOES include a nonce, but it is not validated. This is due to code-reuse between the validate_2fa and revalidate_2fa actions. The inclusion of the nonce here that is not validated is not a risk, due to it being a GET request and not performing an action.

The check could be changed to `if ( ( $is_post_request || $nonce ) && ! wp_verify_nonce( $nonce .. ) ) {` if required, but it seems more explicit to only require it for POST requests, as that's where it's actually protecting against an attack.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Apply PR
2. Login as normal.
3. During revalidate, remove the `wp-auth-nonce` from the POST payload, ensure the request fails.
4. Ensure revalidate succeeds with the `wp-auth-nonce` field.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

N/A - Unreleased feature.