### PR TITLE
Add/reqs policy & related updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
                 wp:
                   - latest
                   - trunk
-                  - '6.3'
+                  - '6.7'
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,10 @@ Here is a list of action and filter hooks provided by the plugin:
 
 == Frequently Asked Questions ==
 
+= What PHP and WordPress versions does the Two-Factor plugin support? =
+
+This plugin supports the last two major versions of WordPress and <a href="https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/">the minimum PHP version</a> supported by those WordPress versions.
+
 = How can I send feedback or get help with a bug? =
 
 The best place to report bugs, feature suggestions, or any other (non-security) feedback is at <a href="https://github.com/WordPress/two-factor/issues">the Two Factor GitHub issues page</a>. Before submitting a new issue, please search the existing issues to check if someone else has reported the same feedback.

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
  * Version:           0.13.0
- * Requires at least: 6.3
+ * Requires at least: 6.7
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?

This pull request updates compatibility and documentation for the Two-Factor plugin, ensuring alignment with the latest WordPress and PHP version requirements. The most important changes include updating the minimum required WordPress version, enhancing the plugin's documentation, and modifying the testing matrix in the workflow configuration.

### Compatibility Updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L82-R82): Updated the WordPress testing matrix to include version `6.7` instead of `6.3`.
* [`two-factor.php`](diffhunk://#diff-d7f63024e0fd3161db0f3a91048d5be3b18c50197b4b6984e5dd6e0ba41bed35L15-R15): Changed the minimum required WordPress version from `6.3` to `6.7`.

### Documentation Enhancements:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R37-R40): Added a new FAQ entry detailing the supported PHP and WordPress versions for the Two-Factor plugin.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Closes #650.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - WordPress and PHP version support policy.
> Changed - Bump WordPress minimum supported version to 6.7.
