### PR TITLE
Add 'Settings' action link to plugin list for quick access to profile… `Addresses #732`

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -128,6 +128,9 @@ class Two_Factor_Core {
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
+		// Add Settings link to plugin action links.
+		add_filter( 'plugin_action_links_' . plugin_basename( TWO_FACTOR_DIR . 'two-factor.php' ), array( __CLASS__, 'add_settings_action_link' ) );
+
 		$compat->init();
 	}
 
@@ -335,6 +338,27 @@ class Two_Factor_Core {
 		}
 
 		return $methods;
+	}
+
+	/**
+	 * Add "Settings" link to the plugin action links on the Plugins screen.
+	 *
+	 * @since 0.14.3
+	 *
+	 * @param string[] $links An array of plugin action links.
+	 * @return string[] Modified array with the Settings link added.
+	 */
+	public static function add_settings_action_link( $links ) {
+		$settings_url  = admin_url( 'profile.php#application-passwords-section' );
+		$settings_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( $settings_url ),
+			esc_html__( 'Settings', 'two-factor' )
+		);
+
+		array_unshift( $links, $settings_link );
+
+		return $links;
 	}
 
 	/**
@@ -2131,7 +2155,7 @@ class Two_Factor_Core {
 						array(
 							'two-factor-provider' => '',
 							'two-factor-login'    => time(),
-						) 
+						)
 					);
 				} elseif ( $existing_providers && ! $enabled_providers ) {
 					// We've disabled two-factor, remove session metadata.
@@ -2139,7 +2163,7 @@ class Two_Factor_Core {
 						array(
 							'two-factor-provider' => null,
 							'two-factor-login'    => null,
-						) 
+						)
 					);
 				}
 			}

--- a/two-factor.php
+++ b/two-factor.php
@@ -53,30 +53,3 @@ Two_Factor_Core::add_hooks( $two_factor_compat );
 
 // Delete our options and user meta during uninstall.
 register_uninstall_hook( __FILE__, array( Two_Factor_Core::class, 'uninstall' ) );
-
-
-/**
- * Add "Settings" link to the plugin action links on the Plugins screen.
- *
- * @since 0.14.3
- *
- * @param string[] $links An array of plugin action links.
- * @return string[] Modified array with the Settings link added.
- */
-function two_factor_add_settings_action_link( $links ) {
-	$settings_url  = admin_url( 'profile.php#application-passwords-section' );
-	$settings_link = sprintf(
-		'<a href="%s">%s</a>',
-		esc_url( $settings_url ),
-		esc_html__( 'Settings', 'two-factor' )
-	);
-
-	array_unshift( $links, $settings_link );
-
-	return $links;
-}
-
-add_filter(
-	'plugin_action_links_' . plugin_basename( __FILE__ ),
-	'two_factor_add_settings_action_link'
-);


### PR DESCRIPTION
## What?
Adds a "Settings" link to the plugin action links on the Plugins screen in the WordPress admin.

## Why?
The plugin currently does not display a “Settings” link under its name on the Plugins page (`/wp-admin/plugins.php`).  
This makes it less intuitive for users to access the plugin’s configuration section (`/wp-admin/profile.php#application-passwords-section`), which is standard behavior for most WordPress plugins.

Fixes #<issue_number> (replace with the actual issue ID if one exists).

## How?
Introduced a new function `two_factor_add_settings_action_link()` in `two-factor.php` that hooks into the `plugin_action_links_{plugin_basename}` filter to prepend a "Settings" link.  
The link directs users to `/wp-admin/profile.php#application-passwords-section`.

```php
add_filter(
	'plugin_action_links_' . plugin_basename( __FILE__ ),
	'two_factor_add_settings_action_link'
);

Testing Instructions

1. Install and activate this branch of the plugin.
2. Navigate to Plugins → Installed Plugins.
3. Verify that a “Settings” link appears below the Two-Factor plugin name.
4. Click the link and confirm it redirects correctly to /wp-admin/profile.php#application-passwords-section.


Changelog Entry

Added - Settings action link on the Plugins screen for quick navigation to the plugin's configuration section.