### PR TITLE
Fire an action when a user revalites their 2FA session.

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1404,6 +1404,8 @@ class Two_Factor_Core {
 			'two-factor-login'    => time(),
 		) );
 
+		do_action( 'two_factor_user_revalidated', $user, $provider );
+		
 		// Must be global because that's how login_header() uses it.
 		global $interim_login;
 		$interim_login = isset( $_REQUEST['interim-login'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited,WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds an action for when a user revalidates their session.

This is similar to the existing `two_factor_user_authenticated` action for when the user authenticated via 2FA in the first place.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

I'm needing to have a cookie set for when the revalidation logic is triggered, and neither Two-Factor nor WordPress (in it's session handler) have a way to detect that the current sessions 2FA has been revalidated / modified.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry

Added - A New hook was added that fires when a user revalidates their 2FA session.

