### PR TITLE
Trigger two-factor flow only when expected

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -682,17 +682,11 @@ class Two_Factor_Core {
 	 * @return WP_User|WP_Error
 	 */
 	public static function filter_authenticate( $user ) {
-		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) ) {
-			// Trigger the second-factor flow if the password was correct.
-			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
-
-			// Disable the XML-RPC and REST API for users with two-factor enabled.
-			if ( self::is_api_request() && ! self::is_user_api_login_enabled( $user->ID ) ) {
-				return new WP_Error(
-					'invalid_application_credentials',
-					__( 'Error: API login for user disabled.', 'two-factor' )
-				);
-			}
+		if ( $user instanceof WP_User && self::is_api_request() && self::is_user_using_two_factor( $user->ID ) && ! self::is_user_api_login_enabled( $user->ID ) ) {
+			return new WP_Error(
+				'invalid_application_credentials',
+				__( 'Error: API login for user disabled.', 'two-factor' )
+			);
 		}
 
 		return $user;
@@ -715,6 +709,7 @@ class Two_Factor_Core {
 		 * rather than through an unsupported 3rd-party login process which this plugin doesn't support.
 		 */
 		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) && did_action( 'login_init' ) ) {
+			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 			add_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -699,7 +699,7 @@ class Two_Factor_Core {
 			}
 
 			// Trigger the second-factor flow for valid users.
-			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
+			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), PHP_INT_MAX, 2 );
 		}
 
 		return $user;

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -682,11 +682,17 @@ class Two_Factor_Core {
 	 * @return WP_User|WP_Error
 	 */
 	public static function filter_authenticate( $user ) {
-		if ( $user instanceof WP_User && self::is_api_request() && self::is_user_using_two_factor( $user->ID ) && ! self::is_user_api_login_enabled( $user->ID ) ) {
-			return new WP_Error(
-				'invalid_application_credentials',
-				__( 'Error: API login for user disabled.', 'two-factor' )
-			);
+		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) ) {
+			// Trigger the second-factor flow if the password was correct.
+			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
+
+			// Disable the XML-RPC and REST API for users with two-factor enabled.
+			if ( self::is_api_request() && ! self::is_user_api_login_enabled( $user->ID ) ) {
+				return new WP_Error(
+					'invalid_application_credentials',
+					__( 'Error: API login for user disabled.', 'two-factor' )
+				);
+			}
 		}
 
 		return $user;
@@ -709,7 +715,6 @@ class Two_Factor_Core {
 		 * rather than through an unsupported 3rd-party login process which this plugin doesn't support.
 		 */
 		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) && did_action( 'login_init' ) ) {
-			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 			add_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -94,7 +94,6 @@ class Two_Factor_Core {
 	 */
 	public static function add_hooks( $compat ) {
 		add_action( 'init', array( __CLASS__, 'get_providers' ) ); // @phpstan-ignore return.void
-		add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 		add_filter( 'wp_login_errors', array( __CLASS__, 'maybe_show_reset_password_notice' ) );
 		add_action( 'after_password_reset', array( __CLASS__, 'clear_password_reset_notice' ) );
 		add_action( 'login_form_validate_2fa', array( __CLASS__, 'login_form_validate_2fa' ) );
@@ -710,6 +709,7 @@ class Two_Factor_Core {
 		 * rather than through an unsupported 3rd-party login process which this plugin doesn't support.
 		 */
 		if ( $user instanceof WP_User && self::is_user_using_two_factor( $user->ID ) && did_action( 'login_init' ) ) {
+			add_action( 'wp_login', array( __CLASS__, 'wp_login' ), 10, 2 );
 			add_filter( 'send_auth_cookies', '__return_false', PHP_INT_MAX );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoid triggering the two-factor logic on every `wp_login` hook even when no login attempt is expected.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Fixes #659.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

WP core uses the following filters during the `wp-login.php` request in the order of priority:

    // Priority 20.
    add_filter( 'authenticate', 'wp_authenticate_username_password', 20, 3 );
    add_filter( 'authenticate', 'wp_authenticate_email_password', 20, 3 );
    add_filter( 'authenticate', 'wp_authenticate_application_password', 20, 3 );

    // Priority 30.
    add_filter( 'authenticate', 'wp_authenticate_cookie', 30, 3 );

    // Priority 99.
    add_filter( 'authenticate', 'wp_authenticate_spam_check', 99 );


We want to trigger the two-factor workflow *only for requests that*:

1. supply username and/or password,
2. and don't have existing and valid user cookies.

So we hook right after `wp_authenticate_cookie` priority 30.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Setup a user with one of two-factor methods enabled.
2. Attempt to login in a new private browser session and confirm that the second factor is requested.
3. After a successful login, visit `wp-login.php` and confirm that you're redirected to the admin dashboard.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Fixed -- ensure that two-factor workflow is triggered only during login attempts.
