### PR TITLE
Fix missing_direct_file_access_protection

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -5,10 +5,6 @@
  * @package Two_Factor
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * Class for creating two factor authorization.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #759

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds direct file access protection to plugin PHP files to prevent them from being executed outside of the WordPress runtime.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
WordPress.org coding standards require plugin PHP files to block direct access when WordPress is not loaded. [Learn more here](https://developer.wordpress.org/plugins/wordpress-org/common-issues/#direct-file-access)

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->
The PR adds a standard abspath guard at the top of affected PHP files. This ensures the files exit early when accessed directly, while leaving normal WordPress execution completely unchanged. No functional or behavioral logic was modified.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install Plugin Check Plugin
2. Choose Two Factor, Categories = "Plugin Repo" and Types = "Error" & "Warning"
3. see results
4. apply fix
5. see results

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
> Security - Added direct file access protection to plugin files to align with WordPress.org security guidelines.
