### PR TITLE
fix: ensure execution stops after redirects

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1479,7 +1479,7 @@ class Two_Factor_Core {
 		// Validate the request.
 		if ( true !== self::verify_login_nonce( $user->ID, $nonce ) ) {
 			wp_safe_redirect( home_url() );
-			exit();
+			exit;
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
@@ -1567,7 +1567,7 @@ class Two_Factor_Core {
 
 		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $redirect_to, $user ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
 		wp_safe_redirect( $redirect_to );
-		exit();
+		exit;
 	}
 
 
@@ -1603,7 +1603,7 @@ class Two_Factor_Core {
 	public static function _login_form_revalidate_2fa( $nonce = '', $provider = '', $redirect_to = '', $is_post_request = false ) {
 		if ( ! is_user_logged_in() ) {
 			wp_safe_redirect( home_url() );
-			exit();
+			exit;
 		}
 
 		$user = wp_get_current_user();
@@ -1611,7 +1611,7 @@ class Two_Factor_Core {
 		// Validate the nonce for POST requests. GET requests do not perform actions, and such do not require the nonce (such as the initial request).
 		if ( $is_post_request && ! wp_verify_nonce( $nonce, 'two_factor_revalidate_' . $user->ID ) ) {
 			wp_safe_redirect( home_url() );
-			exit();
+			exit;
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
@@ -1666,7 +1666,7 @@ class Two_Factor_Core {
 
 		$redirect_to = apply_filters( 'login_redirect', $redirect_to, $redirect_to, $user ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress filter.
 		wp_safe_redirect( $redirect_to );
-		exit();
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
## What?

This PR ensures that code execution stops after calling `wp_safe_redirect()` in the two-factor authentication validation functions. Without `exit()`, PHP continues executing code after sending redirect headers, which could lead to security vulnerabilities or unintended behavior.

## Why?

This follows WordPress best practices and aligns with the existing [function documentation](https://developer.wordpress.org/reference/functions/wp_safe_redirect/) that states "[wp_safe_redirect()](https://developer.wordpress.org/reference/functions/wp_safe_redirect/) does not exit automatically, and should almost always be followed by a call to `exit;`."

## How?

Add `exit()` after calls to `wp_safe_redirect()`.

## Testing Instructions

N/A :-(

## Screenshots or screencast

N/A

## Changelog Entry

> Security - Ensure that code execution stops after calling `wp_safe_redirect()`.
