### PR TITLE
Enable TOTP method when method is configured

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1896,10 +1896,8 @@ class Two_Factor_Core {
 	 * @return bool True if the provider was enabled, false otherwise.
 	 */
 	public static function enable_provider_for_user( $user_id, $new_provider ) {
-		$available_providers = self::get_providers();
-
 		// Ensure the provider is even available.
-		if ( isset( $available_providers[ $new_provider ] ) ) {
+		if ( ! array_key_exists( $new_provider, self::get_providers() ) ) {
 			return false;
 		}
 
@@ -1930,7 +1928,7 @@ class Two_Factor_Core {
 	 */
 	public static function disable_provider_for_user( $user_id, $provider_to_delete ) {
 		// Check if the provider is even enabled.
-		if ( ! in_array( $provider_to_delete, self::get_providers_classes(), true ) ) {
+		if ( ! array_key_exists( $provider_to_delete, self::get_providers() ) ) {
 			return false;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1893,11 +1893,18 @@ class Two_Factor_Core {
 	 * @return bool True if the provider was enabled, false otherwise.
 	 */
 	public static function enable_provider_for_user( $user_id, $new_provider ) {
+		if ( ! in_array( $new_provider, self::get_providers_classes(), true ) ) {
+			return false;
+		}
+
 		$enabled_providers = self::get_enabled_providers_for_user( $user_id );
 
-		if ( ! in_array( $new_provider, $enabled_providers ) ) {
-			$enabled_providers[] = $new_provider;
+		// Check if this is enabled already.
+		if ( in_array( $new_provider, $enabled_providers ) ) {
+			return true;
 		}
+
+		$enabled_providers[] = $new_provider;
 
 		// Add as primary if none set.
 		if ( ! self::get_primary_provider_for_user( $user_id ) ) {
@@ -1921,6 +1928,11 @@ class Two_Factor_Core {
 	 * @return bool True if the provider was disabled, false otherwise.
 	 */
 	public static function disable_provider_for_user( $user_id, $provider_to_delete ) {
+		// Check if the provider is even enabled.
+		if ( ! in_array( $provider_to_delete, self::get_providers_classes(), true ) ) {
+			return false;
+		}
+
 		$enabled_providers = self::get_enabled_providers_for_user( $user_id );
 
 		// Check if this is disabled already.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1896,7 +1896,10 @@ class Two_Factor_Core {
 	 * @return bool True if the provider was enabled, false otherwise.
 	 */
 	public static function enable_provider_for_user( $user_id, $new_provider ) {
-		if ( ! in_array( $new_provider, self::get_providers_classes(), true ) ) {
+		$available_providers = self::get_providers();
+
+		// Ensure the provider is even available.
+		if ( isset( $available_providers[ $new_provider ] ) ) {
 			return false;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1906,11 +1906,6 @@ class Two_Factor_Core {
 
 		$enabled_providers[] = $new_provider;
 
-		// Add as primary if none set.
-		if ( ! self::get_primary_provider_for_user( $user_id ) ) {
-			update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, $new_provider );
-		}
-
 		return (bool) update_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, $enabled_providers );
 	}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -249,7 +249,8 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Get all enabled two-factor providers.
+	 * Get all enabled two-factor providers with keys as the original
+	 * provider class names and the values as the provider class instances.
 	 *
 	 * @since 0.1-dev
 	 *

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1246,6 +1246,8 @@ class Two_Factor_Core {
 			return false;
 		}
 
+		return true;
+
 		// If the current user is not using two-factor, they can adjust the settings.
 		if ( ! self::is_user_using_two_factor( $user_id ) ) {
 			return true;
@@ -1794,13 +1796,8 @@ class Two_Factor_Core {
 		$primary_provider  = self::get_primary_provider_for_user( $user->ID );
 
 		$primary_provider_key = null;
-		if ( is_object( $primary_provider ) ) {
+		if ( ! empty( $primary_provider ) && is_object( $primary_provider ) ) {
 			$primary_provider_key = $primary_provider->get_key();
-		}
-
-		// Reset the primary if it isn't set to one of the enabled providers.
-		if ( ! in_array( $primary_provider_key, $enabled_providers ) ) {
-			$primary_provider_key = null;
 		}
 
 		// This is specific to the current session, not the displayed user.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1793,9 +1793,13 @@ class Two_Factor_Core {
 		$enabled_providers = array_keys( self::get_available_providers_for_user( $user ) );
 		$primary_provider  = self::get_primary_provider_for_user( $user->ID );
 
-		if ( ! empty( $primary_provider ) && is_object( $primary_provider ) ) {
+		$primary_provider_key = null;
+		if ( is_object( $primary_provider ) ) {
 			$primary_provider_key = $primary_provider->get_key();
-		} else {
+		}
+
+		// Reset the primary if it isn't set to one of the enabled providers.
+		if ( ! in_array( $primary_provider_key, $enabled_providers ) ) {
 			$primary_provider_key = null;
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1246,8 +1246,6 @@ class Two_Factor_Core {
 			return false;
 		}
 
-		return true;
-
 		// If the current user is not using two-factor, they can adjust the settings.
 		if ( ! self::is_user_using_two_factor( $user_id ) ) {
 			return true;

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -368,6 +368,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 								user_id: <?php echo wp_json_encode( $user->ID ); ?>,
 								key: key,
 								code: code,
+								enable_provider: true,
 							}
 						} ).fail( function( response, status ) {
 							var errorMessage = response.responseJSON.message || status,

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -151,6 +151,10 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 		$this->delete_user_totp_key( $user_id );
 
+		if ( ! Two_Factor_Core::disable_provider_for_user( $user_id, 'Two_Factor_Totp' ) ) {
+			return new WP_Error( 'db_error', __( 'Unable to disable TOTP provider for this user.', 'two-factor' ), array( 'status' => 500 ) );
+		}
+
 		ob_start();
 		$this->user_two_factor_options( $user );
 		$html = ob_get_clean();

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -384,8 +384,10 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 							$error.find('p').text( errorMessage );
 
+							$( '#enabled-Two_Factor_Totp' ).prop( 'checked', false );
 							$('#two-factor-totp-authcode').val('');
 						} ).then( function( response ) {
+							$( '#enabled-Two_Factor_Totp' ).prop( 'checked', true );
 							$( '#two-factor-totp-options' ).html( response.html );
 						} );
 					} );
@@ -412,6 +414,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 									user_id: <?php echo wp_json_encode( $user->ID ); ?>,
 								}
 							} ).then( function( response ) {
+								$( '#enabled-Two_Factor_Totp' ).prop( 'checked', false );
 								$( '#two-factor-totp-options' ).html( response.html );
 							} );
 						} );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -818,52 +818,52 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	public function test_enable_disable_provider_for_user() {
 		$user              = self::factory()->user->create_and_get();
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertEmpty( $enabled_providers );
+		$this->assertEmpty( $enabled_providers, 'No providers are enabled by default' );
 
 		// Disabling one that's already disabled should succeed.
 		$totp_disabled = Two_Factor_Core::disable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
-		$this->assertTrue( $totp_disabled );
+		$this->assertTrue( $totp_disabled, 'Disabling something that wasn\'t enabled should succeed' );
 
 		// Disabling one that doesn't exist should fail.
 		$nonexistent_enabled = Two_Factor_Core::enable_provider_for_user( $user->ID, 'Nonexistent_Provider' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertFalse( $nonexistent_enabled );
-		$this->assertEmpty( $enabled_providers );
-		$this->assertNull( Two_Factor_Core::get_primary_provider_for_user( $user->ID ) );
+		$this->assertFalse( $nonexistent_enabled, 'Nonexistent shouldn\'t be allowed to be enabled' );
+		$this->assertEmpty( $enabled_providers, 'Nonexistent wasn\'t enabled' );
+		$this->assertNull( Two_Factor_Core::get_primary_provider_for_user( $user->ID ), 'Nonexistent wasn\'t set as primary' );
 
 		// Enabling a valid one should succeed. The first one that's enabled and configured should be the default primary.
 		$totp = Two_Factor_Totp::get_instance();
 		$totp->set_user_totp_key( $user->ID, 'foo' );
 		$totp_enabled = Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertTrue( $totp_enabled );
-		$this->assertSame( array( 'Two_Factor_Totp' ), $enabled_providers );
-		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key() );
+		$this->assertTrue( $totp_enabled, 'Can enable a valid provider' );
+		$this->assertSame( array( 'Two_Factor_Totp' ), $enabled_providers, 'Enabled provider is now listed as enabled' );
+		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key(), 'Primary is now the only enabled provider' );
 
 		// Enabling one that's already enabled should succeed.
 		$totp_enabled = Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
-		$this->assertTrue( $totp_enabled );
+		$this->assertTrue( $totp_enabled, 'Can enable a provider that is already enabled' );
 
 		// Enabling another should succeed, and not change the primary.
 		$dummy_enabled = Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Dummy' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertTrue( $dummy_enabled );
-		$this->assertSame( array( 'Two_Factor_Totp', 'Two_Factor_Dummy' ), $enabled_providers );
-		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key() );
+		$this->assertTrue( $dummy_enabled, 'Can enable valid provider' );
+		$this->assertSame( array( 'Two_Factor_Totp', 'Two_Factor_Dummy' ), $enabled_providers, 'Multiple can be enabled at the same time' );
+		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key(), 'The primary not changed upon additional providers being enabled' );
 
 		// Disabling one that doesn't exist should fail.
 		$nonexistent_disabled = Two_Factor_Core::disable_provider_for_user( $user->ID, 'Nonexistent_Provider' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertFalse( $nonexistent_disabled );
-		$this->assertSame( array( 'Two_Factor_Totp', 'Two_Factor_Dummy' ), $enabled_providers );
-		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key() );
+		$this->assertFalse( $nonexistent_disabled, 'Unavailable provider can\'t be disabled' );
+		$this->assertSame( array( 'Two_Factor_Totp', 'Two_Factor_Dummy' ), $enabled_providers, 'Unavailable wasn\'t added to the list of enabled proviers' );
+		$this->assertSame( 'Two_Factor_Totp', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key(), 'The primary is still the same after unavailable disable attempt' );
 
 		// Disabling one that's enabled should succeed, and change the primary to the next available one.
 		$totp_disabled = Two_Factor_Core::disable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
-		$this->assertTrue( $totp_disabled ); //todo enable and fix
-		$this->assertSame( array( 1 => 'Two_Factor_Dummy' ), $enabled_providers );
-		$this->assertSame( 'Two_Factor_Dummy', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key() );
+		$this->assertTrue( $totp_disabled, 'Can disable a provider that is enabled' );
+		$this->assertSame( array( 1 => 'Two_Factor_Dummy' ), $enabled_providers, 'The other providers are kept enabled' );
+		$this->assertSame( 'Two_Factor_Dummy', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key(), 'Primary is updated to the first available' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Users expect a method to be enabled if they chose to configure it.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Fixes #556.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Setup workflow:

1. Configure the TOTP method by submitting the generated code.
2. Confirm the TOTP method is now enabled in the table.

Reset workflow: 

1. Click on RESET TOTP method button.
2. Confirm the TOTP method is now disabled in the table.

## Screenshots or screencast
<!-- if applicable -->

https://github.com/user-attachments/assets/bd3a9143-86b5-4fa9-b31d-4e27f395f391

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
