### PR TITLE
Fix PHP 8.4 Implicitly marking parameter $previous as nullable is deprecated

### DIFF
--- a/includes/Yubico/U2F.php
+++ b/includes/Yubico/U2F.php
@@ -501,7 +501,7 @@ class Error extends \Exception
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code, \Exception $previous = null) {
+    public function __construct($message, $code, ?\Exception $previous = null) {
         parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
## What?
PHP 8.4 requires `null` values to be explicitly declared: https://www.php.net/manual/en/migration84.deprecated.php

This PR does that for the U2F.php class fixing the warning:
> u2flib_server\Error::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead

## Why?
To avoid noise in the PHP logs and it is likely this may be a fatal in a future version of PHP.

## How?
This adds a `?` to the class to allow it to be explicitly null.

## Testing Instructions
Install PHP 8.4, make the change in the PR and watch the error go away.

## Changelog Entry
Fixed - PHP 8.4: Implicitly marking parameter $previous as nullable is deprecated (#663)
