### PR TITLE
Fixed broken test cases

### DIFF
--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2544,8 +2544,14 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * @covers Two_Factor_Core::add_settings_action_link
 	 */
 	public function test_add_settings_action_link() {
+		$old_user_id = get_current_user_id();
+		$admin       = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
 		$links  = array( 'deactivate' => '<a href="#">Deactivate</a>' );
 		$result = Two_Factor_Core::add_settings_action_link( $links );
+
+		wp_set_current_user( $old_user_id );
 
 		// Settings link should be first.
 		$this->assertCount( 3, $result );

--- a/tests/providers/class-two-factor-backup-codes.php
+++ b/tests/providers/class-two-factor-backup-codes.php
@@ -159,13 +159,19 @@ class Tests_Two_Factor_Backup_Codes extends WP_UnitTestCase {
 	public function test_user_options() {
 		$user = new WP_User( self::factory()->user->create() );
 
+		// Register the script so wp_localize_script() can attach data to it.
+		$this->provider->enqueue_assets();
+
 		ob_start();
 		$this->provider->user_options( $user );
 		$buffer = ob_get_clean();
 
 		$this->assertStringContainsString( '<div id="two-factor-backup-codes">', $buffer );
 		$this->assertStringContainsString( '<div class="two-factor-backup-codes-wrapper" style="display:none;">', $buffer );
-		$this->assertStringContainsString( "user_id: {$user->ID}", $buffer );
+
+		// User ID is passed via wp_localize_script; check the registered script data rather than the HTML buffer.
+		$script_data = wp_scripts()->get_data( 'two-factor-backup-codes-admin', 'data' );
+		$this->assertStringContainsString( '"userId":"' . $user->ID . '"', $script_data );
 	}
 
 	/**


### PR DESCRIPTION
Ensures tests run under the correct user context and accurately verify localized script data.

Explicitly sets an administrator user for the `add_settings_action_link` test, ensuring it runs with appropriate capabilities.

Corrects the `test_user_options` assertion for backup codes by enqueueing assets and checking `wp_localize_script` output directly, reflecting how data is passed to JavaScript.

## Changelog Entry

> Fixed - Fixed broken test cases.
