### PR TITLE
Persist existing translations when introducing new helper text in emails

### DIFF
--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -272,8 +272,8 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 		$message_parts = array(
 			sprintf(
-				/* translators: %1$s: token */
-				__( 'Enter %1$s to log in.', 'two-factor' ),
+				/* translators: %s: token */
+				__( 'Enter %s to log in.', 'two-factor' ),
 				$token
 			),
 			sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Keep the existing `Enter %1$s to log in.` as standalone string to ensure it works with existing translations. Add the new helper text in own line `Didn't expect this? A user from %1$s has successfully authenticated as %2$s. If this wasn't you, please change your password.`.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Follow-up to #728.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

This now keeps the existing translations for the main sentence:

<img width="933" height="529" alt="translation" src="https://github.com/user-attachments/assets/81dd88b1-1644-494d-8794-6389259ffd2e" />

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
