### PR TITLE
Add "Didn't expect this?" message

### DIFF
--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -249,12 +249,22 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		/* translators: %s: site name */
 		$subject = wp_strip_all_tags( sprintf( __( 'Your login confirmation code for %s', 'two-factor' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) );
 
-		/* translators: %s: token */
-		$message  = wp_strip_all_tags( sprintf( __( 'Enter %s to log in.', 'two-factor' ), $token ) ) . PHP_EOL . PHP_EOL;
-		$message .= wp_strip_all_tags( __( 'Didn\'t expect this?', 'two-factor' ) ) . PHP_EOL;
-		/* translators: %1$s: IP-address of user, %2$s `user_login` of authenticated user */
-		$message .= wp_strip_all_tags( sprintf( __( 'A user from %1$s has successfully authenticated as %2$s.', 'two-factor' ), $remote_ip, $user->user_login ) ) . PHP_EOL;
-		$message .= wp_strip_all_tags( __( 'If this wasn\'t you, please change your password', 'two-factor' ) ) . PHP_EOL;
+		$message = wp_strip_all_tags(
+			sprintf(
+				/* translators: %1$s: token, $2$s: IP address of user, %3$s: `user_login` of authenticated user */
+				__(
+					'Enter %1$s to log in.
+
+Didn\'t expect this?
+A user from %2$s has successfully authenticated as %3$s.
+If this wasn\'t you, please change your password.',
+					'two-factor'
+				),
+				$token,
+				$remote_ip,
+				$user->user_login
+			)
+		);
 
 		/**
 		 * Filter the token email subject.


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Add's "Didn't expect this?" message, as suggested by @dd32 in https://github.com/WordPress/two-factor/issues/726#issuecomment-3624152147

## Why?
If your credentials have been compromised and someone's been able to log in to your account with email 2FA active, you might be wondering why your site is sending you 2FA codes, when _you_ haven't been logging in.

## How?
Adds additional information to the sent email.

## Changelog Entry
> Changed - Added additional information to outgoing 2FA email message.

Not sure if we should use `PHP_EOL`, since WordPress codebase doesn't seem to use that either and if we should add the message as whole instead of concating it line by line. `Enter %s to log in` has already been translated to many languages, so that should stay separate?