### PR TITLE
Remove duplicate `two_factor_providers` filter calls to allow disabling core providers

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -151,12 +151,7 @@ class Two_Factor_Core {
 
 		$providers = self::get_default_providers();
 
-		/**
-		 * Include additional providers to be uninstalled.
-		 *
-		 * @param array $providers A key-value array where the key is the class name, and
-		 *                         the value is the path to the file containing the class.
-		 */
+		/** This filter is documented in the get_providers() method */
 		$additional_providers = apply_filters( 'two_factor_providers', $providers );
 
 		// Merge them with the default providers.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -289,6 +289,7 @@ class Two_Factor_Core {
 		// Map provider keys to classes so that we can instantiate them.
 		$providers = self::get_providers_classes( $providers );
 
+		// TODO: Refactor this to avoid instantiating the provider instances every time this method is called.
 		foreach ( $providers as $provider_key => $provider_class ) {
 			try {
 				$providers[ $provider_key ] = call_user_func( array( $provider_class, 'get_instance' ) );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -241,9 +241,9 @@ class Two_Factor_Core {
 			$class = apply_filters( "two_factor_provider_classname_{$provider_key}", $class, $path );
 
 			/**
-			 * Confirm that it's been successfully included before instantiating.
+			 * Confirm that it's been successfully included.
 			 */
-			if ( method_exists( $class, 'get_instance' ) ) {
+			if ( class_exists( $class ) ) {
 				$providers[ $provider_key ] = $class;
 			} else {
 				unset( $providers[ $provider_key ] );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -161,7 +161,7 @@ class Two_Factor_Core {
 
 		// Merge them with the default providers.
 		if ( ! empty( $additional_providers ) ) {
-			return array_merge( $providers, $additional_providers );
+			$providers = array_merge( $providers, $additional_providers );
 		}
 
 		foreach ( self::get_providers_classes( $providers ) as $provider_class ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -149,7 +149,22 @@ class Two_Factor_Core {
 
 		$option_keys = array();
 
-		foreach ( self::get_providers_classes() as $provider_class ) {
+		$providers = self::get_default_providers();
+
+		/**
+		 * Include additional providers to be uninstalled.
+		 *
+		 * @param array $providers A key-value array where the key is the class name, and
+		 *                         the value is the path to the file containing the class.
+		 */
+		$additional_providers = apply_filters( 'two_factor_providers', $providers );
+
+		// Merge them with the default providers.
+		if ( ! empty( $additional_providers ) ) {
+			return array_merge( $providers, $additional_providers );
+		}
+
+		foreach ( self::get_providers_classes( $providers ) as $provider_class ) {
 			// Merge with provider-specific user meta keys.
 			if ( method_exists( $provider_class, 'uninstall_user_meta_keys' ) ) {
 				try {
@@ -192,29 +207,14 @@ class Two_Factor_Core {
 	 *
 	 * @return array List of provider keys and paths to class files.
 	 */
-	public static function get_providers_registered() {
-		$providers = array(
+	private static function get_default_providers() {
+		return array(
 			'Two_Factor_Email'        => TWO_FACTOR_DIR . 'providers/class-two-factor-email.php',
 			'Two_Factor_Totp'         => TWO_FACTOR_DIR . 'providers/class-two-factor-totp.php',
 			'Two_Factor_FIDO_U2F'     => TWO_FACTOR_DIR . 'providers/class-two-factor-fido-u2f.php',
 			'Two_Factor_Backup_Codes' => TWO_FACTOR_DIR . 'providers/class-two-factor-backup-codes.php',
 			'Two_Factor_Dummy'        => TWO_FACTOR_DIR . 'providers/class-two-factor-dummy.php',
 		);
-
-		/**
-		 * Filter the supplied providers.
-		 *
-		 * @param array $providers A key-value array where the key is the class name, and
-		 *                         the value is the path to the file containing the class.
-		 */
-		$additional_providers = apply_filters( 'two_factor_providers', $providers );
-
-		// Merge them with the default providers.
-		if ( ! empty( $additional_providers ) ) {
-			return array_merge( $providers, $additional_providers );
-		}
-
-		return $providers;
 	}
 
 	/**
@@ -261,7 +261,7 @@ class Two_Factor_Core {
 	 * @return array
 	 */
 	public static function get_providers() {
-		$providers = self::get_providers_registered();
+		$providers = self::get_default_providers();
 
 		/**
 		 * Filter the supplied providers.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1587,7 +1587,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		add_filter(
 			'two_factor_providers',
-			function( $providers ) {
+			function ( $providers ) {
 				return array_diff_key( $providers, array( 'Two_Factor_Email' => null ) );
 			}
 		);
@@ -1616,7 +1616,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		add_filter(
 			'two_factor_providers',
-			function( $providers ) {
+			function ( $providers ) {
 				return array_diff_key( $providers, array( 'Two_Factor_Totp' => null ) );
 			}
 		);

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1582,6 +1582,21 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_can_disable_default_providers() {
+		$this->assertContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Email provider is enabled by default' );
+
+		add_filter(
+			'two_factor_providers',
+			function( $providers ) {
+				return array_diff_key( $providers, array( 'Two_Factor_Email' => null ) );
+			}
+		);
+
+		$this->assertNotContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Default provider can be disabled via a filter' );
+
+		remove_all_filters( 'two_factor_providers' );
+	}
+
 	/**
 	 * Plugin uninstall removes all user meta even for disabled providers.
 	 *

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1581,4 +1581,41 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			'Provider was disabled due to uninstall'
 		);
 	}
+
+	/**
+	 * Plugin uninstall removes all user meta even for disabled providers.
+	 *
+	 * @covers Two_Factor_Core::uninstall
+	 */
+	public function test_uninstall_removes_disabled_provider_user_meta() {
+		$user = self::factory()->user->create_and_get();
+
+		// Enable a provider for the user.
+		Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
+
+		$totp_provider = Two_Factor_Totp::get_instance();
+
+		$totp_provider->set_user_totp_key( $user->ID, 'some_key' );
+
+		$this->assertEquals( 'some_key', $totp_provider->get_user_totp_key( $user->ID ), 'TOTP secret was set for user' );
+
+		add_filter(
+			'two_factor_providers',
+			function( $providers ) {
+				return array_diff_key( $providers, array( 'Two_Factor_Totp' => null ) );
+			}
+		);
+
+		$this->assertNotContains(
+			'Two_Factor_Totp',
+			Two_Factor_Core::get_enabled_providers_for_user( $user->ID ),
+			'TOTP provider is disabled for everyone via filter'
+		);
+
+		Two_Factor_Core::uninstall();
+
+		$this->assertEmpty( $totp_provider->get_user_totp_key( $user->ID ), 'TOTP secret was deleted during uninstall' );
+
+		remove_all_filters( 'two_factor_providers' );
+	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/two-factor/pull/637#discussion_r1831364092

<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?

In #637 we introduced a dedicated helper to retrieve all possible two-factor providers (even if disabled) so that we could purge all their added user meta and options during uninstall.

Accidentally it added another instance of the `two_factor_providers` filter which was already defined in `get_providers()`.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

- Introduce a method for getting the default built-in providers. This is used as the starting point for enabled providers and when collecting all providers to clean during plugin uninstall.
- Pass that default list of providers to the `two_factor_providers` filter when getting "enabled" providers from `get_providers()`.
- Refactor `get_providers_classes()` to accept a list of provider names and their class files instead of attempting to retrieve some provider state. During uninstall, we need all providers while during runtime only the enabled ones.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Use the plugin without any `two_factor_providers` filters. All default providers are available to all users.
- Attach a filter to `two_factor_providers` that limits just one provider. Attempt to uninstall the plugin and confirm that it removes also the meta for the disabled providers (see the phpunit test case cover this).

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Changed - removed duplicate two-factor provider filter.
