### PR TITLE
Release 0.11.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 6.6
-Stable tag:   0.10.0
+Stable tag:   0.11.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
- * Version:           0.10.0
+ * Version:           0.11.0
  * Requires at least: 6.3
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
@@ -30,7 +30,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.10.0' );
+define( 'TWO_FACTOR_VERSION', '0.11.0' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
Get a release out that fixes #651 mostly.

## Changelog

* Remove duplicate `two_factor_providers` filter calls to allow disabling core providers by @kasparsd in https://github.com/WordPress/two-factor/pull/651
* Encourage setting up a second recovery method  by @kasparsd in https://github.com/WordPress/two-factor/pull/642
* Focus in code input when totp is checked by @thrijith in https://github.com/WordPress/two-factor/pull/645
* Add autocomplete "one-time-code" attribute by @stefanmomm in https://github.com/WordPress/two-factor/pull/657
* Add filters for email token and backup code length by @kasparsd in https://github.com/WordPress/two-factor/pull/653
* Enable TOTP method when method is configured by @kasparsd in https://github.com/WordPress/two-factor/pull/643

## New Contributors
* @stefanmomm made their first contribution in https://github.com/WordPress/two-factor/pull/657

**Full Changelog**: https://github.com/WordPress/two-factor/compare/0.10.0...master