### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             - name: Setup PHP and Composer
               uses: shivammathur/setup-php@v2
               with:
-                php-version: '8.2'
+                php-version: '8.3'
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -68,6 +68,7 @@ jobs:
         strategy:
             matrix:
                 php:
+                  - '8.4'
                   - '8.3'
                   - '8.2'
                   - '8.1'
@@ -90,7 +91,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                php-version: '8.2'
+                php-version: '8.3'
 
             - name: Setup Node
               uses: actions/setup-node@v4
@@ -131,7 +132,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                php-version: '8.2'
+                php-version: '8.3'
 
             - name: Setup Node
               uses: actions/setup-node@v4


### PR DESCRIPTION
## What?
This PR updates the tests to:
- Add PHP 8.4
- Update builds to 8.3

## Why?
This should help ensure that the plugin works well with PHP 8.4 moving forward and ensure that the tests work better on a slightly updated PHP version 8.3.

## How?
Manually edits the test file.

## Changelog Entry
Changed - Update tests to include PHP 8.4