### PR TITLE
fix(totp): otpauth link in QR code URL

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -317,7 +317,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				<?php esc_html_e( 'Please scan the QR code or manually copy the shared secret key from below to your Authenticator app:', 'two-factor' ); ?>
 			</p>
 			<p id="two-factor-qr-code">
-				<a href="<?php echo esc_url( $totp_url ); ?>">
+				<a href="<?php echo esc_url( $totp_url, array( 'otpauth' ) ); ?>">
 					<?php esc_html_e( 'Loading…', 'two-factor' ); ?>
 					<img src="<?php echo esc_url( admin_url( 'images/spinner.gif' ) ); ?>" alt="" />
 				</a>


### PR DESCRIPTION
## What?

The TOTP URL inside the `#two-factor-qr-code` paragraph in the User Profile is not rendered because `esc_url()` returns an empty string if it encounters an unknown/not allowed protocol.

Fixes: #783

## Why?

`esc_url()` returns an empty string if it encounters an unknown/not allowed protocol. `otpauth:` is not among the allowed ones.

## How?

Pass `array( 'otpauth' )` to `esc_url()`.

## Testing Instructions

1. Log in.
2. Got to /wp-admin/profile.php
3. Check the link around the QR code under the "Please scan the QR code or manually copy the shared secret key from below to your Authenticator app:" label.

## Screenshots or screencast

<img width="521" height="269" alt="Screenshot_20260209_192446" src="https://github.com/user-attachments/assets/c9a1d408-e880-4025-be1d-2803d5bcd222" />


## Changelog Entry

> Fixed - OTP Authentication URL is rendered correctly.
