### PR TITLE
Cleanup TOTP Provider: Remove legacy PHP 5.6 compatibility logic & duplicate autocomplete attribute

### DIFF
--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -690,11 +690,11 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 *
 	 * @since 0.2.0
 	 *
-	 * @param mixed $value The value to be packed.
+	 * @param int $value The value to be packed.
 	 *
 	 * @return string Binary packed string.
 	 */
-	public static function pack64( mixed $value ): string {
+	public static function pack64( int $value ): string {
 		// Native 64-bit support (modern PHP on 64-bit builds).
 		if ( 8 === PHP_INT_SIZE ) {
 			return pack( 'J', $value );


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Refactors pack64() to remove outdated PHP <5.6 compatibility code while retaining 32-bit support.
+ remove duplicated autocomplete attribute

## Why?
PHP 5.6 is no longer supported. The previous implementation contained unnecessary version checks and redundant branching, increasing complexity without benefit.

## How?
- Removed version_compare logic.
- Simplified to a single early-return structure.
- Retained 32-bit fallback using manual high/low 32-bit packing.
- Kept PHP_INT_SIZE >= 8 for defensive architecture handling.

## Changelog Entry
> Changed - Simplified pack64() implementation by removing legacy PHP compatibility logic while retaining 32-bit support.
> Changed - Remove duplicated data attribute for autocomplete