### PR TITLE
mismatched_plugin_name fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Two-Factor ===
+=== Two Factor ===
 Contributors: georgestephanis, valendesigns, stevenkword, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, kasparsd, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 6.9
@@ -64,3 +64,4 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 == Changelog ==
 
 See the [release history](https://github.com/wordpress/two-factor/releases).
+


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
This PR resolves a WordPress.org plugin check warning (mismatched_plugin_name) caused by a mismatch between the plugin name declared in the main plugin file header and the name defined in readme.txt.

## Why?
The following error was shown on the plugin check plugin:
`readme.txt`

| Line | Column | Type | Code | Message | Docs |
| --- | --- | --- | --- | --- | --- |
| 0 | 0 | WARNING | mismatched_plugin_name | Plugin name "Two-Factor" is different from the name declared in plugin header "Two Factor". | [Docs](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#incomplete-readme) |

## How?
Changing the readme.txt plugin name to the declared plugin name

## Testing Instructions
1. Install Plugin Check Plugin
2. Choose Two Factor, Categories = "Plugin Repo" and Types = "Error" & "Warning"
3. see results
4. apply fix
5. see results

## Changelog Entry
Fixed - Resolved a plugin name mismatch between the main plugin file header and readme.txt to satisfy WordPress.org plugin checker requirements.