### PR TITLE
Remove trailing commas in parameters to avoid syntax error with some PHP versions (ex. 7.2.x)

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1450,7 +1450,7 @@ class Two_Factor_Core {
 		if ( ! $provider ) {
 			return new WP_Error(
 				'two_factor_provider_missing',
-				__( 'Cheatin&#8217; uh?', 'two-factor' ),
+				__( 'Cheatin&#8217; uh?', 'two-factor' )
 			);
 		}
 
@@ -1724,7 +1724,7 @@ class Two_Factor_Core {
 
 		printf(
 			'<fieldset id="two-factor-options" %s>',
-			$show_2fa_options ? '' : 'disabled="disabled"',
+			$show_2fa_options ? '' : 'disabled="disabled"'
 		);
 
 		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );


### PR DESCRIPTION
## What?
Per the title of this PR, this simply removes 2 instances of trailing commas when listing out parameters as that causes a syntax error (resulting in a site-wide fatal server error) for sites using PHP 7.2.x (and potentially other versions.) These commas aren't being used for anything anyway while PHP was made to be oddly strict about these unlike arrays & unlike other PHP versions so it's best just not to include them. This was also mentioned at: https://wordpress.org/support/topic/fatal-server-error-on-certain-php-versions-with-0-9-0-plugin-version/

## Why?
Fixes a potential syntax error that results in a fatal server error for PHP 7.2.x & potentially other PHP versions.

## How?
Removing the trailing comma from parameters fixes the syntax error while the commas weren't doing anything anyway.

## Testing Instructions
Having a WordPress site on PHP 7.2.x and then using the 0.9.0 release of this plugin should have a fatal server error come up as a result.

## Changelog Entry
- Fixed - Bug fix for specific PHP versions (removed trailing commas from parameters.)