### PR TITLE
issue/594 - Prefer "require_once" in a few spots.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -184,7 +184,7 @@ class Two_Factor_Core {
 		 * For each filtered provider,
 		 */
 		foreach ( $providers as $provider_key => $path ) {
-			include_once $path;
+			require_once $path;
 
 			$class = $provider_key;
 
@@ -785,7 +785,7 @@ class Two_Factor_Core {
 
 		if ( ! function_exists( 'login_header' ) ) {
 			// We really should migrate login_header() out of `wp-login.php` so it can be called from an includes file.
-			include_once TWO_FACTOR_DIR . 'includes/function.login-header.php';
+			require_once TWO_FACTOR_DIR . 'includes/function.login-header.php';
 		}
 
 		// Disable the language switcher.
@@ -913,7 +913,7 @@ class Two_Factor_Core {
 		</script>
 		<?php
 		if ( ! function_exists( 'login_footer' ) ) {
-			include_once TWO_FACTOR_DIR . 'includes/function.login-footer.php';
+			require_once TWO_FACTOR_DIR . 'includes/function.login-footer.php';
 		}
 
 			login_footer();

--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -208,7 +208,7 @@ class Two_Factor_FIDO_U2F_Admin {
 			<p><a href="https://support.google.com/accounts/answer/6103523"><?php esc_html_e( 'You can find FIDO U2F Security Key devices for sale from here.', 'two-factor' ); ?></a></p>
 
 			<?php
-				require TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f-admin-list-table.php';
+				require_once TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f-admin-list-table.php';
 				$u2f_list_table        = new Two_Factor_FIDO_U2F_Admin_List_Table();
 				$u2f_list_table->items = $security_keys;
 				$u2f_list_table->prepare_items();
@@ -328,7 +328,7 @@ class Two_Factor_FIDO_U2F_Admin {
 	public static function wp_ajax_inline_save() {
 		check_ajax_referer( 'keyinlineeditnonce', '_inline_edit' );
 
-		require TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f-admin-list-table.php';
+		require_once TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f-admin-list-table.php';
 		$wp_list_table = new Two_Factor_FIDO_U2F_Admin_List_Table();
 
 		if ( ! isset( $_POST['keyHandle'] ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,9 +30,9 @@ require_once dirname( __DIR__ ) . '/includes/function.login-footer.php';
 tests_add_filter(
 	'muplugins_loaded',
 	function() {
-		require dirname( __DIR__ ) . '/two-factor.php';
+		require_once dirname( __DIR__ ) . '/two-factor.php';
 	}
 );
 
 // Start up the WP testing environment.
-require getenv( 'WP_PHPUNIT__DIR' ) . '/includes/bootstrap.php';
+require_once getenv( 'WP_PHPUNIT__DIR' ) . '/includes/bootstrap.php';


### PR DESCRIPTION
## What?
Using "require_once" everywhere, replacing a few inconsistent "require" and "include_once" usages

## Why?
I'm being a silly and manually including a file in another plugin

## How?
By using require_once, we'll all get to bypass some PHP warnings that don't appear to be intended behavior as-is

## Testing Instructions
Install the latest Github master branch of the WP User Profiles plugin, navigate to your Admin Area Profile page, and visit the "Account" tab. Once there, you'll see a glorious warning because we're already (manually) including one of the files in this plugin

## Changelog Entry
Prefer "require_once" in a few spots.

This change prevents unintended PHP warnings when silly JJJ people are doing silly JJJ things.

Fixes #594.