### PR TITLE
update nick-fields/retry to support node24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
               run: npm install
 
             - name: Start the Docker testing environment
-              uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+              uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
               with:
                 timeout_minutes: 10
                 max_attempts: 3


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Updates nick-fields/retry to run on Node.js 24 by changing runs.using in action.yml from node20 to node24, and rebuilds the compiled dist bundle with a Node 24-compatible toolchain.

Related: https://github.com/WordPress/two-factor/pull/837

## Why?
Node.js 20 will reach end-of-life in April 2026, and GitHub has begun the deprecation process of Node 20 for GitHub Actions. Runners will begin using Node 24 by default starting June 2nd, 2026. GitHub Actions still targeting node20 will generate deprecation warnings today and will break entirely once Node 20 is removed from runners later in 2026. This PR keeps nick-fields/retry working without any disruption for users.

## Changelog Entry
> Changed - Upgraded action runtime from Node.js 20 to Node.js 24 to comply with GitHub Actions' deprecation of Node 20 (effective June 2026).
