### PR TITLE
add php 8.5 tests for latest and trunk version of WP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         strategy:
             matrix:
                 php:
+                  - '8.5'
                   - '8.4'
                   - '8.3'
                   - '8.2'
@@ -85,6 +86,8 @@ jobs:
                     wp: trunk
                   - php: '7.2'
                     wp: trunk
+                  - php: '8.5'
+                    wp: '6.8'
         env:
             WP_ENV_PHP_VERSION: ${{ matrix.php }}
             WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

Fixes #768

## What?
Extend the GitHub Actions test matrix to include PHP 8.5, while excluding it for WordPress 6.8 where core support is not available.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

## How?
PHP 8.5 is now a released PHP version and should be covered by CI to detect early compatibility issues.
WordPress core support for PHP 8.5 begins with WordPress 6.9, so running PHP 8.5 against the latest trunk and stable would be beneficial.

## Testing Instructions
Open the GitHub Actions run for this PR.

Verify that:
1. PHP 8.5 runs with latest (6.9) and trunk.
2. PHP 8.5 does not run with WordPress 6.8.
3. Confirm all remaining matrix jobs complete successfully.

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
> Changed – CI now includes PHP 8.5 testing, excluding unsupported WordPress 6.8 combinations.

