### PR TITLE
Fix #300: support for application passwords

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -776,7 +776,7 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_user_api_login_enabled( $user_id ) {
-		return (bool) apply_filters( 'two_factor_user_api_login_enable', false, $user_id );
+		return (bool) apply_filters( 'two_factor_user_api_login_enable', (bool) did_action( 'application_password_did_authenticate' ), $user_id );
 	}
 
 	/**


### PR DESCRIPTION
Suggested fix for issue #300

<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Proposed fix for #300: when a user is authenticated using an application password no 2factor is needed.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
Re #300

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->
Depending of if the `application_password_did_authenticate` action has run the plugin now passes `TRUE` (did run) or `FALSE` (did not run) through the `two_factor_user_api_login_enable` filter in the `is_user_api_login_enabled` function.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Install the WordPress app on your device
2. Create an application password and login with your WordPress app

If you succeed my PR works, if you can't login my PR does not work.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.

Fixed #300
Added application passwords support.
