### PR TITLE
fix: constructors must not return value

### DIFF
--- a/providers/class-two-factor-provider.php
+++ b/providers/class-two-factor-provider.php
@@ -37,7 +37,6 @@ abstract class Two_Factor_Provider {
 	 * @since 0.1-dev
 	 */
 	protected function __construct() {
-		return $this;
 	}
 
 	/**


### PR DESCRIPTION
## What?
This pull request removes a redundant `return $this;` statement from the constructor. This aligns with PHP class construction practices.

## Why?
In PHP, constructors are [void](https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor) and, therefore, must not return a value.

## How?
Remove `return $this;`.

## Testing Instructions
N/A - there are no functional changes.

## Screenshots or screencast
N/A

## Changelog Entry
> Fixed - removed `return` statement from `Two_Factor_Provider`'s constructor.
