### PR TITLE
Tests: Update to supported WP version 6.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
                 wp:
                   - latest
                   - trunk
-                  - '6.7'
+                  - '6.8'
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #767

## What?
Update the GitHub Actions test matrix to run CI against WordPress 6.8 instead of 6.7.

## Why?
WordPress 6.8 is the minimum supported WP release of this repo. Testing against the trunk, latest stable version and our minimum supported WP version ensures continued compatibility and keeps CI coverage aligned with supported WordPress releases.

## How?
Replace the 6.7 entry in the GitHub Actions matrix with 6.8.
The workflow already resolves WordPress versions via official wordpress.org release ZIPs, so no additional changes or dependencies are required.

## Testing Instructions

1. Open the GitHub Actions run for this PR.
2. Verify that jobs run with:
3. WP 6.8 (instead of 6.7) across supported PHP versions.
4. Check the workflow logs for the WordPress version output to confirm 6.8.x is installed.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
> Changed – CI tests now run against WordPress 6.8 instead of 6.7.
