### PR TITLE
fix(totp): delete user TOTP key after disabling the provider

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -175,11 +175,11 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$user_id = $request['user_id'];
 		$user    = get_user_by( 'id', $user_id );
 
-		$this->delete_user_totp_key( $user_id );
-
 		if ( ! Two_Factor_Core::disable_provider_for_user( $user_id, 'Two_Factor_Totp' ) ) {
 			return new WP_Error( 'db_error', __( 'Unable to disable TOTP provider for this user.', 'two-factor' ), array( 'status' => 500 ) );
 		}
+
+		$this->delete_user_totp_key( $user_id );
 
 		ob_start();
 		$this->user_two_factor_options( $user );


### PR DESCRIPTION
## What?
The REST handler deletes the TOTP secret key first (`delete_user_totp_key()`), then attempts to disable the provider via `Two_Factor_Core::disable_provider_for_user()`. If disabling fails (due to a DB error), the request returns an error, but the secret has already been removed.

## Why?
Inconsistent user state: the provider may remain enabled even when no secret exists, potentially causing login failures or confusing the UI.

## How?
Change operation order: disable the provider first.

## Testing Instructions
N/A

## Screenshots or screencast
N/A

## Changelog Entry
> Fixed - delete user TOTP key only after the provider has been successfully disabled.
