### PR TITLE
Update props-bot-action to fix failures with bot accounts

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@992186595bc18334988a431c317237c48b7711a5 # v1.0.0
+        uses: WordPress/props-bot-action@635b2c5330167e194cd7b2c8a909991592a5022d # Post-v1.0.0: skips copilot and other bot accounts
         with:
           format: 'git'
 


### PR DESCRIPTION
Bumps the pinned commit from v1.0.0 (992186595) to the latest (635b2c53), which includes fixes for:
- Skipping copilot-pull-request-reviewer (#185)
- Skipping copilot-swe-agent (#189)
- Preventing failures on ghost accounts (#199)

As per suggestion on https://github.com/WordPress/props-bot-action/issues/232

## Changelog Entry

> Fixed - Failing CI due to bot reviewer.

