### PR TITLE
Encourage setting up a second recovery method 

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1821,9 +1821,21 @@ class Two_Factor_Core {
 			$show_2fa_options ? '' : 'disabled="disabled"'
 		);
 
-		wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false );
+		$notices = [];
+		if ( empty( $enabled_providers ) ) {
+			$notices[] = __( 'Configure a primary two-factor method along with a backup method, such as Recovery Codes, to avoid being locked out if you lose access to your primary method.', 'two-factor' );
+		} elseif ( 1 === count( $enabled_providers ) ) {
+			$notices['warning'] = __( 'To prevent being locked out of your account, consider enabling a backup method like Recovery Codes in case you lose access to your primary authentication method.', 'two-factor' );
+		}
+
 		?>
 		<h2><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></h2>
+		<?php foreach ( $notices as $notice_type => $notice ) : ?>
+		<div class="<?php echo esc_attr( $notice_type ? 'notice inline notice-' . $notice_type : '' ); ?>">
+			<p><?php echo esc_html( $notice ); ?></p>
+		</div>
+		<?php endforeach; ?>
+		<?php wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false ); ?>
 		<input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
 		<table class="wp-list-table widefat fixed striped table-view-list two-factor-methods-table">
 			<thead>

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1788,6 +1788,8 @@ class Two_Factor_Core {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function user_two_factor_options( $user ) {
+		$notices = [];
+
 		wp_enqueue_style( 'user-edit-2fa', plugins_url( 'user-edit.css', __FILE__ ), array(), TWO_FACTOR_VERSION );
 
 		$enabled_providers = array_keys( self::get_available_providers_for_user( $user ) );
@@ -1803,16 +1805,16 @@ class Two_Factor_Core {
 		$show_2fa_options = self::current_user_can_update_two_factor_options();
 
 		if ( ! $show_2fa_options ) {
-			$url = self::get_user_two_factor_revalidate_url();
-			$url = add_query_arg( 'redirect_to', urlencode( self::get_user_settings_page_url( $user->ID ) . '#two-factor-options' ), $url );
+			$url = add_query_arg(
+				'redirect_to',
+				urlencode( self::get_user_settings_page_url( $user->ID ) . '#two-factor-options' ),
+				self::get_user_two_factor_revalidate_url()
+			);
 
-			printf(
-				'<div class="notice notice-warning inline"><p>%s</p></div>',
-				sprintf(
-					__( 'To update your Two-Factor options, you must first revalidate your session.', 'two-factor' ) .
-					'<br><a class="button" href="%s">' . __( 'Revalidate now', 'two-factor' ) . '</a>',
+			$notices['warning two-factor-warning-revalidate-session'] = sprintf(
+					esc_html__( 'To update your Two-Factor options, you must first revalidate your session.', 'two-factor' ) .
+					' <a class="button" href="%s">' . esc_html__( 'Revalidate now', 'two-factor' ) . '</a>',
 					esc_url( $url )
-				)
 			);
 		}
 
@@ -1821,20 +1823,19 @@ class Two_Factor_Core {
 			$show_2fa_options ? '' : 'disabled="disabled"'
 		);
 
-		$notices = [];
-		if ( empty( $enabled_providers ) ) {
-			$notices[] = __( 'Configure a primary two-factor method along with a backup method, such as Recovery Codes, to avoid being locked out if you lose access to your primary method.', 'two-factor' );
-		} elseif ( 1 === count( $enabled_providers ) ) {
-			$notices['warning'] = __( 'To prevent being locked out of your account, consider enabling a backup method like Recovery Codes in case you lose access to your primary authentication method.', 'two-factor' );
+		if ( 1 === count( $enabled_providers ) ) {
+			$notices['warning two-factor-warning-suggest-backup'] = esc_html__( 'To prevent being locked out of your account, consider enabling a backup method like Recovery Codes in case you lose access to your primary authentication method.', 'two-factor' );
 		}
-
 		?>
 		<h2><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></h2>
 		<?php foreach ( $notices as $notice_type => $notice ) : ?>
 		<div class="<?php echo esc_attr( $notice_type ? 'notice inline notice-' . $notice_type : '' ); ?>">
-			<p><?php echo esc_html( $notice ); ?></p>
+			<p><?php echo $notice; ?></p>
 		</div>
 		<?php endforeach; ?>
+		<p>
+			<?php  esc_html_e( 'Configure a primary two-factor method along with a backup method, such as Recovery Codes, to avoid being locked out if you lose access to your primary method.', 'two-factor' ); ?>
+		</p>
 		<?php wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false ); ?>
 		<input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
 		<table class="wp-list-table widefat fixed striped table-view-list two-factor-methods-table">

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1830,7 +1830,7 @@ class Two_Factor_Core {
 		<h2><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></h2>
 		<?php foreach ( $notices as $notice_type => $notice ) : ?>
 		<div class="<?php echo esc_attr( $notice_type ? 'notice inline notice-' . $notice_type : '' ); ?>">
-			<p><?php echo $notice; ?></p>
+			<p><?php echo wp_kses_post( $notice ); ?></p>
 		</div>
 		<?php endforeach; ?>
 		<p>


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #485.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Encourage users to configure at least two two-factor methods to prevent them from being locked out of account in case of loosing access to the primary method.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

Showing a notice before any of the methods are configured _and_ when only one method is configured.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Setup a plugin and go to your profile to setup the methods.
2. Select only email, save the settings and confirm that a message is shown suggesting to setup another method.

## Screenshots or screencast
<!-- if applicable -->

No methods configured:

![notice-default](https://github.com/user-attachments/assets/ab29ed61-d2e7-482f-9aa3-127a0537c4eb)

Only one method configured:

![notice-second](https://github.com/user-attachments/assets/3c557c45-a69f-4dd3-b899-10203649c8d2)

Multiple notices:

<img width="1372" alt="multiple-notices" src="https://github.com/user-attachments/assets/1641b496-bb1d-428d-b8dc-e9f47ad8bb5d">

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Added a notice to the user profile suggesting to configure at least two two-factor methods for ensuring access.