### PR TITLE
Bump minimum WP to 6.3, minimum PHP to 7.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "minimum-stability": "dev",
   "prefer-stable" : true,
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.2.24|^8"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "lint": "phpcs",
-    "lint-compat": "phpcs -p --standard=PHPCompatibilityWP --runtime-set testVersion 5.6- --extensions=php --ignore='tests/,dist/,includes/Yubico/,vendor/,wordpress/,node_modules/' .",
+    "lint-compat": "phpcs -p --standard=PHPCompatibilityWP --runtime-set testVersion 7.2- --extensions=php --ignore='tests/,dist/,includes/Yubico/,vendor/,wordpress/,node_modules/' .",
     "test": "phpunit",
     "test:watch": [
       "Composer\\Config::disableProcessTimeout",

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,8 +12,8 @@
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
  * Version:           0.9.1
- * Requires at least: 4.6
- * Requires PHP:      5.6
+ * Requires at least: 6.3
+ * Requires PHP:      7.2
  * Author:            Plugin Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
  * License:           GPL-2.0-or-later


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #461

## What?
<!-- In a few words, what is the PR actually doing? -->
Increases the PHP & WP minimum requirements.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
Because we can. But also because the automated testing isn't going to cover these old versions, and nor should we.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Changed - This plugin now requires PHP 7.2 and WordPress 6.3 or later.