### PR TITLE
Introduce Props Bot workflow

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -1,0 +1,92 @@
+name: Props Bot
+
+on:
+  # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
+  # GitHub does not allow filtering the `labeled` event by a specific label.
+  # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
+  # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
+  # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
+  # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - ready_for_review
+  # This event runs anytime a comment is added or deleted.
+  # You cannot filter this event for PR comments only.
+  # However, the logic below does short-circuit the workflow for issues.
+  issue_comment:
+    types:
+      - created
+  # This event will run everytime a new PR review is initially submitted.
+  pull_request_review:
+    types:
+      - submitted
+  # This event runs anytime a PR review comment is created or deleted.
+  pull_request_review_comment:
+    types:
+      - created
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Compiles a list of props for a pull request.
+  #
+  # Performs the following steps:
+  # - Collects a list of contributor props and leaves a comment.
+  # - Removes the props-bot label, if necessary.
+  props-bot:
+    name: Generate a list of props
+    runs-on: ubuntu-24.04
+    permissions:
+      # The action needs permission `write` permission for PRs in order to add a comment.
+      pull-requests: write
+      contents: read
+    timeout-minutes: 20
+    # The job will run when pull requests are open, ready for review and:
+    #
+    # - A comment is added to the pull request.
+    # - A review is created or commented on (unless PR originates from a fork).
+    # - The pull request is opened, synchronized, marked ready for review, or reopened.
+    # - The `props-bot` label is added to the pull request.
+    if: |
+      (
+        github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+        ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
+        github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+        'props-bot' == github.event.label.name
+      ) &&
+      ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
+
+    steps:
+      - name: Gather a list of contributors
+        uses: WordPress/props-bot-action@trunk
+        with:
+          format: 'git'
+
+      - name: Remove the props-bot label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: process.env.ISSUE_NUMBER,
+              name: 'props-bot'
+            });
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Props Bot is a GitHub Action that processes the activity on a pull request and any linked issues.

The bot attempts to associate each GitHub use account with a linked w.org one and outputs a formatted list of `Co-authored-by` trailers that can be copied and pasted into the merge commit message.

This ensures that everyone who contributed to a given merge receives props for their effort, and that the list of contributors is predictably formatted for easy processing.

This bot is currently in the following repositories under the WordPress organization:
- https://github.com/WordPress/wordpress-develop
- https://github.com/WordPress/gutenberg
- https://github.com/WordPress/plugin-check
- https://github.com/WordPress/performance
- https://github.com/WordPress/grunt-patch-wordpress
- https://github.com/WordPress/ai
- https://github.com/WordPress/mcp-adapter
- https://github.com/WordPress/php-ai-client
- https://github.com/WordPress/abilities-api

More details about the bot can be found in the [original announcement post on the Make WordPress Core blog](https://make.wordpress.org/core/2024/02/01/new-commit-message-requirements-in-git-hello-props-bot/).