### PR TITLE
Add a filter to limit two-factor providers available to each user

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1879,11 +1879,15 @@ class Two_Factor_Core {
 		</div>
 		<?php endforeach; ?>
 
+		<fieldset id="two-factor-options" <?php echo $show_2fa_options ? '' : 'disabled="disabled"'; ?>>
 		<?php
 		if ( $providers ) {
 			self::render_user_providers_form( $user, $providers );
 		}
+		?>
+		</fieldset>
 
+		<?php
 		/**
 		 * Fires after the Two Factor methods table.
 		 *
@@ -1906,7 +1910,6 @@ class Two_Factor_Core {
 			<?php esc_html_e( 'Configure a primary two-factor method along with a backup method, such as Recovery Codes, to avoid being locked out if you lose access to your primary method.', 'two-factor' ); ?>
 		</p>
 
-		<fieldset id="two-factor-options" <?php echo $show_2fa_options ? '' : 'disabled="disabled"'; ?>>
 		<?php wp_nonce_field( 'user_two_factor_options', '_nonce_user_two_factor_options', false ); ?>
 		<input type="hidden" name="<?php echo esc_attr( self::ENABLED_PROVIDERS_USER_META_KEY ); ?>[]" value="<?php /* Dummy input so $_POST value is passed when no providers are enabled. */ ?>" />
 
@@ -1957,7 +1960,6 @@ class Two_Factor_Core {
 				</tr>
 			</tbody>
 		</table>
-		</fieldset>
 		<?php
 	}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -298,6 +298,28 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Get providers available for user which may not be enabled or configured.
+	 *
+	 * @see Two_Factor_Core::get_enabled_providers_for_user()
+	 * @see Two_Factor_Core::get_available_providers_for_user()
+	 *
+	 * @param  WP_User|int|null $user User ID.
+	 * @return array List of provider instances indexed by provider key.
+	 */
+	public function get_supported_providers_for_user( $user = null ) {
+		$user = self::fetch_user( $user );
+		$providers = self::get_providers();
+
+		/**
+		 * List of providers available to user which may not be enabled or configured.
+		 *
+		 * @param array       $providers List of available provider instances indexed by provider key.
+		 * @param int|WP_User $user User ID.
+		 */
+		return apply_filters( 'two_factor_providers_for_user', $providers, $user );
+	}
+
+	/**
 	 * Enable the dummy method only during debugging.
 	 *
 	 * @param array $methods List of enabled methods.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -309,7 +309,7 @@ class Two_Factor_Core {
 	 * @param  WP_User|int|null $user User ID.
 	 * @return array List of provider instances indexed by provider key.
 	 */
-	public function get_supported_providers_for_user( $user = null ) {
+	public static function get_supported_providers_for_user( $user = null ) {
 		$user = self::fetch_user( $user );
 		$providers = self::get_providers();
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1899,6 +1899,7 @@ class Two_Factor_Core {
 
 	private static function render_user_providers_form( $user, $providers ) {
 		$primary_provider_key = self::get_primary_provider_key_selected_for_user( $user );
+		$enabled_providers = self::get_enabled_providers_for_user( $user );
 
 		?>
 		<p>

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1552,7 +1552,7 @@ class Two_Factor_Core {
 			array(
 				'two-factor-provider' => $provider->get_key(),
 				'two-factor-login'    => time(),
-			) 
+			)
 		);
 
 		do_action( 'two_factor_user_revalidated', $user, $provider );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1848,7 +1848,7 @@ class Two_Factor_Core {
 		// This is specific to the current session, not the displayed user.
 		$show_2fa_options = self::current_user_can_update_two_factor_options();
 
-		if ( $providers && ! $show_2fa_options ) {
+		if ( ! $show_2fa_options ) {
 			$url = add_query_arg(
 				'redirect_to',
 				urlencode( self::get_user_settings_page_url( $user->ID ) . '#two-factor-options' ),

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -310,7 +310,7 @@ class Two_Factor_Core {
 	 * @return array List of provider instances indexed by provider key.
 	 */
 	public static function get_supported_providers_for_user( $user = null ) {
-		$user = self::fetch_user( $user );
+		$user      = self::fetch_user( $user );
 		$providers = self::get_providers();
 
 		/**
@@ -523,7 +523,7 @@ class Two_Factor_Core {
 			return array();
 		}
 
-		$providers         = self::get_supported_providers_for_user();
+		$providers         = self::get_supported_providers_for_user( $user );
 		$enabled_providers = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
 		if ( empty( $enabled_providers ) ) {
 			$enabled_providers = array();
@@ -555,7 +555,7 @@ class Two_Factor_Core {
 			return array();
 		}
 
-		$providers = self::get_supported_providers_for_user( $user ); // Returns full objects.
+		$providers            = self::get_supported_providers_for_user( $user ); // Returns full objects.
 		$enabled_providers    = self::get_enabled_providers_for_user( $user ); // Returns just the keys.
 		$configured_providers = array();
 
@@ -571,7 +571,7 @@ class Two_Factor_Core {
 	/**
 	 * Fetch the provider for the request based on the user preferences.
 	 *
-	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
+	 * @param int|WP_User        $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @param null|string|object $preferred_provider Optional. The name of the provider, the provider, or empty.
 	 * @return null|object The provider
 	 */
@@ -1837,7 +1837,7 @@ class Two_Factor_Core {
 	public static function user_two_factor_options( $user ) {
 		$notices = [];
 
-		$providers = self::get_supported_providers_for_user( $user->ID );
+		$providers = self::get_supported_providers_for_user( $user );
 
 		wp_enqueue_style( 'user-edit-2fa', plugins_url( 'user-edit.css', __FILE__ ), array(), TWO_FACTOR_VERSION );
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -547,7 +547,7 @@ class Two_Factor_Core {
 	 * @see Two_Factor_Core::get_enabled_providers_for_user()
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
-	 * @return array
+	 * @return array List of provider instances.
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
 		$user = self::fetch_user( $user );
@@ -555,11 +555,12 @@ class Two_Factor_Core {
 			return array();
 		}
 
-		$enabled_providers    = self::get_enabled_providers_for_user( $user );
+		$providers = self::get_supported_providers_for_user( $user ); // Returns full objects.
+		$enabled_providers    = self::get_enabled_providers_for_user( $user ); // Returns just the keys.
 		$configured_providers = array();
 
-		foreach ( $enabled_providers as $provider_key => $provider ) {
-			if ( $provider->is_available_for_user( $user ) ) {
+		foreach ( $providers as $provider_key => $provider ) {
+			if ( in_array( $provider_key, $enabled_providers, true ) && $provider->is_available_for_user( $user ) ) {
 				$configured_providers[ $provider_key ] = $provider;
 			}
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -626,7 +626,7 @@ class Two_Factor_Core {
 			return null;
 		}
 
-		$providers           = self::get_providers();
+		$providers           = self::get_supported_providers_for_user();
 		$available_providers = self::get_available_providers_for_user( $user );
 
 		// If there's only one available provider, force that to be the primary.
@@ -1826,6 +1826,8 @@ class Two_Factor_Core {
 	public static function user_two_factor_options( $user ) {
 		$notices = [];
 
+		$providers = self::get_supported_providers_for_user( $user->ID );
+
 		wp_enqueue_style( 'user-edit-2fa', plugins_url( 'user-edit.css', __FILE__ ), array(), TWO_FACTOR_VERSION );
 
 		$enabled_providers = array_keys( self::get_available_providers_for_user( $user ) );
@@ -1872,7 +1874,7 @@ class Two_Factor_Core {
 
 		<table class="form-table two-factor-methods-table" role="presentation">
 			<tbody>
-			<?php foreach ( self::get_providers() as $provider_key => $object ) : ?>
+			<?php foreach ( $providers as $provider_key => $object ) : ?>
 				<tr>
 					<th><?php echo esc_html( $object->get_label() ); ?></th>
 					<td>
@@ -1906,7 +1908,7 @@ class Two_Factor_Core {
 					<td>
 						<select name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>">
 							<option value=""><?php echo esc_html( __( 'Default', 'two-factor' ) ); ?></option>
-							<?php foreach ( self::get_providers() as $provider_key => $object ) : ?>
+							<?php foreach ( $providers as $provider_key => $object ) : ?>
 								<option value="<?php echo esc_attr( $provider_key ); ?>" <?php selected( $provider_key, $primary_provider_key ); ?> <?php disabled( ! in_array( $provider_key, $enabled_providers, true ) ); ?>>
 									<?php echo esc_html( $object->get_label() ); ?>
 								</option>
@@ -1942,7 +1944,7 @@ class Two_Factor_Core {
 	 */
 	public static function enable_provider_for_user( $user_id, $new_provider ) {
 		// Ensure the provider is even available.
-		if ( ! array_key_exists( $new_provider, self::get_providers() ) ) {
+		if ( ! array_key_exists( $new_provider, self::get_supported_providers_for_user( $user_id ) ) ) {
 			return false;
 		}
 
@@ -1973,7 +1975,7 @@ class Two_Factor_Core {
 	 */
 	public static function disable_provider_for_user( $user_id, $provider_to_delete ) {
 		// Check if the provider is even enabled.
-		if ( ! array_key_exists( $provider_to_delete, self::get_providers() ) ) {
+		if ( ! array_key_exists( $provider_to_delete, self::get_supported_providers_for_user( $user_id ) ) ) {
 			return false;
 		}
 
@@ -2017,7 +2019,7 @@ class Two_Factor_Core {
 				return;
 			}
 
-			$providers          = self::get_providers();
+			$providers          = self::get_supported_providers_for_user( $user_id );
 			$enabled_providers  = $_POST[ self::ENABLED_PROVIDERS_USER_META_KEY ];
 			$existing_providers = self::get_enabled_providers_for_user( $user_id );
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -249,8 +249,11 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Get all enabled two-factor providers with keys as the original
+	 * Get all registered two-factor providers with keys as the original
 	 * provider class names and the values as the provider class instances.
+	 *
+	 * @see Two_Factor_Core::get_enabled_providers_for_user()
+	 * @see Two_Factor_Core::get_supported_providers_for_user()
 	 *
 	 * @since 0.1-dev
 	 *
@@ -505,7 +508,11 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Get all Two-Factor Auth providers that are enabled for the specified|current user.
+	 * Get two-factor providers that are enabled for the specified (or current) user
+	 * but might not be configured, yet.
+	 *
+	 * @see Two_Factor_Core::get_supported_providers_for_user()
+	 * @see Two_Factor_Core::get_available_providers_for_user()
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return array
@@ -533,7 +540,11 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Get all Two-Factor Auth providers that are both enabled and configured for the specified|current user.
+	 * Get all two-factor providers that are both enabled and configured
+	 * for the specified (or current) user.
+	 *
+	 * @see Two_Factor_Core::get_supported_providers_for_user()
+	 * @see Two_Factor_Core::get_enabled_providers_for_user()
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return array

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -589,7 +589,7 @@ class Two_Factor_Core {
 		// Default to the currently logged in provider.
 		if ( ! $preferred_provider && get_current_user_id() === $user->ID ) {
 			$session = self::get_current_user_session();
-			if ( ! empty( $session['two-factor-provider'] )	) {
+			if ( ! empty( $session['two-factor-provider'] ) ) {
 				$preferred_provider = $session['two-factor-provider'];
 			}
 		}
@@ -1548,10 +1548,12 @@ class Two_Factor_Core {
 		}
 
 		// Update the session metadata with the revalidation details.
-		self::update_current_user_session( array(
-			'two-factor-provider' => $provider->get_key(),
-			'two-factor-login'    => time(),
-		) );
+		self::update_current_user_session(
+			array(
+				'two-factor-provider' => $provider->get_key(),
+				'two-factor-login'    => time(),
+			) 
+		);
 
 		do_action( 'two_factor_user_revalidated', $user, $provider );
 
@@ -1787,7 +1789,7 @@ class Two_Factor_Core {
 			)
 		);
 
-		login_header( __( 'Password Reset', 'two-factor' ), '',  $error );
+		login_header( __( 'Password Reset', 'two-factor' ), '', $error );
 		login_footer();
 	}
 
@@ -1854,9 +1856,9 @@ class Two_Factor_Core {
 			);
 
 			$notices['warning two-factor-warning-revalidate-session'] = sprintf(
-					esc_html__( 'To update your Two-Factor options, you must first revalidate your session.', 'two-factor' ) .
+				esc_html__( 'To update your Two-Factor options, you must first revalidate your session.', 'two-factor' ) .
 					' <a class="button" href="%s">' . esc_html__( 'Revalidate now', 'two-factor' ) . '</a>',
-					esc_url( $url )
+				esc_url( $url )
 			);
 		}
 
@@ -1896,7 +1898,7 @@ class Two_Factor_Core {
 	}
 
 	private static function render_user_providers_form( $user, $providers ) {
-		$primary_provider_key  = self::get_primary_provider_key_selected_for_user( $user );
+		$primary_provider_key = self::get_primary_provider_key_selected_for_user( $user );
 
 		?>
 		<p>
@@ -1939,7 +1941,7 @@ class Two_Factor_Core {
 		<table class="form-table two-factor-primary-method-table" role="presentation">
 			<tbody>
 				<tr>
-					<th><?php esc_html_e( 'Primary Method', 'two-factor' ) ?></th>
+					<th><?php esc_html_e( 'Primary Method', 'two-factor' ); ?></th>
 					<td>
 						<select name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>">
 							<option value=""><?php echo esc_html( __( 'Default', 'two-factor' ) ); ?></option>
@@ -1949,7 +1951,7 @@ class Two_Factor_Core {
 								</option>
 							<?php endforeach; ?>
 						</select>
-						<p class="description"><?php esc_html_e( 'Select the primary method to use for two-factor authentication when signing into this site.', 'two-factor' ) ?></p>
+						<p class="description"><?php esc_html_e( 'Select the primary method to use for two-factor authentication when signing into this site.', 'two-factor' ); ?></p>
 					</td>
 				</tr>
 			</tbody>

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1866,7 +1866,7 @@ class Two_Factor_Core {
 			$notices['notice two-factor-notice-no-providers-supported'] = esc_html__( 'No providers are available for your account.', 'two-factor' );
 		}
 
-		// Suggest enabling a backup method if only method is enabled and there are more available.
+		// Suggest enabling a backup method if only one method is enabled and there are more available.
 		if ( count( $providers ) > 1 && 1 === count( $enabled_providers ) ) {
 			$notices['warning two-factor-warning-suggest-backup'] = esc_html__( 'To prevent being locked out of your account, consider enabling a backup method like Recovery Codes in case you lose access to your primary authentication method.', 'two-factor' );
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -516,7 +516,7 @@ class Two_Factor_Core {
 			return array();
 		}
 
-		$providers         = self::get_providers();
+		$providers         = self::get_supported_providers_for_user();
 		$enabled_providers = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
 		if ( empty( $enabled_providers ) ) {
 			$enabled_providers = array();
@@ -544,12 +544,11 @@ class Two_Factor_Core {
 			return array();
 		}
 
-		$providers            = self::get_providers();
 		$enabled_providers    = self::get_enabled_providers_for_user( $user );
 		$configured_providers = array();
 
-		foreach ( $providers as $provider_key => $provider ) {
-			if ( in_array( $provider_key, $enabled_providers, true ) && $provider->is_available_for_user( $user ) ) {
+		foreach ( $enabled_providers as $provider_key => $provider ) {
+			if ( $provider->is_available_for_user( $user ) ) {
 				$configured_providers[ $provider_key ] = $provider;
 			}
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -636,7 +636,7 @@ class Two_Factor_Core {
 			return null;
 		}
 
-		$providers           = self::get_supported_providers_for_user();
+		$providers           = self::get_supported_providers_for_user( $user );
 		$available_providers = self::get_available_providers_for_user( $user );
 
 		// If there's only one available provider, force that to be the primary.

--- a/providers/class-two-factor-fido-u2f-admin.php
+++ b/providers/class-two-factor-fido-u2f-admin.php
@@ -164,6 +164,10 @@ class Two_Factor_FIDO_U2F_Admin {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function show_user_profile( $user ) {
+		if ( ! Two_Factor_FIDO_U2F::is_supported_for_user( $user ) ) {
+			return;
+		}
+
 		wp_nonce_field( "user_security_keys-{$user->ID}", '_nonce_user_security_keys' );
 		$new_key = false;
 

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -133,7 +133,7 @@ abstract class Two_Factor_Provider {
 	public static function is_supported_for_user( $user = null ) {
 		$providers = Two_Factor_Core::get_supported_providers_for_user( $user );
 
-		return isset( $providers[ self::class ] );
+		return isset( $providers[ static::class ] );
 	}
 
 	/**

--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -124,6 +124,19 @@ abstract class Two_Factor_Provider {
 	abstract public function is_available_for_user( $user );
 
 	/**
+	 * If this provider should be available for the user.
+	 *
+	 * @param WP_User|int $user WP_User object, user ID or null to resolve the current user.
+	 *
+	 * @return bool
+	 */
+	public static function is_supported_for_user( $user = null ) {
+		$providers = Two_Factor_Core::get_supported_providers_for_user( $user );
+
+		return isset( $providers[ self::class ] );
+	}
+
+	/**
 	 * Generate a random eight-digit string to send out as an auth code.
 	 *
 	 * @since 0.1-dev

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,7 @@ For more history, see [this post](https://georgestephanis.wordpress.com/2013/08/
 Here is a list of action and filter hooks provided by the plugin:
 
 - `two_factor_providers` filter overrides the available two-factor providers such as email and time-based one-time passwords. Array values are PHP classnames of the two-factor providers.
+- `two_factor_providers_for_user` filter overrides the available two-factor providers for a specific user. Array values are instances of provider classes and the user object `WP_User` is available as the second argument.
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_email_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1585,6 +1585,21 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		remove_all_filters( 'two_factor_providers_for_user' );
 	}
 
+	public function test_can_disable_default_providers() {
+		$this->assertContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Email provider is enabled by default' );
+
+		add_filter(
+			'two_factor_providers',
+			function ( $providers ) {
+				return array_diff_key( $providers, array( 'Two_Factor_Email' => null ) );
+			}
+		);
+
+		$this->assertNotContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Default provider can be disabled via a filter' );
+
+		remove_all_filters( 'two_factor_providers' );
+	}
+
 	/**
 	 * Plugin uninstall removes all user meta.
 	 *
@@ -1609,21 +1624,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			Two_Factor_Core::get_enabled_providers_for_user( $user->ID ),
 			'Provider was disabled due to uninstall'
 		);
-	}
-
-	public function test_can_disable_default_providers() {
-		$this->assertContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Email provider is enabled by default' );
-
-		add_filter(
-			'two_factor_providers',
-			function ( $providers ) {
-				return array_diff_key( $providers, array( 'Two_Factor_Email' => null ) );
-			}
-		);
-
-		$this->assertNotContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Default provider can be disabled via a filter' );
-
-		remove_all_filters( 'two_factor_providers' );
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1568,7 +1568,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		add_filter(
 			'two_factor_providers_for_user',
 			function( $providers, $user ) {
-				$this->assertInstanceOf( WP_User::class, $user );
+				$this->assertInstanceOf( WP_User::class, $user, 'A user referenced is passed to the filter' );
 
 				return array_diff_key( $providers, array( 'Two_Factor_Email' => null ) );
 			},
@@ -1576,11 +1576,8 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			2
 		);
 
-		$providers = Two_Factor_Core::get_providers();
-		unset( $providers['Two_Factor_Email'] );
-
-		$this->assertEquals(
-			$providers,
+		$this->assertNotContains(
+			'Two_Factor_Email',
 			Two_Factor_Core::get_supported_providers_for_user( $user ),
 			'Email provider can be disabled for a user'
 		);

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1586,7 +1586,13 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	public function test_can_disable_default_providers() {
-		$this->assertContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Email provider is enabled by default' );
+		$user = self::factory()->user->create_and_get();
+		$providers = Two_Factor_Core::get_providers();
+		$default_provider = current( $providers );
+
+		$this->assertContains( 'Two_Factor_Email', array_keys( $providers ), 'Email provider is enabled by default' );
+
+		$this->assertTrue( $default_provider::is_supported_for_user( $user ), 'Available provider is supported by default' );
 
 		add_filter(
 			'two_factor_providers',
@@ -1596,6 +1602,8 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		);
 
 		$this->assertNotContains( 'Two_Factor_Email', array_keys( Two_Factor_Core::get_providers() ), 'Default provider can be disabled via a filter' );
+
+		$this->assertFalse( $default_provider::is_supported_for_user( $user ), 'Disabled provider is not supported for user' );
 
 		remove_all_filters( 'two_factor_providers' );
 	}

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1558,12 +1558,15 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 	public function test_can_filter_registered_providers_for_user() {
 		$user = self::factory()->user->create_and_get();
+		$providers = Two_Factor_Core::get_providers();
 
 		$this->assertEquals(
-			Two_Factor_Core::get_providers(),
+			$providers,
 			Two_Factor_Core::get_supported_providers_for_user( $user ),
 			'All providers are available by default'
 		);
+
+		$this->assertTrue( $providers['Two_Factor_Email']::is_supported_for_user( $user ), 'Email provider is supported by default' );
 
 		add_filter(
 			'two_factor_providers_for_user',
@@ -1581,6 +1584,8 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			Two_Factor_Core::get_supported_providers_for_user( $user ),
 			'Email provider can be disabled for a user'
 		);
+
+		$this->assertFalse( $providers['Two_Factor_Email']::is_supported_for_user( $user ), 'Email provider is disabled if not supported' );
 
 		remove_all_filters( 'two_factor_providers_for_user' );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?

1. Add a filter to allow limiting the available providers per user.
2. Skip rendering the provider table if no providers are available for a user.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Fixes #647, #662.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

1. Introduce a new method `get_supported_providers_for_user( $user )` which wraps the output of `get_providers()` in a filter `two_factor_providers_for_user`.
2. Use the new helper whenever we're looking for two-factor methods that should be available to a user.

Note that we already similar methods:

- `get_enabled_providers_for_user( $user = null )` for the provider _keys_ that are enabled in the user profile **but might not be configured, yet**.
- `get_available_providers_for_user( $user = null )` for the provider _keys_ that **are both enabled and configured**.

so I chose the name `supported` to designate if a provider is available to a specific user.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Unit tests have been added to cover the filtering scenario. There are no user settings to toggle this.

## Screenshots or screencast
<!-- if applicable -->

If all providers are disabled for a user we now display a notice instead of an empty table:

<img width="725" alt="two-factor-options-no-providers" src="https://github.com/user-attachments/assets/bda2356a-258d-489e-ab09-a2b028f1352e" />

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

Add a filter `two_factor_providers_for_user` to disable providers for specific users.