### PR TITLE
fix accessbility issues

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2047,6 +2047,7 @@ class Two_Factor_Core {
 		<?php endforeach; ?>
 
 		<fieldset id="two-factor-options" <?php echo $show_2fa_options ? '' : 'disabled="disabled"'; ?>>
+		<legend class="screen-reader-text"><?php esc_html_e( 'Two-Factor Options', 'two-factor' ); ?></legend>
 		<?php
 		if ( $providers ) {
 			self::render_user_providers_form( $user, $providers );
@@ -2161,9 +2162,9 @@ class Two_Factor_Core {
 		<table class="form-table two-factor-primary-method-table" role="presentation">
 			<tbody>
 				<tr>
-					<th><?php esc_html_e( 'Primary Method', 'two-factor' ); ?></th>
+					<th><label for="two-factor-primary-provider"><?php esc_html_e( 'Primary Method', 'two-factor' ); ?></label></th>
 					<td>
-						<select name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>">
+						<select id="two-factor-primary-provider" name="<?php echo esc_attr( self::PROVIDER_USER_META_KEY ); ?>">
 							<option value=""><?php echo esc_html( __( 'Default', 'two-factor' ) ); ?></option>
 							<?php foreach ( $providers as $provider_key => $object ) : ?>
 								<option value="<?php echo esc_attr( $provider_key ); ?>" <?php selected( $provider_key, $primary_provider_key ); ?> <?php disabled( ! in_array( $provider_key, $enabled_providers, true ) ); ?>>


### PR DESCRIPTION
## What?
Fix two accessibility issues in the Two-Factor settings UI.

## Why?
- The "Primary Method" `<select>` had no programmatically associated label, failing WCAG 1.3.1.
- The `<fieldset id="two-factor-options">` had no `<legend>`, leaving screen readers without a group description for the contained controls.

## How?
- Wrapped the "Primary Method" `<th>` text in `<label for="two-factor-primary-provider">` and added the matching `id` to the `<select>`.
- Added `<legend class="screen-reader-text">Two-Factor Options</legend>` as the first child of the fieldset. The `screen-reader-text` class keeps it visually hidden since the `<h2>` above already provides the visible heading.

## Testing Instructions
1. Open a user profile page with Two-Factor active.
2. Run an automated a11y scan (e.g. Axe, WAVE) — "select has no label" and "fieldset has no legend" errors should be gone.
3. Navigate with a screen reader (VoiceOver/NVDA) — the primary method select should announce "Primary Method" and each checkbox within the fieldset should be preceded by "Two-Factor Options".

## Changelog Entry
> Fixed - "Primary Method" select and Two-Factor Options fieldset were missing accessible labels for screen readers.