### PR TITLE
Add filter for rest_api_can_edit_user_and_update_two_factor_options

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1349,7 +1349,7 @@ class Two_Factor_Core {
 			return new WP_Error( 'revalidation_required', __( 'Two Factor Revalidation required.', 'two-factor' ) );
 		}
 
-		return true;
+		return apply_filters( 'two_factor_rest_api_can_edit_user', true, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Introduce a new filter hook in the `Two_Factor_Core::rest_api_can_edit_user_and_update_two_factor_options` method.

## Why?
To allow developers to programmatically control whether REST API endpoints related to Two-Factor authentication can edit a specific user’s settings.

## How?
Added a new filter, `two_factor_rest_api_can_edit_user`, which allows overriding the default behavior by modifying the return value of the `rest_api_can_edit_user_and_update_two_factor_options` method.

## Testing Instructions
The following snippet disables Two-Factor-related REST API endpoints (`rest_setup_totp`, `rest_delete_totp`, and `rest_generate_codes`) for a specific user (user ID 123):
```php
add_filter( 'two_factor_rest_api_can_edit_user', function( $can_edit, $user_id ) {
    if ( $user_id === 123 ) {
        return false;
    }

    return $can_edit;
}, 10, 2 );
```

## Testing Instructions
1. Apply the above filter to your codebase.
2. Attempt to call the Two-Factor-related REST API endpoints for user ID 123.
3. Confirm that the calls are blocked.
4. Ensure the endpoints continue to work for other users.

## Changelog Entry
Added - New `two_factor_rest_api_can_edit_user` filter to control edit permissions via the REST API for specific users