### PR TITLE
Focus in code input when totp is checked

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -359,7 +359,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 					// Focus the auth code input when the checkbox is clicked.
 					document.getElementById('enabled-Two_Factor_Totp').addEventListener('click', function(e) {
 						if ( e.target.checked ) {
-							document.getElementById('two-factor-totp-augthcode').focus();
+							document.getElementById('two-factor-totp-authcode').focus();
 						}
 					});
 

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -356,6 +356,13 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 
 			<script>
 				(function($){
+					// Focus the auth code input when the checkbox is clicked.
+					document.getElementById('enabled-Two_Factor_Totp').addEventListener('click', function(e) {
+						if ( e.target.checked ) {
+							document.getElementById('two-factor-totp-augthcode').focus();
+						}
+					});
+
 					$('.totp-submit').click( function( e ) {
 						e.preventDefault();
 						var key = $('#two-factor-totp-key').val(),


### PR DESCRIPTION
## What?
This PR updates the UX for when TOTP is checked it focuses in the code input, fixes https://github.com/WordPress/two-factor/issues/159

## Why?
For better UX as requested in https://github.com/WordPress/two-factor/issues/159 

## How?
Adds an event listener to check when the checkbox is enabled to focus into the code.

## Testing Instructions
Start the env after checking out into the branch go to http://localhost:8888/wp-admin/profile.php, scroll down two factor options, confirm it focuses into the input.

## Screenshots or screencast
https://share.cleanshot.com/qWNlb6gQTp90hDS8Fq0Q

## Changelog Entry
> Changed - UX update, focus into code input when TOTP is enabled