### PR TITLE
fix(backup-codes): minor UI issues and JS var leak

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -106,7 +106,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 						array( 'a' => array( 'href' => true ) )
 					);
 					?>
-				<span>
+				</span>
 			</p>
 		</div>
 		<?php
@@ -159,7 +159,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		$count = self::codes_remaining_for_user( $user );
 		?>
-		<p id="two-factor-backup-codes">
+		<div id="two-factor-backup-codes">
 			<p class="two-factor-backup-codes-count">
 			<?php
 				echo esc_html(
@@ -178,13 +178,13 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 				<em><?php esc_html_e( 'This invalidates all currently stored codes.', 'two-factor' ); ?></em>
 			</p>
-		</p>
+		</div>
 		<div class="two-factor-backup-codes-wrapper" style="display:none;">
 			<ol class="two-factor-backup-codes-unused-codes"></ol>
 			<p class="description"><?php esc_html_e( 'Write these down! Once you navigate away from this page, you will not be able to view these codes again.', 'two-factor' ); ?></p>
 			<p>
 				<a class="button button-two-factor-backup-codes-download button-secondary hide-if-no-js" href="javascript:void(0);" id="two-factor-backup-codes-download-link" download="two-factor-backup-codes.txt"><?php esc_html_e( 'Download Codes', 'two-factor' ); ?></a>
-			<p>
+			</p>
 		</div>
 		<script type="text/javascript">
 			( function( $ ) {
@@ -202,7 +202,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 						$codesList.html( '' );
 
 						// Append the codes.
-						for ( i = 0; i < response.codes.length; i++ ) {
+						for ( var i = 0; i < response.codes.length; i++ ) {
 							$codesList.append( '<li>' + response.codes[ i ] + '</li>' );
 						}
 

--- a/tests/providers/class-two-factor-backup-codes.php
+++ b/tests/providers/class-two-factor-backup-codes.php
@@ -163,7 +163,7 @@ class Tests_Two_Factor_Backup_Codes extends WP_UnitTestCase {
 		$this->provider->user_options( $user );
 		$buffer = ob_get_clean();
 
-		$this->assertStringContainsString( '<p id="two-factor-backup-codes">', $buffer );
+		$this->assertStringContainsString( '<div id="two-factor-backup-codes">', $buffer );
 		$this->assertStringContainsString( '<div class="two-factor-backup-codes-wrapper" style="display:none;">', $buffer );
 		$this->assertStringContainsString( "user_id: {$user->ID}", $buffer );
 	}


### PR DESCRIPTION
## What?

This pull request updates the markup structure and JavaScript in the backup codes provider to fix HTML issues. It also updates related tests to match these changes.

Markup improvements:
* Changed the main container in `user_options` from a `<p>` to a `<div>` because it is illegal to nest `<p>` tags.
* Corrected misplaced closing tags.

JavaScript update:
* Prevented leakage of the `i` variable into the global scope.

Test updates:
* Updated the tests to match the changes.

## Why?
Correctness and maintainability.

## How?
* For nested `<p>` tags, replaced the outermost `<p>` with a `<div>`;
* For the misplaced tags, converted them into closing tags.

## Testing Instructions
CI must pass - I have updated the tests.

## Screenshots or screencast
N/A

## Changelog Entry
> Fixed - Minor markup and JS issues in the Backup Code provider.
