### PR TITLE
fix php 8.5 deprecated message

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -673,7 +673,7 @@ class Two_Factor_Core {
 			$provider = self::get_primary_provider_key_selected_for_user( $user );
 
 			// If the provider specified isn't enabled, just grab the first one that is.
-			if ( ! isset( $available_providers[ $provider ] ) ) {
+			if ( empty( $provider ) || ! isset( $available_providers[ $provider ] ) ) {
 				$provider = key( $available_providers );
 			}
 		}


### PR DESCRIPTION
Fixes #761

<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes a PHP deprecation warning caused by using null as an array offset when determining the primary two-factor provider.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->
PHP 7.4+ emits a deprecation notice when null is used as an array key. This can happen if no primary provider is selected for a user, resulting in noisy logs and potential issues on stricter setups.

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->
Explicitly guard against null (or empty string) before using it as an array offset.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. setup totp, backup codes and email codes for a user
2. go to /wp-admin/users.php
3. see the deprecation message
4. apply fix
5. go to /wp-admin/users.php - no deprecation message anymore showing up

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
Fixed - Prevent PHP 7.4+ deprecation warning when resolving the primary two-factor provider.
