### PR TITLE
Fix Codecov badge by adding OIDC permission for tokenless upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,9 @@ jobs:
             - name: Composer install
               run: |
                 rm composer.lock || true # We need to install fresh.
-                # On PHP 8+, the composer.json platform override (php: 7.2.24) causes PHPUnit 8.5 to
-                # be installed. PHPUnit 8.5 explicitly refuses to generate code coverage on PHP 8 with
-                # the message "This version of PHPUnit does not support code coverage on PHP 8". Pass
-                # --ignore-platform-req=php so Composer resolves against the actual PHP runtime and
-                # installs PHPUnit 9.6, which supports coverage on PHP 8.x.
+                # The composer.json platform override (php: 7.2.24) installs PHPUnit 8.5, which does
+                # not support code coverage on PHP 8. Use --ignore-platform-req=php on PHP 8+ so
+                # Composer installs PHPUnit 9.6, which supports coverage on PHP 8.x.
                 if [[ "${WP_ENV_PHP_VERSION}" == 8.* ]]; then
                   npm run composer -- install --ignore-platform-req=php
                 else
@@ -142,29 +140,15 @@ jobs:
             - name: Test
               run: |
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
-                # For the coverage matrix cell, set XDEBUG_MODE=coverage explicitly via env var
-                # (Xdebug 3 feature) rather than relying on the ini configuration that wp-env
-                # applies to persistent containers — ephemeral wp-env run containers may not
-                # inherit it. Pass --coverage-clover in addition to what phpunit.xml.dist configures
-                # so the clover output is guaranteed regardless of XML config format differences
-                # between PHPUnit versions.
-                if [[ "${{ matrix.php }}" == "8.3" && "${{ matrix.wp }}" == "latest" ]]; then
-                  # Call wp-env directly (not via npm run) to avoid npm re-splitting the argument
-                  # list. env sets XDEBUG_MODE=coverage and execs composer, which resolves phpunit
-                  # from vendor/bin — the same path used by npm run test.
-                  ./node_modules/.bin/wp-env run tests-cli --env-cwd=wp-content/plugins/two-factor \
-                    -- env XDEBUG_MODE=coverage composer test
-                else
-                  npm run test
-                fi
+                npm run test
 
             - name: Retrieve coverage report from container
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               run: |
                 # PHPUnit writes clover.xml into the Docker volume shared between tests-cli and
-                # tests-wordpress. We use docker cp (not 'docker exec cat > file') because docker cp
-                # is an atomic Docker API call that avoids a shell redirect pre-truncating the
-                # destination — which would zero-out the file before cat can read it.
+                # tests-wordpress. Use docker cp (not 'docker exec cat > file'): docker cp is an
+                # atomic API call that avoids a shell redirect pre-truncating the destination file,
+                # which would zero it out before cat can read it (self-overwrite).
                 CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
                 if [ -z "$CONTAINER" ]; then
                   echo "Error: tests-wordpress container not found"
@@ -172,11 +156,6 @@ jobs:
                 fi
                 mkdir -p tests/logs
                 docker cp "$CONTAINER:/var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml" tests/logs/clover.xml
-                echo "=== xdebug mode in tests-wordpress ==="
-                docker exec "$CONTAINER" php -r "echo ini_get('xdebug.mode') . PHP_EOL;"
-                echo "=== clover.xml size and first 10 lines ==="
-                wc -c tests/logs/clover.xml
-                head -10 tests/logs/clover.xml
                 if [ ! -s tests/logs/clover.xml ]; then
                   echo "Error: clover.xml is empty — coverage was not generated"
                   exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,16 @@ jobs:
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
+            - name: Retrieve coverage report from container
+              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
+              continue-on-error: true
+              run: |
+                mkdir -p tests/logs
+                docker exec \
+                  $(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1) \
+                  cat /var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml \
+                  > tests/logs/clover.xml
+
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,8 +132,15 @@ jobs:
 
             - name: Test
               run: |
-                mkdir -p tests/logs
+                npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
+
+            - name: Retrieve coverage report from container
+              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
+              continue-on-error: true
+              run: |
+                mkdir -p tests/logs
+                npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- cat tests/logs/clover.xml > tests/logs/clover.xml
 
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,32 +132,45 @@ jobs:
 
             - name: Test
               run: |
+                # Create tests/logs inside the container (uid=1000) so PHPUnit can write coverage
+                # reports to the shared Docker volume. The host runner (uid=1001) cannot create a
+                # writable directory here due to the UID mismatch with the container user.
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
             - name: Retrieve coverage report from container
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
-              continue-on-error: true
               run: |
+                # PHPUnit writes clover.xml inside the tests-wordpress Docker volume. We use
+                # docker exec (not wp-env run) because wp-env run creates a new ephemeral container
+                # that does not share the named volume state where PHPUnit wrote its output.
+                # The tests-wordpress container shares the volume and is guaranteed to be running.
+                CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
+                if [ -z "$CONTAINER" ]; then
+                  echo "Error: tests-wordpress container not found"
+                  exit 1
+                fi
                 mkdir -p tests/logs
-                docker exec \
-                  $(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1) \
+                docker exec "$CONTAINER" \
                   cat /var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml \
                   > tests/logs/clover.xml
+                if [ ! -s tests/logs/clover.xml ]; then
+                  echo "Error: clover.xml is empty or was not retrieved"
+                  exit 1
+                fi
+                echo "Coverage report retrieved: $(wc -c < tests/logs/clover.xml) bytes"
 
             - name: Debug coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               continue-on-error: true
               run: |
-                echo "=== clover.xml file size ==="
-                wc -c tests/logs/clover.xml || echo "File not found"
                 echo "=== clover.xml first 30 lines ==="
-                head -30 tests/logs/clover.xml || echo "Cannot read file"
+                head -30 tests/logs/clover.xml
                 echo "=== xdebug mode in tests-cli ==="
                 npm run env run tests-cli -- php -r "echo xdebug_info();" 2>&1 | grep -i "mode\|coverage" || echo "xdebug info unavailable"
 
             - name: Upload code coverage report
-              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
+              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' && hashFiles('tests/logs/clover.xml') != '' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
               with:
                 use_oidc: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,25 +132,34 @@ jobs:
 
             - name: Test
               run: |
-                # Create tests/logs inside the container so PHPUnit can write coverage reports.
-                # The plugin directory is bind-mounted from the workspace, so PHPUnit writing to
-                # tests/logs/clover.xml inside the container also writes to the workspace path on
-                # the host runner. The directory must be created by the container user (uid=1000)
-                # to be writable; creating it on the runner (uid=1001) would cause a permissions
-                # mismatch and prevent PHPUnit from writing coverage output.
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
-            - name: Verify coverage report
+            - name: Retrieve coverage report from container
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               run: |
-                if [ ! -s tests/logs/clover.xml ]; then
-                  echo "Error: tests/logs/clover.xml is missing or empty. Coverage was not generated."
+                # PHPUnit writes clover.xml into the named Docker volume shared between the
+                # tests-wordpress and tests-cli containers. The plugin directory is NOT bind-mounted
+                # from the workspace in CI, so the file does not appear on the host filesystem after
+                # npm run test. We use docker cp (not 'docker exec cat > file') because docker cp is
+                # an atomic Docker API call that reads from the container's merged filesystem without
+                # a shell redirect that would pre-truncate the destination and cause a self-overwrite.
+                CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
+                if [ -z "$CONTAINER" ]; then
+                  echo "Error: tests-wordpress container not found"
                   exit 1
                 fi
-                echo "Coverage report found: $(wc -c < tests/logs/clover.xml) bytes"
-                echo "=== clover.xml project summary (first 10 lines) ==="
+                mkdir -p tests/logs
+                docker cp "$CONTAINER:/var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml" tests/logs/clover.xml
+                echo "=== xdebug mode reported by tests-wordpress ==="
+                docker exec "$CONTAINER" php -r "echo ini_get('xdebug.mode') . PHP_EOL;"
+                echo "=== clover.xml size and summary ==="
+                wc -c tests/logs/clover.xml
                 head -10 tests/logs/clover.xml
+                if [ ! -s tests/logs/clover.xml ]; then
+                  echo "Error: clover.xml is empty — coverage was not generated"
+                  exit 1
+                fi
 
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' && hashFiles('tests/logs/clover.xml') != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,8 @@ jobs:
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
               with:
-                file: tests/logs/clover.xml
+                use_oidc: true
+                files: tests/logs/clover.xml
                 flags: phpunit
                 fail_ci_if_error: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,16 @@ jobs:
             - name: Composer install
               run: |
                 rm composer.lock || true # We need to install fresh.
-                npm run composer install
+                # On PHP 8+, the composer.json platform override (php: 7.2.24) causes PHPUnit 8.5 to
+                # be installed. PHPUnit 8.5 explicitly refuses to generate code coverage on PHP 8 with
+                # the message "This version of PHPUnit does not support code coverage on PHP 8". Pass
+                # --ignore-platform-req=php so Composer resolves against the actual PHP runtime and
+                # installs PHPUnit 9.6, which supports coverage on PHP 8.x.
+                if [[ "${WP_ENV_PHP_VERSION}" == 8.* ]]; then
+                  npm run composer -- install --ignore-platform-req=php
+                else
+                  npm run composer install
+                fi
 
             - name: Versions
               run: |
@@ -133,17 +142,26 @@ jobs:
             - name: Test
               run: |
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
-                npm run test
+                # For the coverage matrix cell, set XDEBUG_MODE=coverage explicitly via env var
+                # (Xdebug 3 feature) rather than relying on the ini configuration that wp-env
+                # applies to persistent containers — ephemeral wp-env run containers may not
+                # inherit it. Pass --coverage-clover in addition to what phpunit.xml.dist configures
+                # so the clover output is guaranteed regardless of XML config format differences
+                # between PHPUnit versions.
+                if [[ "${{ matrix.php }}" == "8.3" && "${{ matrix.wp }}" == "latest" ]]; then
+                  npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- \
+                    sh -c 'XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text --coverage-clover tests/logs/clover.xml'
+                else
+                  npm run test
+                fi
 
             - name: Retrieve coverage report from container
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               run: |
-                # PHPUnit writes clover.xml into the named Docker volume shared between the
-                # tests-wordpress and tests-cli containers. The plugin directory is NOT bind-mounted
-                # from the workspace in CI, so the file does not appear on the host filesystem after
-                # npm run test. We use docker cp (not 'docker exec cat > file') because docker cp is
-                # an atomic Docker API call that reads from the container's merged filesystem without
-                # a shell redirect that would pre-truncate the destination and cause a self-overwrite.
+                # PHPUnit writes clover.xml into the Docker volume shared between tests-cli and
+                # tests-wordpress. We use docker cp (not 'docker exec cat > file') because docker cp
+                # is an atomic Docker API call that avoids a shell redirect pre-truncating the
+                # destination — which would zero-out the file before cat can read it.
                 CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
                 if [ -z "$CONTAINER" ]; then
                   echo "Error: tests-wordpress container not found"
@@ -151,9 +169,9 @@ jobs:
                 fi
                 mkdir -p tests/logs
                 docker cp "$CONTAINER:/var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml" tests/logs/clover.xml
-                echo "=== xdebug mode reported by tests-wordpress ==="
+                echo "=== xdebug mode in tests-wordpress ==="
                 docker exec "$CONTAINER" php -r "echo ini_get('xdebug.mode') . PHP_EOL;"
-                echo "=== clover.xml size and summary ==="
+                echo "=== clover.xml size and first 10 lines ==="
                 wc -c tests/logs/clover.xml
                 head -10 tests/logs/clover.xml
                 if [ ! -s tests/logs/clover.xml ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,42 +132,25 @@ jobs:
 
             - name: Test
               run: |
-                # Create tests/logs inside the container (uid=1000) so PHPUnit can write coverage
-                # reports to the shared Docker volume. The host runner (uid=1001) cannot create a
-                # writable directory here due to the UID mismatch with the container user.
+                # Create tests/logs inside the container so PHPUnit can write coverage reports.
+                # The plugin directory is bind-mounted from the workspace, so PHPUnit writing to
+                # tests/logs/clover.xml inside the container also writes to the workspace path on
+                # the host runner. The directory must be created by the container user (uid=1000)
+                # to be writable; creating it on the runner (uid=1001) would cause a permissions
+                # mismatch and prevent PHPUnit from writing coverage output.
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
-            - name: Retrieve coverage report from container
+            - name: Verify coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               run: |
-                # PHPUnit writes clover.xml inside the tests-wordpress Docker volume. We use
-                # docker exec (not wp-env run) because wp-env run creates a new ephemeral container
-                # that does not share the named volume state where PHPUnit wrote its output.
-                # The tests-wordpress container shares the volume and is guaranteed to be running.
-                CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
-                if [ -z "$CONTAINER" ]; then
-                  echo "Error: tests-wordpress container not found"
-                  exit 1
-                fi
-                mkdir -p tests/logs
-                docker exec "$CONTAINER" \
-                  cat /var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml \
-                  > tests/logs/clover.xml
                 if [ ! -s tests/logs/clover.xml ]; then
-                  echo "Error: clover.xml is empty or was not retrieved"
+                  echo "Error: tests/logs/clover.xml is missing or empty. Coverage was not generated."
                   exit 1
                 fi
-                echo "Coverage report retrieved: $(wc -c < tests/logs/clover.xml) bytes"
-
-            - name: Debug coverage report
-              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
-              continue-on-error: true
-              run: |
-                echo "=== clover.xml first 30 lines ==="
-                head -30 tests/logs/clover.xml
-                echo "=== xdebug mode in tests-cli ==="
-                npm run env run tests-cli -- php -r "echo xdebug_info();" 2>&1 | grep -i "mode\|coverage" || echo "xdebug info unavailable"
+                echo "Coverage report found: $(wc -c < tests/logs/clover.xml) bytes"
+                echo "=== clover.xml project summary (first 10 lines) ==="
+                head -10 tests/logs/clover.xml
 
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' && hashFiles('tests/logs/clover.xml') != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,8 @@ jobs:
     test-php:
         name: Test PHP ${{ matrix.php }} ${{ matrix.wp != '' && format( ' (WP {0}) ', matrix.wp ) || '' }}
         runs-on: ubuntu-24.04
+        permissions:
+            id-token: write
         strategy:
             matrix:
                 php:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,17 @@ jobs:
                   cat /var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml \
                   > tests/logs/clover.xml
 
+            - name: Debug coverage report
+              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
+              continue-on-error: true
+              run: |
+                echo "=== clover.xml file size ==="
+                wc -c tests/logs/clover.xml || echo "File not found"
+                echo "=== clover.xml first 30 lines ==="
+                head -30 tests/logs/clover.xml || echo "Cannot read file"
+                echo "=== xdebug mode in tests-cli ==="
+                npm run env run tests-cli -- php -r "echo xdebug_info();" 2>&1 | grep -i "mode\|coverage" || echo "xdebug info unavailable"
+
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         name: Test PHP ${{ matrix.php }} ${{ matrix.wp != '' && format( ' (WP {0}) ', matrix.wp ) || '' }}
         runs-on: ubuntu-24.04
         permissions:
+            contents: read
             id-token: write
         strategy:
             matrix:
@@ -130,7 +131,9 @@ jobs:
                 npm run env run cli wp core version
 
             - name: Test
-              run: npm run test
+              run: |
+                mkdir -p tests/logs
+                npm run test
 
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,8 +149,11 @@ jobs:
                 # so the clover output is guaranteed regardless of XML config format differences
                 # between PHPUnit versions.
                 if [[ "${{ matrix.php }}" == "8.3" && "${{ matrix.wp }}" == "latest" ]]; then
-                  npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- \
-                    sh -c 'XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text --coverage-clover tests/logs/clover.xml'
+                  # Call wp-env directly (not via npm run) to avoid npm re-splitting the argument
+                  # list. env sets XDEBUG_MODE=coverage and execs composer, which resolves phpunit
+                  # from vendor/bin — the same path used by npm run test.
+                  ./node_modules/.bin/wp-env run tests-cli --env-cwd=wp-content/plugins/two-factor \
+                    -- env XDEBUG_MODE=coverage composer test
                 else
                   npm run test
                 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,13 +135,6 @@ jobs:
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
-            - name: Retrieve coverage report from container
-              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
-              continue-on-error: true
-              run: |
-                mkdir -p tests/logs
-                npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- cat tests/logs/clover.xml > tests/logs/clover.xml
-
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,25 +142,6 @@ jobs:
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
-            - name: Retrieve coverage report from container
-              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
-              run: |
-                # PHPUnit writes clover.xml into the Docker volume shared between tests-cli and
-                # tests-wordpress. Use docker cp (not 'docker exec cat > file'): docker cp is an
-                # atomic API call that avoids a shell redirect pre-truncating the destination file,
-                # which would zero it out before cat can read it (self-overwrite).
-                CONTAINER=$(docker ps --filter "name=tests-wordpress" --format "{{.Names}}" | head -1)
-                if [ -z "$CONTAINER" ]; then
-                  echo "Error: tests-wordpress container not found"
-                  exit 1
-                fi
-                mkdir -p tests/logs
-                docker cp "$CONTAINER:/var/www/html/wp-content/plugins/two-factor/tests/logs/clover.xml" tests/logs/clover.xml
-                if [ ! -s tests/logs/clover.xml ]; then
-                  echo "Error: clover.xml is empty — coverage was not generated"
-                  exit 1
-                fi
-
             - name: Upload code coverage report
               if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' && hashFiles('tests/logs/clover.xml') != '' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 20
         permissions:
-            contents: read # Required to clone the repo.
-            id-token: write
+          contents: read # Required to clone the repo.
         strategy:
             matrix:
                 php:
@@ -137,10 +136,11 @@ jobs:
             - name: Composer install
               run: |
                 rm composer.lock || true # We need to install fresh.
-                # The composer.json platform override (php: 7.2.24) installs PHPUnit 8.5, which does
-                # not support code coverage on PHP 8. Use --ignore-platform-req=php on PHP 8+ so
-                # Composer installs PHPUnit 9.6, which supports coverage on PHP 8.x.
-                if [[ "${WP_ENV_PHP_VERSION}" == 8.* ]]; then
+                # The composer.json platform override (php: 7.2.24) installs PHPUnit 8.5, which
+                # cannot generate code coverage on PHP 8. For the coverage build only, bypass the
+                # platform check so Composer installs PHPUnit 9.6. All other matrix jobs keep the
+                # default dependency set.
+                if [[ "${{ matrix.php }}" == "8.3" && "${{ matrix.wp }}" == "latest" ]]; then
                   npm run composer -- install --ignore-platform-req=php
                 else
                   npm run composer install
@@ -156,8 +156,39 @@ jobs:
                 npm run env run tests-cli --env-cwd=wp-content/plugins/two-factor -- mkdir -p tests/logs
                 npm run test
 
+            - name: Upload coverage report artifact
+              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' }}
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                name: coverage-report
+                path: tests/logs/clover.xml
+                if-no-files-found: error # Coverage silently going missing is the bug this is meant to fix.
+
+    # Uploading to Codecov without a CODECOV_TOKEN requires OIDC (`id-token: write`).
+    # That permission is kept out of the test jobs, which run npm/Composer dependencies
+    # and the test suite; this job only runs the pinned actions below. The Codecov badge
+    # reflects the default branch, so uploading on pushes is sufficient and no PR-triggered
+    # run ever holds the permission.
+    coverage:
+        name: Upload code coverage
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        needs: test-php
+        if: ${{ github.event_name == 'push' }}
+        permissions:
+          contents: read # Required to clone the repo, which Codecov uses to attribute the report.
+          id-token: write # Required for tokenless (OIDC) upload to Codecov.
+        steps:
+            - name: Checkout
+              uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+            - name: Download coverage report artifact
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                name: coverage-report
+                path: tests/logs
+
             - name: Upload code coverage report
-              if: ${{ matrix.php == '8.3' && matrix.wp == 'latest' && hashFiles('tests/logs/clover.xml') != '' }}
               uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
               with:
                 use_oidc: true


### PR DESCRIPTION
The codecov-action v5 requires `id-token: write` to authenticate via OIDC when no CODECOV_TOKEN is provided. Without it the upload silently fails (fail_ci_if_error: false) leaving the badge as "unknown".

The Codecov GitHub App is already installed on the WordPress org, so OIDC-based tokenless uploads work once this permission is granted.

## AI Usage

Used Claude Sonnet 4.6 AI for troubleshooting.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22codecov-integration%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->