### PR TITLE
Add method to disable an individual provider

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -125,7 +125,7 @@ class Two_Factor_Core {
 		add_filter( 'authenticate', array( __CLASS__, 'filter_authenticate_block_cookies' ), PHP_INT_MAX );
 
 		add_filter( 'attach_session_information', array( __CLASS__, 'filter_session_information' ), 10, 2 );
-		
+
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
@@ -1818,6 +1818,37 @@ class Two_Factor_Core {
 		}
 
 		return $enabled && $has_primary;
+	}
+
+	/**
+	 * Disable a provider for a user.
+	 *
+	 * This intentionally doesn't set a new primary provider when disabling the current primary provider, because
+	 * `get_primary_provider_for_user()` will pick a new one automatically.
+	 *
+	 * @param int    $user_id  The ID of the user.
+	 * @param string $provider The name of the provider class.
+	 *
+	 * @return bool True if the provider was disabled, false otherwise.
+	 */
+	public static function disable_provider_for_user( $user_id, $provider_to_delete ) {
+		$is_registered = array_key_exists( $provider_to_delete, self::get_providers() );
+
+		if ( ! $is_registered ) {
+			return false;
+		}
+
+		$old_enabled_providers = self::get_enabled_providers_for_user( $user_id );
+		$is_enabled            = in_array( $provider_to_delete, $old_enabled_providers );
+
+		if ( ! $is_enabled ) {
+			return true;
+		}
+
+		$new_enabled_providers     = array_diff( $old_enabled_providers, array( $provider_to_delete ) );
+		$was_disabled              = update_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, $new_enabled_providers );
+
+		return (bool) $was_disabled;
 	}
 
 	/**

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1788,6 +1788,8 @@ class Two_Factor_Core {
 	/**
 	 * Enable a provider for a user.
 	 *
+	 * The caller is responsible for checking the user has permission to do this.
+	 *
 	 * @param int    $user_id      The ID of the user.
 	 * @param string $new_provider The name of the provider class.
 	 *
@@ -1825,6 +1827,8 @@ class Two_Factor_Core {
 	 *
 	 * This intentionally doesn't set a new primary provider when disabling the current primary provider, because
 	 * `get_primary_provider_for_user()` will pick a new one automatically.
+	 *
+	 * The caller is responsible for checking the user has permission to do this.
 	 *
 	 * @param int    $user_id  The ID of the user.
 	 * @param string $provider The name of the provider class.


### PR DESCRIPTION
## What?

Adds a `Two_Factor_Core::disable_provider_for_user()`  method.

## Why?

This provides parity with the `Two_Factor_Core::enable_provider_for_user()` method. It's not currently used by Two Factor itself, but it allows plugins to disable an individual provider directly, rather than having to know the internals and update meta keys, etc.

One example use case for that is https://github.com/WordPress/wporg-two-factor/pull/223#pullrequestreview-1570860929, where a custom front-end UI was developed in React, using REST API endpoints.

Fixes #585 

## Testing Instructions

1. Enable a provider via `wp-admin/profile.php` and save
2. Add the following code in an mu-plugin. Replace the name of the provider with one you enabled.
	add_action( 'init', function() {
		Two_Factor_Core::disable_provider_for_user( get_current_user_id(), 'Two_Factor_Dummy' );
	} );
3. Refresh `profile.php` and see that the provider has been disabled. If another provider was enabled, it should now be set as the primary provider.

## Changelog Entry

> Added - New `Two_Factor_Core::disable_provider_for_user()`  method provides parity with the `Two_Factor_Core::enable_provider_for_user()` method. It allows plugins to disable an individual provider directly, rather than having to know the internals and update meta keys, etc.
