### PR TITLE
Fix plugin Author to the `wordpressdotorg` user

### DIFF
--- a/two-factor.php
+++ b/two-factor.php
@@ -14,7 +14,7 @@
  * Version:           0.13.0
  * Requires at least: 6.3
  * Requires PHP:      7.2
- * Author:            WordPress.org Contributors
+ * Author:            wordpressdotorg
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
  * License:           GPL-2.0-or-later
  * License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?

This pull request includes a minor change to the `two-factor.php` file, updating the author information to reflect the correct attribution.

* Updated the `Author` field in the file header from "WordPress.org Contributors" to "wordpressdotorg" to align with the repository's contributor naming convention.

## Why?

The current plugin page at https://wordpress.org/plugins/two-factor/ shows "By George Stephanis".

![Screenshot 2025-05-20 at 2 21 17 PM](https://github.com/user-attachments/assets/d182eb45-9a76-4718-b09d-3101cae57f3d)

## How?

In making the Author header field change and then having @georgestephanis  go to https://wordpress.org/plugins/two-factor/advanced/ he'll be able to update to the `wordpressdotorg` user and then have the plugin page show as "By WordPress.org".

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a
