### PR TITLE
Add filters for email token and backup code length

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -239,8 +239,16 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			$codes_hashed = (array) get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 		}
 
+		/**
+		 * Customize the character count of the backup codes.
+		 *
+		 * @var int $code_length Length of the backup code.
+		 * @var WP_User $user User object.
+		 */
+		$code_length = (int) apply_filters( 'two_factor_backup_code_length', 8, $user );
+
 		for ( $i = 0; $i < $num_codes; $i++ ) {
-			$code           = $this->get_code();
+			$code           = $this->get_code( $code_length );
 			$codes_hashed[] = wp_hash_password( $code );
 			$codes[]        = $code;
 			unset( $code );

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -214,6 +214,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
+	/**
+	 * Get the backup code length for a user.
+	 *
+	 * @param WP_User $user User object.
+	 *
+	 * @return int Number of characters.
+	 */
 	private function get_backup_code_length( $user ) {
 		/**
 		 * Customize the character count of the backup codes.

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -214,6 +214,18 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		<?php
 	}
 
+	private function get_backup_code_length( $user ) {
+		/**
+		 * Customize the character count of the backup codes.
+		 *
+		 * @var int $code_length Length of the backup code.
+		 * @var WP_User $user User object.
+		 */
+		$code_length = (int) apply_filters( 'two_factor_backup_code_length', 8, $user );
+
+		return $code_length;
+	}
+
 	/**
 	 * Generates backup codes & updates the user meta.
 	 *
@@ -239,13 +251,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			$codes_hashed = (array) get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
 		}
 
-		/**
-		 * Customize the character count of the backup codes.
-		 *
-		 * @var int $code_length Length of the backup code.
-		 * @var WP_User $user User object.
-		 */
-		$code_length = (int) apply_filters( 'two_factor_backup_code_length', 8, $user );
+		$code_length = $this->get_backup_code_length( $user );
 
 		for ( $i = 0; $i < $num_codes; $i++ ) {
 			$code           = $this->get_code( $code_length );
@@ -335,7 +341,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once ABSPATH . '/wp-admin/includes/template.php';
 
-		$code_placeholder = str_repeat( '0', self::NUMBER_OF_CODES );
+		$code_placeholder = str_repeat( 'X', $this->get_backup_code_length( $user ) );
 
 		?>
 		<p class="two-factor-prompt"><?php esc_html_e( 'Enter a recovery code.', 'two-factor' ); ?></p><br/>

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -348,13 +348,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	public function authentication_page( $user ) {
 		require_once ABSPATH . '/wp-admin/includes/template.php';
 
-		$code_placeholder = str_repeat( 'X', $this->get_backup_code_length( $user ) );
+		$code_length = $this->get_backup_code_length( $user );
+		$code_placeholder = str_repeat( 'X', $code_length );
 
 		?>
 		<p class="two-factor-prompt"><?php esc_html_e( 'Enter a recovery code.', 'two-factor' ); ?></p>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Recovery Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php esc_attr( self::NUMBER_OF_CODES ); ?>" />
+			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php echo esc_attr( $code_length ); ?>" />
 		</p>
 		<?php
 		submit_button( __( 'Submit', 'two-factor' ) );

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -344,7 +344,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$code_placeholder = str_repeat( 'X', $this->get_backup_code_length( $user ) );
 
 		?>
-		<p class="two-factor-prompt"><?php esc_html_e( 'Enter a recovery code.', 'two-factor' ); ?></p><br/>
+		<p class="two-factor-prompt"><?php esc_html_e( 'Enter a recovery code.', 'two-factor' ); ?></p>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Recovery Code:', 'two-factor' ); ?></label>
 			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php esc_attr( self::NUMBER_OF_CODES ); ?>" />

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -334,11 +334,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 */
 	public function authentication_page( $user ) {
 		require_once ABSPATH . '/wp-admin/includes/template.php';
+
+		$code_placeholder = str_repeat( '0', self::NUMBER_OF_CODES );
+
 		?>
 		<p class="two-factor-prompt"><?php esc_html_e( 'Enter a recovery code.', 'two-factor' ); ?></p><br/>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Recovery Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="1234 5678" autocomplete="one-time-code" data-digits="8" />
+			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php esc_attr( self::NUMBER_OF_CODES ); ?>" />
 		</p>
 		<?php
 		submit_button( __( 'Submit', 'two-factor' ) );

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -63,6 +63,11 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		return __( 'Send a code to your email', 'two-factor' );
 	}
 
+	/**
+	 * Get the email token length.
+	 *
+	 * @return int Email token string length.
+	 */
 	private function get_token_length() {
 		/**
 		 * Number of characters in the email token.

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -153,7 +153,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		 * @param integer $token_ttl Token time-to-live in seconds.
 		 * @param integer $user_id User ID.
 		 */
-		$token_ttl = (int) apply_filters_deprecated( 'two_factor_token_ttl', array( $token_ttl, $user_id ), '0.7.0', 'two_factor_email_token_ttl' );
+		$token_ttl = (int) apply_filters_deprecated( 'two_factor_token_ttl', array( $token_ttl, $user_id ), '0.11.0', 'two_factor_email_token_ttl' );
 
 		/**
 		 * Number of seconds the token is considered valid

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -148,10 +148,21 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		 * Number of seconds the token is considered valid
 		 * after the generation.
 		 *
+		 * @deprecated 0.11.0 Use {@see 'two_factor_email_token_ttl'} instead.
+		 *
 		 * @param integer $token_ttl Token time-to-live in seconds.
 		 * @param integer $user_id User ID.
 		 */
-		return (int) apply_filters( 'two_factor_token_ttl', $token_ttl, $user_id );
+		$token_ttl = (int) apply_filters_deprecated( 'two_factor_token_ttl', array( $token_ttl, $user_id ), '0.7.0', 'two_factor_email_token_ttl' );
+
+		/**
+		 * Number of seconds the token is considered valid
+		 * after the generation.
+		 *
+		 * @param integer $token_ttl Token time-to-live in seconds.
+		 * @param integer $user_id User ID.
+		 */
+		return (int) apply_filters( 'two_factor_email_token_ttl', $token_ttl, $user_id );
 	}
 
 	/**

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -63,6 +63,17 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		return __( 'Send a code to your email', 'two-factor' );
 	}
 
+	private function get_token_length() {
+		/**
+		 * Number of characters in the email token.
+		 *
+		 * @param int $token_length Number of characters in the email token.
+		 */
+		$token_length = (int) apply_filters( 'two_factor_email_token_length', 8 );
+
+		return $token_length;
+	}
+
 	/**
 	 * Generate the user token.
 	 *
@@ -72,9 +83,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function generate_token( $user_id ) {
-		$token_length = (int) apply_filters( 'two_factor_email_token_length', 8 );
-
-		$token = $this->get_code( $token_length );
+		$token = $this->get_code( $this->get_token_length() );
 
 		update_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, time() );
 		update_user_meta( $user_id, self::TOKEN_META_KEY, wp_hash( $token ) );
@@ -272,12 +281,15 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			$this->generate_and_email_token( $user );
 		}
 
+		$token_length = $this->get_token_length();
+		$token_placeholder = str_repeat( 'X', $token_length );
+
 		require_once ABSPATH . '/wp-admin/includes/template.php';
 		?>
 		<p class="two-factor-prompt"><?php esc_html_e( 'A verification code has been sent to the email address associated with your account.', 'two-factor' ); ?></p>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="two-factor-email-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="1234 5678" data-digits="8" />
+			<input type="text" inputmode="numeric" name="two-factor-email-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $token_placeholder ); ?>" data-digits="<?php echo esc_attr( $token_length ); ?>" />
 			<?php submit_button( __( 'Log In', 'two-factor' ) ); ?>
 		</p>
 		<p class="two-factor-email-resend">

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -72,7 +72,9 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function generate_token( $user_id ) {
-		$token = $this->get_code();
+		$token_length = (int) apply_filters( 'two_factor_token_length', 8 );
+
+		$token = $this->get_code( $token_length );
 
 		update_user_meta( $user_id, self::TOKEN_META_KEY_TIMESTAMP, time() );
 		update_user_meta( $user_id, self::TOKEN_META_KEY, wp_hash( $token ) );

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -72,7 +72,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return string
 	 */
 	public function generate_token( $user_id ) {
-		$token_length = (int) apply_filters( 'two_factor_token_length', 8 );
+		$token_length = (int) apply_filters( 'two_factor_email_token_length', 8 );
 
 		$token = $this->get_code( $token_length );
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,6 +28,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
+- `two_factor_token_length` filter overrides the default 8 character count for email tokens.
 
 == Frequently Asked Questions ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_providers` filter overrides the available two-factor providers such as email and time-based one-time passwords. Array values are PHP classnames of the two-factor providers.
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
-- `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
+- `two_factor_email_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 - `two_factor_email_token_length` filter overrides the default 8 character count for email tokens.
 - `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Providers the `WP_User` of the associated user as the second argument.
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
-- `two_factor_token_length` filter overrides the default 8 character count for email tokens.
+- `two_factor_email_token_length` filter overrides the default 8 character count for email tokens.
 - `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Providers the `WP_User` of the associated user as the second argument.
 
 == Frequently Asked Questions ==

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 - `two_factor_token_length` filter overrides the default 8 character count for email tokens.
+- `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Providers the `WP_User` of the associated user as the second argument.
 
 == Frequently Asked Questions ==
 

--- a/tests/providers/class-two-factor-backup-codes.php
+++ b/tests/providers/class-two-factor-backup-codes.php
@@ -194,4 +194,25 @@ class Tests_Two_Factor_Backup_Codes extends WP_UnitTestCase {
 		$this->provider->delete_code( $user, $backup_codes[0] );
 		$this->assertEquals( 1, $this->provider->codes_remaining_for_user( $user ) );
 	}
+
+	public function test_backup_code_length_filter() {
+		$user = new WP_User( self::factory()->user->create() );
+
+		$code_default = $this->provider->generate_codes( $user, array( 'number' => 1 ) );
+
+		add_filter(
+			'two_factor_backup_code_length',
+			function() {
+				return 7;
+			}
+		);
+
+		$code_custom_length = $this->provider->generate_codes( $user, array( 'number' => 1 ) );
+
+		$this->assertNotEquals( strlen( $code_custom_length[0] ), strlen( $code_default[0] ), 'Backup code length can be adjusted via filter' );
+
+		$this->assertEquals( 7, strlen( $code_custom_length[0] ), 'Backup code length matches the filtered length' );
+
+		remove_all_filters( 'two_factor_backup_code_length' );
+	}
 }

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -352,4 +352,24 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_custom_token_length() {
+		$user_id = self::factory()->user->create();
+
+		$default_token = $this->provider->generate_token( $user_id );
+
+		add_filter(
+			'two_factor_token_length',
+			function() {
+				return 15;
+			}
+		);
+
+		$custom_token = $this->provider->generate_token( $user_id );
+
+		$this->assertNotEquals( strlen( $default_token ), strlen( $custom_token ), 'Token length is different due to filter' );
+		$this->assertEquals( 15, strlen( $custom_token ), 'Token length matches the filter value' );
+
+		remove_all_filters( 'two_factor_token_length' );
+	}
+
 }

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -372,4 +372,47 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		remove_all_filters( 'two_factor_email_token_length' );
 	}
 
+	/**
+	 * Test the email token TTL.
+	 *
+	 * @expectedDeprecated two_factor_token_ttl
+	 */
+	public function test_email_token_ttl() {
+		$this->assertEquals(
+			15 * MINUTE_IN_SECONDS,
+			$this->provider->user_token_ttl( 123 ),
+			'The email token matches the default TTL'
+		);
+
+		add_filter(
+			'two_factor_email_token_ttl',
+			function() {
+				return 42;
+			}
+		);
+
+		$this->assertEquals(
+			42,
+			$this->provider->user_token_ttl( 123 ),
+			'The email token ttl can be filtered'
+		);
+
+		remove_all_filters( 'two_factor_email_token_ttl' );
+
+		add_filter(
+			'two_factor_token_ttl',
+			function() {
+				return 66;
+			}
+		);
+
+		$this->assertEquals(
+			66,
+			$this->provider->user_token_ttl( 123 ),
+			'The email token matches can be filtered with the deprecated filter'
+		);
+
+		remove_all_filters( 'two_factor_token_ttl' );
+	}
+
 }

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -358,7 +358,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		$default_token = $this->provider->generate_token( $user_id );
 
 		add_filter(
-			'two_factor_token_length',
+			'two_factor_email_token_length',
 			function() {
 				return 15;
 			}
@@ -369,7 +369,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		$this->assertNotEquals( strlen( $default_token ), strlen( $custom_token ), 'Token length is different due to filter' );
 		$this->assertEquals( 15, strlen( $custom_token ), 'Token length matches the filter value' );
 
-		remove_all_filters( 'two_factor_token_length' );
+		remove_all_filters( 'two_factor_email_token_length' );
 	}
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #374.

Replaces #419.

## What?
<!-- In a few words, what is the PR actually doing? -->

Implements two new filters:

- `two_factor_email_token_ttl` filter overrides the default 8 character count for email tokens. This has been renamed from `two_factor_token_ttl` which is now marked as deprecated.

- `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Providers the `WP_User` of the associated user as the second argument.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Users might want to increase this.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

- Introduce the filters and rename existing ones for consistency. Add tests to confirm both old and new filters are working.

- Updated the input field placeholders to match the expected character length. Note that this might give away the expected character length for a brute force attacker but we're rate limiting these attempts so that is not an issue.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

Note the updated `XXXX` characters for the placeholders and the correct length. Previously the placeholder was also including spaces but that could have confused the users about the format not matching what they get in the email or app. The input automatically removes invalid characters so the processing happens in either way.

![email-codes](https://github.com/user-attachments/assets/f13ce641-1978-4535-8a60-5533aa28c5e5)

![recover-codes](https://github.com/user-attachments/assets/c2fc97a3-de90-4b32-ba2a-0a9e055fb234)

Inspiration:

![input-format](https://github.com/user-attachments/assets/0e4369a4-a058-4ba5-8d55-36cbedc4e41f)

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Added - Introduce `two_factor_email_token_length` and `two_factor_backup_code_length` filters for adjusting the length of the respective tokens.