### PR TITLE
Update WordPress plugin deployment action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: WordPress.org deploy
         id: deploy
-        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
         if: startsWith( github.ref, 'refs/tags/' )
         with:
           generate-zip: true


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?

Puts back the right deploy action and pins to the latest release commit hash.

### Copilot summary

This pull request updates the deployment workflow to use a newer and more appropriate GitHub Action for deploying to WordPress.org. The action has been changed from an asset update action to a dedicated deploy action, and the version has been bumped.

Deployment workflow update:

* Updated the WordPress.org deployment step in `.github/workflows/deploy.yml` to use `10up/action-wordpress-plugin-deploy@v2.3.0` instead of `10up/action-wordpress-plugin-asset-update@v2.2.0`, ensuring a more suitable and up-to-date deployment process.

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- if applicable -->

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - WordPress Deploy action.