### PR TITLE
Keep the requirements at PHP 5.6 and WP 4.6 until we have a practical reason

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
                   - latest
                   - trunk
                   - '6.3'
+                include:
+                    - php: '5.6'
+                      wp: '4.6'
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "minimum-stability": "dev",
   "prefer-stable" : true,
   "require": {
-    "php": ">=7.2.24|^8"
+    "php": ">=5.6"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "lint": "phpcs",
-    "lint-compat": "phpcs -p --standard=PHPCompatibilityWP --runtime-set testVersion 7.2- --extensions=php --ignore='tests/,dist/,includes/Yubico/,vendor/,node_modules/' .",
+    "lint-compat": "phpcs -p --standard=PHPCompatibilityWP --runtime-set testVersion 5.6- --extensions=php --ignore='tests/,dist/,includes/Yubico/,vendor/,node_modules/' .",
     "lint-phpstan": "phpstan analyse --verbose --memory-limit=1G",
     "test": "vendor/bin/phpunit",
     "test:watch": [

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ Here is a list of action and filter hooks provided by the plugin:
 
 = PHP and WordPress Version Support =
 
-Starting from version 1.0.0 of this plugin, it will maintain compatibility with WordPress core versions that are up to one year old, as well as the minimum PHP version supported by those WordPress versions.
+Starting from version 1.0.0 of this plugin, it will maintain compatibility with WordPress core versions that are up to one year old, as well as <a href="https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/">the minimum PHP version supported by those WordPress versions</a>.
 
 == Frequently Asked Questions ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,10 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 
+= PHP and WordPress Version Support =
+
+Starting from version 1.0.0 of this plugin, it will maintain compatibility with WordPress core versions that are up to one year old, as well as the minimum PHP version supported by those WordPress versions.
+
 == Frequently Asked Questions ==
 
 = How can I send feedback or get help with a bug? =
@@ -46,6 +50,13 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 1. Two-factor options under User Profile.
 2. U2F Security Keys section under User Profile.
 3. Email Code Authentication during WordPress Login.
+
+== Upgrade Notice ==
+
+<!-- Keep this in sync with the next version up until 1.0.0. -->
+= 0.10.0 =
+
+From version 1.0.0, this plugin will support WordPress versions up to one year old and the minimum PHP version they require.
 
 == Changelog ==
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,8 +12,8 @@
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
  * Version:           0.9.1
- * Requires at least: 6.3
- * Requires PHP:      7.2
+ * Requires at least: 4.6
+ * Requires PHP:      5.6
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
  * License:           GPL-2.0-or-later


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Reverts #625.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Although we want users to upgrade their PHP and WP, the plugin code currently supports PHP 5.6+ and WP 4.6 so we keep those requirements until we've given plenty of notice that version 1.0.0 of this plugin will no longer support anything below 7.4 and a year old WP core. 

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

- Update README to include an official policy on the supported versions of PHP and WP core.
- Use the upgrade notice up until version 1.0.0 to inform users about the upcoming enforcement.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
