### PR TITLE
docs: document login_redirect filter for post-2FA redirect (#278)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -105,7 +105,7 @@ Here is a list of action and filter hooks provided by the plugin:
 
 == Redirect After the Two-Factor Challenge ==
 
-To redirect users to a specific URL after completing the two-factor challenge, use the `login_redirect` filter:
+To redirect users to a specific URL after completing the two-factor challenge, use WordPress Core built-in login_redirect filter. The filter works the same way as in a standard WordPress login flow:
 
     add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $user ) {
         return home_url( '/dashboard/' );


### PR DESCRIPTION
Fixes #278

## What?
Adds a short documentation entry to `readme.txt` explaining how to redirect users after the two-factor challenge completes.

## Why?
There was no documentation on how to control the post-login destination when 2FA is enabled.

## How?
Adds a new `= Redirect After the Two-Factor Challenge =` entry to the Actions & Filters section in `readme.txt` with a working `login_redirect` filter example.

## Testing Instructions
1. Install the plugin and enable 2FA for a user.
2. Add the following to `functions.php`:
```php
add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $user ) {
    return home_url( '/dashboard/' );
}, 10, 3 );
```
3. Log in with that user and complete the 2FA challenge.
4. Confirm the user lands on `/dashboard/`.

## Screenshots or screencast
N/A

## Changelog Entry
> Added - Document the `login_redirect` filter for controlling redirect destination after the two-factor challenge.