### PR TITLE
Don't URI encode the TOTP url for display.

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -255,7 +255,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		 * @param WP_User $user     The user object.
 		 */
 		$totp_url = apply_filters( 'two_factor_totp_url', $totp_url, $user );
-		$totp_url = esc_url( $totp_url, array( 'otpauth' ) );
+		$totp_url = esc_url_raw( $totp_url, array( 'otpauth' ) );
 
 		return $totp_url;
 	}


### PR DESCRIPTION
Fixes #710 - Full props to @fb656720 for change.

<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

2FAS authenticator doesn't support the url-encoded format, while other authenticator apps appear to support this, it doesn't appear to be allowable by the standard.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->


## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->
Avoids encoding the TOTP QR code url for display, by using `esc_url_raw()` in the provider. 
URL is properly encoded for display at display time, and encoded properly for JS usage.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Verify that TOTP can be setup with multiple authenticator apps

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry

Fixed: TOTP QR Code not working with 2FAS authenticator.

<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
