### PR TITLE
Release 0.14.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,9 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 
 1. Two-factor options under User Profile.
 2. U2F Security Keys section under User Profile.
-3. Email Code Authentication during WordPress Login.
+3. Login with authentication app code.
+4. Login with recovery code.
+5. Login with email code.
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 6.7
-Stable tag:   0.13.0
+Stable tag:   0.14.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Two-Factor ===
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   0.14.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/two-factor.php
+++ b/two-factor.php
@@ -11,8 +11,8 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
- * Requires at least: 6.7
  * Version:           0.14.0
+ * Requires at least: 6.8
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors

--- a/two-factor.php
+++ b/two-factor.php
@@ -30,7 +30,7 @@ define( 'TWO_FACTOR_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * Version of the plugin.
  */
-define( 'TWO_FACTOR_VERSION', '0.13.0' );
+define( 'TWO_FACTOR_VERSION', '0.14.0' );
 
 /**
  * Include the base class here, so that other plugins can also extend it.

--- a/two-factor.php
+++ b/two-factor.php
@@ -11,8 +11,8 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
- * Version:           0.13.0
  * Requires at least: 6.7
+ * Version:           0.14.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors

--- a/two-factor.php
+++ b/two-factor.php
@@ -11,8 +11,8 @@
  * Plugin Name:       Two Factor
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, Universal 2nd Factor (FIDO U2F, YubiKey), email, and backup verification codes.
+ * Requires at least: 6.7
  * Version:           0.14.0
- * Requires at least: 6.8
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors


### PR DESCRIPTION
Diff: https://github.com/WordPress/two-factor/compare/0.13.0...master

## Changelog

Features:

* Enable Application Passwords for REST API and XML-RPC authentication (by default) by @joostdekeijzer in https://github.com/WordPress/two-factor/pull/697 and https://github.com/WordPress/two-factor/pull/698. Previously this required `two_factor_user_api_login_enable` filter to be set to `true` which is now the default during application password auth. XML-RPC login is still disabled for regular user passwords.
* Label recommended methods to simplify the configuration by @kasparsd in https://github.com/WordPress/two-factor/pull/676 and https://github.com/WordPress/two-factor/pull/675


Documentation:

* Add WP.org plugin demo by @kasparsd in https://github.com/WordPress/two-factor/pull/667
* Document supported versions of WP core and PHP by @jeffpaul in https://github.com/WordPress/two-factor/pull/695
* Document the release process by @jeffpaul in https://github.com/WordPress/two-factor/pull/684

Tooling:

* Remove duplicate WP.org screenshots and graphics from SVN `trunk` by @jeffpaul in https://github.com/WordPress/two-factor/pull/683
