### PR TITLE
Release 0.12.0

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
- * Version:           0.11.0
+ * Version:           0.12.0
  * Requires at least: 6.3
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
@@ -30,7 +30,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.11.0' );
+define( 'TWO_FACTOR_VERSION', '0.12.0' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
## What's Changed

* Fix PHP 8.4 Implicitly marking parameter $previous as nullable is deprecated by @BrookeDot in https://github.com/WordPress/two-factor/pull/664
* Simplify the Two Factor settings in user profile by @kasparsd in https://github.com/WordPress/two-factor/pull/654

**Full Changelog**: https://github.com/WordPress/two-factor/compare/0.11.0...master