### PR TITLE
Add email verification before activation

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -697,7 +697,7 @@ class Two_Factor_Core {
 		 * Possible enhancement: add a filter to change the fallback method?
 		 */
 		if ( empty( $enabled_providers ) && $user_providers_raw ) {
-			if ( isset( $providers['Two_Factor_Email'] ) ) {
+			if ( isset( $providers['Two_Factor_Email'] ) && $providers['Two_Factor_Email']->is_available_for_user( $user ) ) {
 				// Force Emailed codes to 'on'.
 				$enabled_providers[] = 'Two_Factor_Email';
 			} else {
@@ -772,6 +772,10 @@ class Two_Factor_Core {
 	private static function get_primary_provider_key_selected_for_user( $user ) {
 		$primary_provider    = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		$available_providers = self::get_available_providers_for_user( $user );
+
+		if ( is_wp_error( $available_providers ) ) {
+			return null;
+		}
 
 		if ( ! empty( $primary_provider ) && ! empty( $available_providers[ $primary_provider ] ) ) {
 			return $primary_provider;
@@ -1100,15 +1104,15 @@ class Two_Factor_Core {
 
 		$provider_key        = $provider->get_key();
 		$available_providers = self::get_available_providers_for_user( $user );
+		if ( is_wp_error( $available_providers ) ) {
+			wp_die( $available_providers );
+		}
 		$backup_providers    = array_diff_key( $available_providers, array( $provider_key => null ) );
 		$interim_login       = isset( $_REQUEST['interim-login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$rememberme = intval( self::rememberme() );
 
-		if ( is_wp_error( $available_providers ) ) {
-			// If it returned an error, the configured methods don't exist, and it couldn't swap in a replacement.
-			wp_die( $available_providers );
-		}
+
 
 		if ( ! function_exists( 'login_header' ) ) {
 			// We really should migrate login_header() out of `wp-login.php` so it can be called from an includes file.
@@ -2088,7 +2092,8 @@ class Two_Factor_Core {
 
 		wp_enqueue_style( 'user-edit-2fa', plugins_url( 'user-edit.css', __FILE__ ), array(), TWO_FACTOR_VERSION );
 
-		$enabled_providers = array_keys( self::get_available_providers_for_user( $user ) );
+		$available_providers_result = self::get_available_providers_for_user( $user );
+		$enabled_providers = is_wp_error( $available_providers_result ) ? array() : array_keys( $available_providers_result );
 
 		// This is specific to the current session, not the displayed user.
 		$show_2fa_options = self::current_user_can_update_two_factor_options();

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -62,7 +62,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	/**
 	 * Enqueue scripts for email provider.
 	 *
-	 * @since 0.10.0
+	 * @since 0.16.0
 	 *
 	 * @codeCoverageIgnore
 	 *
@@ -98,6 +98,8 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 	/**
 	 * Register the rest-api endpoints required for this provider.
+	 *
+	 * @since 0.16.0
 	 */
 	public function register_rest_routes() {
 		register_rest_route(
@@ -147,6 +149,8 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	/**
 	 * REST API endpoint for setting up Email.
 	 *
+	 * @since 0.16.0
+	 *
 	 * @param WP_REST_Request $request The Rest Request object.
 	 * @return WP_Error|array Array of data on success, WP_Error on error.
 	 */
@@ -188,6 +192,8 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 	/**
 	 * Rest API endpoint for handling deactivation of Email.
+	 *
+	 * @since 0.16.0
 	 *
 	 * @param WP_REST_Request $request The Rest Request object.
 	 * @return array Success array.
@@ -654,6 +660,8 @@ class Two_Factor_Email extends Two_Factor_Provider {
 
 	/**
 	 * Prevent enabling the Email provider if it hasn't been verified (and isn't a legacy enabled user).
+	 *
+	 * @since 0.16.0
 	 *
 	 * @param int $user_id The user ID.
 	 */

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -29,6 +29,13 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	const TOKEN_META_KEY_TIMESTAMP = '_two_factor_email_token_timestamp';
 
 	/**
+	 * The user meta verified key.
+	 *
+	 * @var string
+	 */
+	const VERIFIED_META_KEY = '_two_factor_email_verified';
+
+	/**
 	 * Name of the input field used for code resend.
 	 *
 	 * @var string
@@ -43,8 +50,32 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @codeCoverageIgnore
 	 */
 	protected function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 		add_action( 'two_factor_user_options_' . __CLASS__, array( $this, 'user_options' ) );
+		add_action( 'personal_options_update', array( $this, 'pre_user_options_update' ), 5 );
+		add_action( 'edit_user_profile_update', array( $this, 'pre_user_options_update' ), 5 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		parent::__construct();
+	}
+
+	/**
+	 * Enqueue scripts for email provider.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $hook_suffix Optional. The current admin page hook suffix.
+	 */
+	public function enqueue_assets( $hook_suffix = '' ) {
+		wp_register_script(
+			'two-factor-email-admin',
+			plugins_url( 'js/email-admin.js', __FILE__ ),
+			array( 'jquery', 'wp-api-request' ),
+			TWO_FACTOR_VERSION,
+			true
+		);
 	}
 
 	/**
@@ -63,6 +94,122 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 */
 	public function get_alternative_provider_label() {
 		return __( 'Send a code to your email', 'two-factor' );
+	}
+
+	/**
+	 * Register the rest-api endpoints required for this provider.
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			Two_Factor_Core::REST_NAMESPACE,
+			'/email',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'rest_delete_email' ),
+					'permission_callback' => function ( $request ) {
+						return Two_Factor_Core::rest_api_can_edit_user_and_update_two_factor_options( $request['user_id'] );
+					},
+					'args'                => array(
+						'user_id' => array(
+							'required' => true,
+							'type'     => 'integer',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'rest_setup_email' ),
+					'permission_callback' => function ( $request ) {
+						return Two_Factor_Core::rest_api_can_edit_user_and_update_two_factor_options( $request['user_id'] );
+					},
+					'args'                => array(
+						'user_id' => array(
+							'required' => true,
+							'type'     => 'integer',
+						),
+						'code'    => array(
+							'type'              => 'string',
+							'default'           => '',
+							'validate_callback' => null, // Note: validation handled in ::rest_setup_email().
+						),
+						'enable_provider' => array(
+							'required' => false,
+							'type'     => 'boolean',
+							'default'  => false,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * REST API endpoint for setting up Email.
+	 *
+	 * @param WP_REST_Request $request The Rest Request object.
+	 * @return WP_Error|array Array of data on success, WP_Error on error.
+	 */
+	public function rest_setup_email( $request ) {
+		$user_id = $request['user_id'];
+		$user    = get_user_by( 'id', $user_id );
+
+		$code = preg_replace( '/\s+/', '', $request['code'] );
+
+		// If no code, generate and email one.
+		if ( empty( $code ) ) {
+			if ( $this->generate_and_email_token( $user, 'verification_setup' ) ) {
+				return array( 'success' => true );
+			}
+			return new WP_Error( 'email_error', __( 'Unable to send email. Please check your server settings.', 'two-factor' ), array( 'status' => 500 ) );
+		}
+
+		// Verify code.
+		if ( ! $this->validate_token( $user_id, $code ) ) {
+			return new WP_Error( 'invalid_code', __( 'Invalid verification code.', 'two-factor' ), array( 'status' => 400 ) );
+		}
+
+		// Mark as verified.
+		update_user_meta( $user_id, self::VERIFIED_META_KEY, true );
+
+		if ( $request->get_param( 'enable_provider' ) && ! Two_Factor_Core::enable_provider_for_user( $user_id, 'Two_Factor_Email' ) ) {
+			return new WP_Error( 'db_error', __( 'Unable to enable Email provider for this user.', 'two-factor' ), array( 'status' => 500 ) );
+		}
+
+		ob_start();
+		$this->user_options( $user );
+		$html = ob_get_clean();
+
+		return array(
+			'success' => true,
+			'html'    => $html,
+		);
+	}
+
+	/**
+	 * Rest API endpoint for handling deactivation of Email.
+	 *
+	 * @param WP_REST_Request $request The Rest Request object.
+	 * @return array Success array.
+	 */
+	public function rest_delete_email( $request ) {
+		$user_id = $request['user_id'];
+		$user    = get_user_by( 'id', $user_id );
+
+		delete_user_meta( $user_id, self::VERIFIED_META_KEY );
+
+		if ( ! Two_Factor_Core::disable_provider_for_user( $user_id, 'Two_Factor_Email' ) ) {
+			return new WP_Error( 'db_error', __( 'Unable to disable Email provider for this user.', 'two-factor' ), array( 'status' => 500 ) );
+		}
+
+		ob_start();
+		$this->user_options( $user );
+		$html = ob_get_clean();
+
+		return array(
+			'success' => true,
+			'html'    => $html,
+		);
 	}
 
 	/**
@@ -274,39 +421,57 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 *
 	 * @since 0.1-dev
 	 *
-	 * @param WP_User $user WP_User object of the logged-in user.
+	 * @param WP_User $user   WP_User object of the logged-in user.
+	 * @param string  $action Optional. The action intended for the token. Default 'login'.
+	 *                        Accepts 'login', 'verification_setup'.
 	 * @return bool Whether the email contents were sent successfully.
 	 */
-	public function generate_and_email_token( $user ) {
+	public function generate_and_email_token( $user, $action = 'login' ) {
 		$token       = $this->generate_token( $user->ID );
 		$remote_ip   = $this->get_client_ip();
 		$ttl_minutes = (int) ceil( $this->user_token_ttl( $user->ID ) / MINUTE_IN_SECONDS );
 
-		$subject = wp_strip_all_tags(
-			sprintf(
-				/* translators: %s: site name */
-				__( '[%s] Login confirmation code', 'two-factor' ),
-				wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
-			)
-		);
+		if ( 'verification_setup' === $action ) {
+			$subject = wp_strip_all_tags(
+				sprintf(
+					/* translators: %s: site name */
+					__( 'Verify your email for Two-Factor Authentication at %s', 'two-factor' ),
+					wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
+				)
+			);
+			$message = wp_strip_all_tags(
+				sprintf(
+					/* translators: %s: token */
+					__( 'Enter %s to verify your email address for two-factor authentication.', 'two-factor' ),
+					$token
+				)
+			);
+		} else {
+			$subject = wp_strip_all_tags(
+				sprintf(
+					/* translators: %s: site name */
+					__( '[%s] Login confirmation code', 'two-factor' ),
+					wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES )
+				)
+			);
 
-		$message_parts = array(
-			__( 'Please complete the login by entering the verification code below:', 'two-factor' ),
-			$token,
-			sprintf(
-				/* translators: %d: number of minutes */
-				__( 'This code will expire in %d minutes.', 'two-factor' ),
-				$ttl_minutes
-			),
-			sprintf(
-				/* translators: %1$s: IP address of user, %2$s: user login */
-				__( 'A user from IP address %1$s has successfully authenticated as %2$s. If this wasn\'t you, please change your password.', 'two-factor' ),
-				$remote_ip,
-				$user->user_login
-			),
-		);
-
-		$message = wp_strip_all_tags( implode( "\n\n", $message_parts ) );
+			$message_parts = array(
+				__( 'Please complete the login by entering the verification code below:', 'two-factor' ),
+				$token,
+				sprintf(
+					/* translators: %d: number of minutes */
+					__( 'This code will expire in %d minutes.', 'two-factor' ),
+					$ttl_minutes
+				),
+				sprintf(
+					/* translators: %1$s: IP address of user, %2$s: user login */
+					__( 'A user from IP address %1$s has successfully authenticated as %2$s. If this wasn\'t you, please change your password.', 'two-factor' ),
+					$remote_ip,
+					$user->user_login
+				),
+			);
+			$message = wp_strip_all_tags( implode( "\n\n", $message_parts ) );
+		}
 
 		/**
 		 * Filters the token email subject.
@@ -422,7 +587,14 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 * @return boolean
 	 */
 	public function is_available_for_user( $user ) {
-		return true;
+		// If the user has already enabled the provider (legacy), allow them to continue using it.
+		$providers = get_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+		if ( is_array( $providers ) && in_array( 'Two_Factor_Email', $providers, true ) ) {
+			return true;
+		}
+
+		// Otherwise, only available if verified.
+		return (bool) get_user_meta( $user->ID, self::VERIFIED_META_KEY, true );
 	}
 
 	/**
@@ -434,7 +606,21 @@ class Two_Factor_Email extends Two_Factor_Provider {
 	 */
 	public function user_options( $user ) {
 		$email = $user->user_email;
+
+		// Check if user is verified.
+		$is_verified = $this->is_available_for_user( $user );
+
+		wp_localize_script(
+			'two-factor-email-admin',
+			'twoFactorEmailAdmin',
+			array(
+				'restPath' => Two_Factor_Core::REST_NAMESPACE . '/email',
+				'userId'   => $user->ID,
+			)
+		);
+		wp_enqueue_script( 'two-factor-email-admin' );
 		?>
+		<div id="two-factor-email-options">
 		<p>
 			<?php
 			echo esc_html(
@@ -446,11 +632,50 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			);
 			?>
 		</p>
+		<?php if ( ! $is_verified ) : ?>
+			<p>
+				<button type="button" class="button" id="two-factor-email-send-code">
+					<?php esc_html_e( 'Verify your e-mail address', 'two-factor' ); ?>
+				</button>
+			</p>
+			<div id="two-factor-email-verification-form" style="display:none; margin-top: 10px;">
+				<p>
+					<label for="two-factor-email-code-input"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
+					<input type="text" id="two-factor-email-code-input" class="input" size="20" autocomplete="off" />
+					<button type="button" class="button" id="two-factor-email-verify-code">
+						<?php esc_html_e( 'Verify', 'two-factor' ); ?>
+					</button>
+				</p>
+			</div>
+		<?php endif; ?>
+		</div>
 		<?php
 	}
 
 	/**
-	 * Return user meta keys to delete during plugin uninstall.
+	 * Prevent enabling the Email provider if it hasn't been verified (and isn't a legacy enabled user).
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function pre_user_options_update( $user_id ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce validation is handled by core.
+		if ( isset( $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] ) && is_array( $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] ) ) {
+			$enabled_providers = $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ]; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Payload is sanitized when saved.
+			if ( in_array( 'Two_Factor_Email', $enabled_providers, true ) ) {
+				$is_verified = get_user_meta( $user_id, self::VERIFIED_META_KEY, true );
+				$current_providers = get_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+				
+				// If not verified, and NOT currently enabled (legacy), disallow enabling.
+				if ( ! $is_verified && ( ! is_array( $current_providers ) || ! in_array( 'Two_Factor_Email', $current_providers, true ) ) ) {
+					$enabled_providers = array_diff( $enabled_providers, array( 'Two_Factor_Email' ) );
+					$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = $enabled_providers;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Returns the key of the user meta. keys to delete during plugin uninstall.
 	 *
 	 * @since 0.10.0
 	 *
@@ -460,6 +685,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		return array(
 			self::TOKEN_META_KEY,
 			self::TOKEN_META_KEY_TIMESTAMP,
+			self::VERIFIED_META_KEY,
 		);
 	}
 }

--- a/providers/js/email-admin.js
+++ b/providers/js/email-admin.js
@@ -1,0 +1,56 @@
+/* global twoFactorEmailAdmin, wp, jQuery */
+( function( $ ) {
+	$( '#two-factor-email-send-code' ).on( 'click', function( e ) {
+		var $btn = $( this );
+
+		e.preventDefault();
+		$btn.prop( 'disabled', true );
+
+		wp.apiRequest( {
+			method: 'POST',
+			path: twoFactorEmailAdmin.restPath,
+			data: {
+				user_id: parseInt( twoFactorEmailAdmin.userId, 10 )
+			}
+		} ).done( function() {
+			$btn.hide();
+			$( '#two-factor-email-verification-form' ).slideDown();
+			$( '#two-factor-email-code-input' ).focus();
+		} ).fail( function( response ) {
+			var msg = ( response.responseJSON && response.responseJSON.message ) ? response.responseJSON.message : 'Error sending email';
+
+			// eslint-disable-next-line no-alert
+			alert( msg );
+			$btn.prop( 'disabled', false );
+		} );
+	} );
+
+	$( '#two-factor-email-verify-code' ).on( 'click', function( e ) {
+		var $btn = $( this ),
+			code = $( '#two-factor-email-code-input' ).val();
+
+		e.preventDefault();
+		$btn.prop( 'disabled', true );
+
+		wp.apiRequest( {
+			method: 'POST',
+			path: twoFactorEmailAdmin.restPath,
+			data: {
+				user_id: parseInt( twoFactorEmailAdmin.userId, 10 ),
+				code: code,
+				enable_provider: true
+			}
+		} ).done( function( response ) {
+			var $newContent = $( response.html );
+
+			$( '#two-factor-email-options' ).replaceWith( $newContent );
+			$( '#enabled-Two_Factor_Email' ).prop( 'checked', true );
+		} ).fail( function( response ) {
+			var msg = ( response.responseJSON && response.responseJSON.message ) ? response.responseJSON.message : 'Error verifying code';
+
+			// eslint-disable-next-line no-alert
+			alert( msg );
+			$btn.prop( 'disabled', false );
+		} );
+	} );
+}( jQuery ) );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -355,6 +355,9 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			)
 		);
 
+		// Mark the user as verified for Two_Factor_Email.
+		update_user_meta( $user->ID, Two_Factor_Email::VERIFIED_META_KEY, $user->user_email );
+
 		// This should fail back to `Two_Factor_Email` then.
 		$this->assertEquals(
 			array(
@@ -2544,6 +2547,9 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * @covers Two_Factor_Core::add_settings_action_link
 	 */
 	public function test_add_settings_action_link() {
+		$admin_user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_user );
+
 		$links  = array( 'deactivate' => '<a href="#">Deactivate</a>' );
 		$result = Two_Factor_Core::add_settings_action_link( $links );
 
@@ -2553,5 +2559,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<a', $first );
 		$this->assertStringContainsString( 'Settings', $first );
 		$this->assertStringContainsString( 'options-general.php', $first );
+
+		wp_set_current_user( 0 );
 	}
 }

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1671,6 +1671,9 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$session_manager->create( time() + DAY_IN_SECONDS );
 		$this->assertCount( 2, $session_manager->get_all(), 'Failed to create another session' );
 
+		// Set the email provider as verified so it can be enabled.
+		update_user_meta( $user->ID, Two_Factor_Email::VERIFIED_META_KEY, true );
+
 		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array(
 			'Two_Factor_Dummy' => 'Two_Factor_Dummy',
 			'Two_Factor_Email' => 'Two_Factor_Email',

--- a/tests/providers/class-two-factor-backup-codes.php
+++ b/tests/providers/class-two-factor-backup-codes.php
@@ -165,7 +165,10 @@ class Tests_Two_Factor_Backup_Codes extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '<div id="two-factor-backup-codes">', $buffer );
 		$this->assertStringContainsString( '<div class="two-factor-backup-codes-wrapper" style="display:none;">', $buffer );
-		$this->assertStringContainsString( "user_id: {$user->ID}", $buffer );
+
+		$scripts = wp_scripts();
+		$data    = $scripts->get_data( 'two-factor-backup-codes-admin', 'data' );
+		$this->assertStringContainsString( '"userId":' . $user->ID, $data );
 	}
 
 	/**

--- a/tests/providers/class-two-factor-email-rest-api.php
+++ b/tests/providers/class-two-factor-email-rest-api.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Test Two Factor Email REST API.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Tests_Two_Factor_Email_REST_API
+ *
+ * @package Two_Factor
+ * @group providers
+ * @group email
+ */
+class Tests_Two_Factor_Email_REST_API extends WP_Test_REST_TestCase {
+
+	/**
+	 * Instance of our provider class.
+	 *
+	 * @var Two_Factor_Email
+	 */
+	protected static $provider;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * Instance of the PHPMailer class.
+	 *
+	 * @var PHPMailer
+	 */
+	protected static $phpmailer = null;
+
+	/**
+	 * Instance of the MockPHPMailer class.
+	 *
+	 * @var MockPHPMailer
+	 */
+	protected static $mockmailer;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		self::$editor_id = $factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		self::$provider = Two_Factor_Email::get_instance();
+
+		self::$mockmailer = new MockPHPMailer();
+
+		if ( isset( $GLOBALS['phpmailer'] ) ) {
+			self::$phpmailer      = $GLOBALS['phpmailer'];
+			$GLOBALS['phpmailer'] = self::$mockmailer;
+		}
+
+		$_SERVER['SERVER_NAME'] = 'example.com';
+	}
+
+	/**
+	 * Clean up test fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$editor_id );
+
+		unset( $_SERVER['SERVER_NAME'] );
+
+		if ( isset( self::$phpmailer ) ) {
+			$GLOBALS['phpmailer'] = self::$phpmailer;
+			self::$phpmailer      = null;
+		}
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// Clear mock emails before each test.
+		self::$mockmailer->mock_sent = array();
+	}
+
+	/**
+	 * Verify setting up email without a code triggers email sending.
+	 *
+	 * @covers Two_Factor_Email::rest_setup_email
+	 */
+	public function test_user_two_factor_rest_setup_email_sends_code() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+			)
+		);
+
+		$emails_before = count( self::$mockmailer->mock_sent );
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $data['success'] );
+
+		$this->assertCount( $emails_before + 1, self::$mockmailer->mock_sent, 'A new email should be sent' );
+
+		// User should have a token saved.
+		$this->assertTrue( self::$provider->user_has_token( self::$admin_id ) );
+	}
+
+	/**
+	 * Verify setting up email with an invalid code.
+	 *
+	 * @covers Two_Factor_Email::rest_setup_email
+	 */
+	public function test_user_two_factor_rest_setup_email_bad_code() {
+		wp_set_current_user( self::$admin_id );
+
+		self::$provider->generate_token( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+				'code'    => 'invalid123',
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'invalid_code', $response, 400 );
+		$this->assertFalse( self::$provider->is_available_for_user( wp_get_current_user() ) );
+	}
+
+	/**
+	 * Verify setting up email with a valid code enables the provider.
+	 *
+	 * @covers Two_Factor_Email::rest_setup_email
+	 */
+	public function test_user_two_factor_rest_setup_email_valid_code() {
+		wp_set_current_user( self::$admin_id );
+
+		$token = self::$provider->generate_token( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id'         => self::$admin_id,
+				'code'            => $token,
+				'enable_provider' => true,
+			)
+		);
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'html', $data );
+
+		// Should be verified and enabled.
+		$this->assertTrue( (bool) get_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true ) );
+		$this->assertTrue( Two_Factor_Core::is_provider_enabled_for_user( self::$admin_id, 'Two_Factor_Email' ) );
+	}
+
+	/**
+	 * Verify deleting email verification via REST API.
+	 *
+	 * @covers Two_Factor_Email::rest_delete_email
+	 */
+	public function test_user_can_delete_email_verification() {
+		wp_set_current_user( self::$admin_id );
+		Two_Factor_Core::enable_provider_for_user( self::$admin_id, 'Two_Factor_Email' );
+		update_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+
+		$request = new WP_REST_Request( 'DELETE', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Should no longer be verified.
+		$this->assertFalse( get_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true ) );
+	}
+
+	/**
+	 * Verify admin can delete email verification for others.
+	 *
+	 * @covers Two_Factor_Email::rest_delete_email
+	 */
+	public function test_admin_can_delete_email_for_others() {
+		wp_set_current_user( self::$admin_id );
+		update_user_meta( self::$editor_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+
+		$request = new WP_REST_Request( 'DELETE', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$editor_id,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( get_user_meta( self::$editor_id, Two_Factor_Email::VERIFIED_META_KEY, true ) );
+	}
+
+	/**
+	 * Verify deleting email via REST API denied for other users.
+	 *
+	 * @covers Two_Factor_Email::rest_delete_email
+	 */
+	public function test_user_cannot_delete_email_for_others() {
+		wp_set_current_user( self::$editor_id );
+		update_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+
+		$request = new WP_REST_Request( 'DELETE', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+
+		// Verified state shouldn't be altered.
+		$this->assertTrue( (bool) get_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true ) );
+	}
+
+	/**
+	 * Verify setup email via REST API denied for other users.
+	 *
+	 * @covers Two_Factor_Email::rest_setup_email
+	 */
+	public function test_user_cannot_setup_email_for_others() {
+		wp_set_current_user( self::$editor_id );
+
+		$request = new WP_REST_Request( 'POST', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+	}
+}

--- a/tests/providers/class-two-factor-email-rest-api.php
+++ b/tests/providers/class-two-factor-email-rest-api.php
@@ -184,7 +184,7 @@ class Tests_Two_Factor_Email_REST_API extends WP_Test_REST_TestCase {
 
 		// Should be verified and enabled.
 		$this->assertTrue( (bool) get_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true ) );
-		$this->assertTrue( Two_Factor_Core::is_provider_enabled_for_user( self::$admin_id, 'Two_Factor_Email' ) );
+		$this->assertTrue( in_array( 'Two_Factor_Email', Two_Factor_Core::get_enabled_providers_for_user( self::$admin_id ), true ) );
 	}
 
 	/**
@@ -194,8 +194,8 @@ class Tests_Two_Factor_Email_REST_API extends WP_Test_REST_TestCase {
 	 */
 	public function test_user_can_delete_email_verification() {
 		wp_set_current_user( self::$admin_id );
-		Two_Factor_Core::enable_provider_for_user( self::$admin_id, 'Two_Factor_Email' );
 		update_user_meta( self::$admin_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+		Two_Factor_Core::enable_provider_for_user( self::$admin_id, 'Two_Factor_Email' );
 
 		$request = new WP_REST_Request( 'DELETE', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
 		$request->set_body_params(
@@ -219,6 +219,7 @@ class Tests_Two_Factor_Email_REST_API extends WP_Test_REST_TestCase {
 	public function test_admin_can_delete_email_for_others() {
 		wp_set_current_user( self::$admin_id );
 		update_user_meta( self::$editor_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+		Two_Factor_Core::enable_provider_for_user( self::$editor_id, 'Two_Factor_Email' );
 
 		$request = new WP_REST_Request( 'DELETE', '/' . Two_Factor_Core::REST_NAMESPACE . '/email' );
 		$request->set_body_params(

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -175,6 +175,55 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that verification setup emails have correct content.
+	 *
+	 * @covers Two_Factor_Email::generate_and_email_token
+	 */
+	public function test_generate_and_email_token_verification_context() {
+		$user = new WP_User( self::factory()->user->create() );
+
+		$this->provider->generate_and_email_token( $user, 'verification_setup' );
+
+		$subject = $GLOBALS['phpmailer']->Subject;
+		$content = $GLOBALS['phpmailer']->Body;
+
+		$this->assertStringContainsString( 'Verify your email for Two-Factor Authentication', $subject );
+		$this->assertStringContainsString( 'verify your email address', $content );
+		$this->assertStringNotContainsString( 'successfully authenticated', $content );
+	}
+
+	/**
+	 * Verify that login emails have correct content arguments.
+	 *
+	 * @covers Two_Factor_Email::generate_and_email_token
+	 */
+	public function test_generate_and_email_token_login_context_correct_args() {
+		$user = new WP_User( self::factory()->user->create() );
+		// Mock REMOTE_ADDR for IP check
+		$prev_remote_addr       = $_SERVER['REMOTE_ADDR'] ?? null;
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+
+		try {
+			$this->provider->generate_and_email_token( $user, 'login' );
+		} finally {
+			if ( null === $prev_remote_addr ) {
+				unset( $_SERVER['REMOTE_ADDR'] );
+			} else {
+				$_SERVER['REMOTE_ADDR'] = $prev_remote_addr;
+			}
+		}
+
+		$content = $GLOBALS['phpmailer']->Body;
+
+		$this->assertStringContainsString( 'Enter', $content );
+		$this->assertStringContainsString( 'log in', $content );
+		// Check that IP is effectively in the message (and not the token key or something else)
+		$this->assertStringContainsString( '127.0.0.1', $content );
+		// Check that username is in the message
+		$this->assertStringContainsString( $user->user_login, $content );
+	}
+
+	/**
 	 * Verify the contents of the authentication page when no user is provided.
 	 *
 	 * @covers Two_Factor_Email::authentication_page
@@ -237,12 +286,45 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify that availability returns true.
+	 * Verify that availability returns false for unverified users.
 	 *
 	 * @covers Two_Factor_Email::is_available_for_user
 	 */
 	public function test_is_available_for_user() {
-		$this->assertTrue( $this->provider->is_available_for_user( false ) );
+		$user = new WP_User( self::factory()->user->create() );
+		$this->assertFalse( $this->provider->is_available_for_user( $user ) );
+	}
+
+	/**
+	 * Verify that availability returns true for verified users.
+	 *
+	 * @covers Two_Factor_Email::is_available_for_user
+	 */
+	public function test_is_available_for_user_verified() {
+		$user = new WP_User( self::factory()->user->create() );
+		update_user_meta( $user->ID, Two_Factor_Email::VERIFIED_META_KEY, true );
+		$this->assertTrue( $this->provider->is_available_for_user( $user ) );
+	}
+
+	/**
+	 * Verify that availability returns true for users who already have it enabled (backwards compatibility).
+	 *
+	 * @covers Two_Factor_Email::is_available_for_user
+	 */
+	public function test_is_available_for_user_backwards_compat() {
+		$user = new WP_User( self::factory()->user->create() );
+		update_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Email' ) );
+		$this->assertTrue( $this->provider->is_available_for_user( $user ) );
+	}
+
+	/**
+	 * Verify that the verified meta key is cleaned up on uninstall.
+	 *
+	 * @covers Two_Factor_Email::uninstall_user_meta_keys
+	 */
+	public function test_verified_meta_cleanup() {
+		$keys = Two_Factor_Email::uninstall_user_meta_keys();
+		$this->assertContains( Two_Factor_Email::VERIFIED_META_KEY, $keys );
 	}
 
 	/**
@@ -258,6 +340,67 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		$this->assertEquals( $token, $this->provider->get_user_token( $user_with_token->ID ), 'Failed to retrieve a valid user token.' );
 		$this->assertFalse( $this->provider->get_user_token( $user_without_token->ID ), 'Failed to recognize a missing token.' );
+	}
+
+	/**
+	 * Verify that pre_user_options_update blocks enabling if not verified.
+	 *
+	 * @covers Two_Factor_Email::pre_user_options_update
+	 */
+	public function test_pre_user_options_update_blocks_unverified() {
+		$user_id = self::factory()->user->create();
+		
+		// Simulate POST request trying to enable Email provider.
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array( 'Two_Factor_Email', 'Two_Factor_Dummy' );
+		
+		$this->provider->pre_user_options_update( $user_id );
+		
+		$this->assertNotContains( 'Two_Factor_Email', $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+		$this->assertContains( 'Two_Factor_Dummy', $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+		
+		unset( $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+	}
+
+	/**
+	 * Verify that pre_user_options_update allows keeping legacy enabled provider.
+	 *
+	 * @covers Two_Factor_Email::pre_user_options_update
+	 */
+	public function test_pre_user_options_update_allows_legacy() {
+		$user_id = self::factory()->user->create();
+		
+		// Set up legacy state: enabled but not verified.
+		update_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Email' ) );
+		
+		// Simulate POST request keeping it enabled.
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array( 'Two_Factor_Email' );
+		
+		$this->provider->pre_user_options_update( $user_id );
+		
+		$this->assertContains( 'Two_Factor_Email', $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+		
+		unset( $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+	}
+
+	/**
+	 * Verify that verified users can enable the provider.
+	 *
+	 * @covers Two_Factor_Email::pre_user_options_update
+	 */
+	public function test_pre_user_options_update_allows_verified() {
+		$user_id = self::factory()->user->create();
+		
+		// Set up verified state.
+		update_user_meta( $user_id, Two_Factor_Email::VERIFIED_META_KEY, true );
+		
+		// Simulate POST request enabling it.
+		$_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] = array( 'Two_Factor_Email' );
+		
+		$this->provider->pre_user_options_update( $user_id );
+		
+		$this->assertContains( 'Two_Factor_Email', $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
+		
+		unset( $_POST[ Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY ] );
 	}
 
 	/**

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -215,8 +215,8 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		$content = $GLOBALS['phpmailer']->Body;
 
-		$this->assertStringContainsString( 'Enter', $content );
-		$this->assertStringContainsString( 'log in', $content );
+		$this->assertStringContainsString( 'entering', $content );
+		$this->assertStringContainsString( 'login', $content );
 		// Check that IP is effectively in the message (and not the token key or something else)
 		$this->assertStringContainsString( '127.0.0.1', $content );
 		// Check that username is in the message


### PR DESCRIPTION
## Description

This PR implements a verification step for the Email provider in the Two-Factor plugin.

Previously, users could enable Email 2FA without confirming ownership of the email address, which posed a risk of account lockout if the email was incorrect or inaccessible. This change aligns the Email provider's activation flow with the TOTP provider by requiring successful code verification before the provider can be enabled.

## Changes

- **User Options UI:**
    - The "Email" provider section now displays a **"Verify your e-mail address"** button for unverified users.
    - Clicking this button initiates an AJAX request to send a verification code.
    - A new input field allows the user to enter the received code.
    - Upon successful verification, the provider is enabled, and the UI updates to show the standard "Enabled" checkbox state.
- **REST API:**
    - Added `POST /two-factor/1.0/email`: Handles sending verification codes and validating them.
    - Added `DELETE /two-factor/1.0/email`: Handles resetting the verification status (if needed).
- **Verification Logic:**
    - `Two_Factor_Email::is_available_for_user()` now returns `true` **only if** the user has verified their email (checked via `_two_factor_email_verified` user meta).
- **Backwards Compatibility:**
    - Users who *already* have the Email provider enabled are considered "legacy verified" and can continue using it without re-verification.
- **Data Integrity:**
    - Added a `pre_user_options_update` hook to prevent the Email provider from being enabled via the standard profile form save unless the user is verified.

## How to Test

### New User (Fresh Setup)
1.  Navigate to **Users > Profile**.
2.  Scroll to the **Two-Factor Options** section.
3.  Ensure the "Email" option is *not* enabled.
4.  Click the **"Verify your e-mail address"** button.
5.  Check your email for a verification code.
6.  Enter the code in the input field and click **"Verify"**.
7.  Observe that the page updates, and the "Email" checkbox is now checked and enabled.

### Legacy User (Existing Setup)
1.  Log in as a user who already has Email 2FA enabled.
2.  Navigate to **Users > Profile**.
3.  Confirm that the "Email" checkbox remains checked and functional.
4.  Verify that no re-verification prompt is shown.

## Screenshot
![Email TOTP](https://github.com/user-attachments/assets/0947923e-2091-4f75-bcb8-c617f3bb857e)

## Technical Details

- **Class:** `Two_Factor_Email`
- **New Methods:**
    - `register_rest_routes()`
    - `rest_setup_email()`
    - `rest_delete_email()`
    - `pre_user_options_update()`
- **Modified Methods:**
    - `user_options()`: updated to render the verification UI.
    - `is_available_for_user()`: added verification check (with legacy fallback).
    - `generate_and_email_token()`: updated to accept an `$action` argument ('login' vs 'verification_setup') to send context-appropriate emails.
- **New Constants:**
    - `VERIFIED_META_KEY`: `_two_factor_email_verified`

## Checklist

- [x] Code follows the WordPress Coding Standards.
- [x] Unit tests have been added/updated.
- [x] Verified manual testing of the new flow.
- [x] Verified backwards compatibility for existing users.

Fixes #778