### PR TITLE
Destroy existing sessions when activating 2FA.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1873,6 +1873,17 @@ class Two_Factor_Core {
 					) );
 				}
 			}
+
+			// Destroy other sessions if we've activated a new provider.
+			if ( array_diff( $enabled_providers, $existing_providers ) ) {
+				if ( $user_id === get_current_user_id() ) {
+					// Keep the current session, destroy others sessions for this user.
+					wp_destroy_other_sessions();
+				} else {
+					// Destroy all sessions for the user.
+					WP_Session_Tokens::get_instance( $user_id )->destroy_all();
+				}
+			}
 		}
 	}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1874,8 +1874,13 @@ class Two_Factor_Core {
 				}
 			}
 
-			// Destroy other sessions if we've activated a new provider.
-			if ( array_diff( $enabled_providers, $existing_providers ) ) {
+			// Destroy other sessions if setup 2FA for the first time, or deactivated a provider
+			if (
+				// No providers, enabling one (or more)
+				( ! $existing_providers && $enabled_providers ) ||
+				// Has providers, and is disabling one (or more)
+				( $existing_providers && array_diff( $existing_providers, $enabled_providers ) )
+			) {
 				if ( $user_id === get_current_user_id() ) {
 					// Keep the current session, destroy others sessions for this user.
 					wp_destroy_other_sessions();

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1878,8 +1878,8 @@ class Two_Factor_Core {
 			if (
 				// No providers, enabling one (or more)
 				( ! $existing_providers && $enabled_providers ) ||
-				// Has providers, and is disabling one (or more)
-				( $existing_providers && array_diff( $existing_providers, $enabled_providers ) )
+				// Has providers, and is disabling one (or more), but remaining with 2FA.
+				( $existing_providers && $enabled_providers && array_diff( $existing_providers, $enabled_providers ) )
 			) {
 				if ( $user_id === get_current_user_id() ) {
 					// Keep the current session, destroy others sessions for this user.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1342,4 +1342,152 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'tests-key', $session );
 	}
 
+
+	/**
+	 * Validate that other sessions are destroyed once Two-Factor is enabled.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 */
+	public function test_other_sessions_destroyed_when_enabling_2fa() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'username',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$user = new WP_User( $user_id );
+
+		$session_manager = WP_Session_Tokens::get_instance( $user->ID );
+
+		$this->assertCount( 0, $session_manager->get_all(), 'No user sessions are present first' );
+
+		// Generate multiple existing sessions.
+		$session_manager->create( time() + HOUR_IN_SECONDS );
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Can fetch active sessions' );
+
+		// Shim the cookie... this allows for functions that use sessions to know the current session.
+		add_action( 'set_logged_in_cookie', function( $logged_in_cookie ) {
+			$_COOKIE[ LOGGED_IN_COOKIE ] = $logged_in_cookie;
+		} );
+
+		$user_authenticated = wp_signon(
+			array(
+				'user_login'    => 'username',
+				'user_password' => 'password',
+			)
+		);
+		$this->assertEquals( $user_authenticated, $user, 'User can authenticate' );
+
+		// Enable Two-Factor for the user.
+		wp_set_current_user( $user->ID );
+
+		$key              = '_nonce_user_two_factor_options';
+		$nonce            = wp_create_nonce( 'user_two_factor_options' );
+		$_POST[ $key ]    = $nonce;
+		$_REQUEST[ $key ] = $nonce;
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy'
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		// Validate that only the current session still exists.
+		$this->assertCount( 1, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Create another session, activate another provider, verify sessions are still valid.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Failed to create another session' );
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy',
+			'Two_Factor_Email' => 'Two_Factor_Email',
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled with two providers.
+		$this->assertCount( 2, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 2, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		$this->assertCount( 1, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Create another session, disable a provider, verify both sessions still exist.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 2, $session_manager->get_all(), 'Failed to create another session' );
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
+			'Two_Factor_Dummy' => 'Two_Factor_Dummy',
+		);
+
+		Two_Factor_Core::user_two_factor_options_update( $user->ID );
+
+		// Validate that Two-Factor is now enabled with two providers.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user->ID ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user->ID ) );
+
+		$this->assertCount( 2, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+	}
+
+	/**
+	 * Validate the administrators sessions are not modified when modifying another user.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options_update
+	 */
+	public function test_all_sessions_destroyed_when_enabling_2fa_by_admin() {
+		$admin_id = self::factory()->user->create(
+			array(
+				'role' => 'administrator'
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		// Create an admin session,.
+		$admin_session_manager = WP_Session_Tokens::get_instance( $admin_id );
+
+		$admin_session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 1, $admin_session_manager->get_all(), 'No admin sessions are present first' );
+
+		// Create the target user.
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login' => 'username',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$session_manager = WP_Session_Tokens::get_instance( $user_id );
+
+		$this->assertCount( 0, $session_manager->get_all(), 'No user sessions are present first' );
+
+		// Generate multiple existing sessions.
+		$session_manager->create( time() + DAY_IN_SECONDS  );
+		$this->assertCount( 1, $session_manager->get_all(), 'Can fetch active sessions' );
+
+		$key              = '_nonce_user_two_factor_options';
+		$nonce            = wp_create_nonce( 'user_two_factor_options' );
+		$_POST[ $key ]    = $nonce;
+		$_REQUEST[ $key ] = $nonce;
+
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array( 'Two_Factor_Dummy' => 'Two_Factor_Dummy' );
+
+		Two_Factor_Core::user_two_factor_options_update( $user_id );
+
+		// Validate that Two-Factor is now enabled.
+		$this->assertCount( 1, Two_Factor_Core::get_available_providers_for_user( $user_id ) );
+		$this->assertCount( 1, Two_Factor_Core::get_enabled_providers_for_user( $user_id ) );
+
+		// Validate the User has no sessions.
+		$this->assertCount( 0, $session_manager->get_all(), 'All known authentication sessions have been destroyed' );
+
+		// Validate that the Admin still has a session.
+		$this->assertCount( 1, $admin_session_manager->get_all(), 'No admin sessions are present first' );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Upon a new 2FA provider being set, existing sessions for the user are destroyed.

Fixes #577

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

It's considered best-practice to terminate existing sessions when "enhancing" an authenticated session.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

For the current user, the active session is kept, other sessions are destroyed upon 2FA being activated.
For other users, all their sessions are terminated.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

See #577 

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Security - When 2FA is activated for a user, destroy any existing sessions.