### PR TITLE
Add/filter for support links

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -835,6 +835,7 @@ class Two_Factor_Core {
 							</a>
 						</li>
 					<?php endforeach; ?>
+					<?php echo apply_filters( 'two_factor_login_support_links', '' ); ?>
 				</ul>
 			</div>
 		<?php endif; ?>

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -835,7 +835,12 @@ class Two_Factor_Core {
 							</a>
 						</li>
 					<?php endforeach; ?>
-					<?php echo apply_filters( 'two_factor_login_support_links', '' ); ?>
+					<?php
+					/*
+					* Allow plugins to add links to the two-factor login form.
+					*/
+					echo apply_filters( 'two_factor_login_support_links', '' );
+					?>
 				</ul>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
## What?
Sometimes users have difficulty with their two-factor settings. In the "Having Problems?" section, we currently don't have a way to add links that are not providers. 

This PR adds a filter called `two_factor_login_support_links` to allow plugins to provide non-provider support links.

## Why?
We want to give users access to documentation that can help them with using 2fa or with recovering their account.

For example, it would allow us to do

```
Having Problems?
- Use your authenticator app
- Use a recovery code
- Recover your account
```

## How?
It adds a filter inside the `<ul>` so HTML can be passed in like so:

```
function my_custom_login_support_links( $content ) {
    return '<li><a href="{href}">Recover your account</a></li>';
}
add_filter( 'two_factor_login_support_links', 'my_custom_login_support_links' )

```

## Testing Instructions
1. Add the filter mentioned above
2. With 2fa configured, try logging in
3. Expect to see the new link in the list.


## Changelog Entry
> Added - Filter named `two_factor_login_support_links` to support adding links to login form.
