### PR TITLE
Use working GitHub Action runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
 
   deploy:
     name: Deploy to WordPress.org
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
     lint-js-css:
         name: Lint JS & CSS
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
     lint-php-and-compatibility:
         name: Lint PHP & PHP Compatibility checks.
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
 
     test-php:
         name: Test PHP ${{ matrix.php }} ${{ matrix.wp != '' && format( ' (WP {0}) ', matrix.wp ) || '' }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
                 php:
@@ -124,7 +124,7 @@ jobs:
 
     build:
         name: Build
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
Bump GitHub action runners to known stable versions.

<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Locks the GitHub Actions runners to `ubuntu-24.04`.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Fixes #702.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
