### PR TITLE
Release 0.13.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Two-Factor ===
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   0.13.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 6.6
-Stable tag:   0.12.0
+Stable tag:   0.13.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
- * Version:           0.12.0
+ * Version:           0.13.0
  * Requires at least: 6.3
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
@@ -30,7 +30,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.12.0' );
+define( 'TWO_FACTOR_VERSION', '0.13.0' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.


### PR DESCRIPTION
- Minor version bump 0.13.0 since we're adding features with no breaking changes.
- Mark as tested with the latest version of WordPress core.

## What's Changed

* Add a filter to limit two-factor providers available to each user by @kasparsd in https://github.com/WordPress/two-factor/pull/669
* Update automated testing to cover PHP 8.4 and default to PHP 8.3 by @BrookeDot in https://github.com/WordPress/two-factor/pull/665

**Full Changelog**: https://github.com/WordPress/two-factor/compare/0.12.0...master