### PR TITLE
Rely on just-in-time translation loading

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -93,7 +93,6 @@ class Two_Factor_Core {
 	 * @since 0.1-dev
 	 */
 	public static function add_hooks( $compat ) {
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_textdomain' ) );
 		add_action( 'init', array( __CLASS__, 'get_providers' ) );
 		add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 		add_filter( 'wp_login_errors', array( __CLASS__, 'maybe_show_reset_password_notice' ) );
@@ -130,15 +129,6 @@ class Two_Factor_Core {
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
 		$compat->init();
-	}
-
-	/**
-	 * Loads the plugin's text domain.
-	 *
-	 * Sites on WordPress 4.6+ benefit from just-in-time loading of translations.
-	 */
-	public static function load_textdomain() {
-		load_plugin_textdomain( 'two-factor' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Two-Factor ===
 Contributors:      georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:              two factor, two step, authentication, login, totp, fido u2f, u2f, email, backup codes, 2fa, yubikey
-Requires at least: 4.3
+Requires at least: 4.6
 Tested up to:      6.5
 Requires PHP:      5.6
 Stable tag:        0.9.1

--- a/two-factor.php
+++ b/two-factor.php
@@ -8,14 +8,16 @@
  * @license     GPL-2.0-or-later
  *
  * @wordpress-plugin
- * Plugin Name: Two Factor
- * Plugin URI:  https://wordpress.org/plugins/two-factor/
- * Description: Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
- * Author:      Plugin Contributors
- * Version:     0.9.1
- * Author URI:  https://github.com/wordpress/two-factor/graphs/contributors
- * Network:     True
- * Text Domain: two-factor
+ * Plugin Name:       Two Factor
+ * Plugin URI:        https://wordpress.org/plugins/two-factor/
+ * Description:       wo-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F), email and backup verification codes.
+ * Author:            Plugin Contributors
+ * Version:           0.9.1
+ * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
+ * Network:           True
+ * Text Domain:       two-factor
+ * Requires at least: 4.6
+ * Requires PHP:      5.6
  */
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Removes the manual `load_plugin_textdomain()` call to rely on WordPress to load translations at the right time.

Bumps the requirement to WordPress 4.6 accordingly.

Also, defines the `Requires *` headers in the main plugin file so that WordPress can actually read them and prevent you from installing the plugin if requirements are not met.

The headers mustn't really be set in the readme.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

The plugin was loading translations too early on `plugins_loaded`. Plugins should wait until `init` to ensure the current user has been set up, so that the current user's locale can be respected.

That said, why manually load translations when WordPress can do it for you :-)

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Switch to a different language and see that the translations are still loaded as expected.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Ensured translations are only loaded just-in-time.
