### PR TITLE
Move rate-limit check before provider pre-processing and invalidate tokens

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1688,18 +1688,18 @@ class Two_Factor_Core {
 			);
 		}
 
-		// Allow the provider to re-send codes, etc.
-		if ( true === $provider->pre_process_authentication( $user ) ) {
-			return false;
-		}
-
 		// If it's not a POST request, there's no processing to perform.
 		if ( ! $is_post_request ) {
 			return false;
 		}
 
-		// Rate limit two factor authentication attempts.
+		// Rate limit two factor authentication attempts, including pre-processing (e.g. resend).
 		if ( true === self::is_user_rate_limited( $user ) ) {
+			// Invalidate any provider token to prevent reuse after rate limiting.
+			if ( method_exists( $provider, 'delete_token' ) ) {
+				$provider->delete_token( $user->ID );
+			}
+
 			$time_delay = self::get_user_time_delay( $user );
 			$last_login = get_user_meta( $user->ID, self::USER_RATE_LIMIT_KEY, true );
 
@@ -1711,6 +1711,11 @@ class Two_Factor_Core {
 					human_time_diff( $last_login + $time_delay )
 				)
 			);
+		}
+
+		// Allow the provider to re-send codes, etc.
+		if ( true === $provider->pre_process_authentication( $user ) ) {
+			return false;
 		}
 
 		// Ask the provider to verify the second factor.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -654,7 +654,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$provider = Two_Factor_Email::get_instance();
 
 		$provider->generate_token( $user->ID );
-		$original_token = $provider->get_user_token( $user->ID );
 
 		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 1 );
 		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -695,6 +695,86 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that switching providers while rate-limited invalidates email token.
+	 *
+	 * If a user fails on TOTP triggering rate limiting, then switches back
+	 * to email, the rate-limit gate should invalidate the email token.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_invalidates_email_token_on_provider_switch_while_rate_limited() {
+		$user          = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$email_provider = Two_Factor_Email::get_instance();
+
+		// Generate an email token.
+		$email_provider->generate_token( $user->ID );
+		$this->assertTrue( $email_provider->user_has_token( $user->ID ), 'Email token exists before TOTP failures' );
+
+		// Simulate rate-limited state from TOTP failures.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 5 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// User switches back to email provider while rate-limited.
+		$result = Two_Factor_Core::process_provider( $email_provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $email_provider->user_has_token( $user->ID ), 'Email token is invalidated when rate-limited via another provider' );
+	}
+
+	/**
+	 * Test that GET requests pass through without rate-limit side effects.
+	 *
+	 * Page reloads should not trigger rate limiting, token deletion, or
+	 * error messages — even when the user is rate-limited.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_get_request_bypasses_rate_limit() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before GET request' );
+
+		// Simulate a rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// GET request (is_post_request = false).
+		$result = Two_Factor_Core::process_provider( $provider, $user, false );
+
+		$this->assertFalse( $result, 'GET request returns false, not WP_Error' );
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token survives GET request while rate-limited' );
+	}
+
+	/**
+	 * Test that rate limiting applies during the revalidation flow.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_rate_limits_revalidation() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before revalidation' );
+
+		// Simulate rate-limited state from prior failures.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// Revalidation is also a POST through process_provider.
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated during rate-limited revalidation' );
+	}
+
+	/**
 	 * Test that the "invalid login attempts have occurred" login notice works as expected.
 	 *
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -645,6 +645,56 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that email resend requests are blocked while rate limited.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_blocks_email_resend_while_rate_limited() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+		$original_token = $provider->get_user_token( $user->ID );
+
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 1 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		$_REQUEST[ Two_Factor_Email::INPUT_NAME_RESEND_CODE ] = 1;
+
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		unset( $_REQUEST[ Two_Factor_Email::INPUT_NAME_RESEND_CODE ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->get_user_token( $user->ID ), 'Token is invalidated when rate limited' );
+	}
+
+	/**
+	 * Test that rate limiting invalidates the email token on validation attempts.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_invalidates_email_token_when_rate_limited() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before rate limiting' );
+
+		// Simulate a rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated when rate limited' );
+	}
+
+	/**
 	 * Test that the "invalid login attempts have occurred" login notice works as expected.
 	 *
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()


### PR DESCRIPTION
## Summary

The rate-limit check now runs before any provider can resend or validate on POST requests, and it kills the existing token when it fires. One commit, two files (core + tests), no provider-specific changes.

- Reorders `process_provider()` so the rate-limit gate runs before `pre_process_authentication()`, blocking all providers from resending or rotating state while rate-limited. Previously, the email provider could bypass the rate limit via the "Resend Code" button because `pre_process_authentication()` ran first.
- Also invalidates provider tokens (e.g., email verification codes) when the rate limit fires, preventing a captured token from remaining valid for its full TTL after brute-force detection.
- GET requests (page loads) are excluded from rate-limiting, so the login form renders normally and can regenerate an expired or invalidated token when the rate limit expires.

Implements the core-level approach [suggested by @kasparsd in #848](https://github.com/WordPress/two-factor/pull/848#issuecomment-2755338046).

## Security Context

**Summary:** These changes invalidate the email token when the rate limit fires, so a captured code can't outlive the brute-force threshold. GET requests are excluded to avoid triggering repeated token emails on page reload. Pre-existing concurrency races (#510) are not worsened.

### Token persistence after rate limiting

Before this change, when the rate limiter fired, the existing email OTP remained valid in `_two_factor_email_token` for up to 15 minutes (the default `two_factor_email_token_ttl`). An attacker who had intercepted or guessed the token could wait out the rate-limit delay and replay it. Now, `delete_token()` is called on any provider that supports it as soon as the rate limit triggers.

### Provider switching during rate limiting

Rate-limit state is per-user, not per-provider (`_two_factor_last_login_failure`, `_two_factor_failed_login_attempts`). If a user fails repeatedly on TOTP and triggers the rate limit, then switches to the email provider, the rate-limit gate still fires and invalidates the email token. This is intentional — the account is under attack regardless of which provider the failures came from.

### GET requests excluded

The `$is_post_request` early return is kept above the rate-limit check. Without this, a page reload while rate-limited would delete the token, and then `authentication_page()` would immediately regenerate and email a new one, triggering repeated token emails on every reload. The resend button is a POST form submission, so it is still gated.

### Concurrent request races

The read-modify-write race on the failure counter ([acknowledged by @dd32 in #510](https://github.com/WordPress/two-factor/issues/510)) and the TOCTOU window in `validate_token()` are pre-existing and not worsened by this change. The `method_exists` guard ensures `delete_token()` is only called on providers that implement it (currently only the email provider).

## Specific changes

- **Reorder `process_provider()`**: `$is_post_request` check first, then `is_user_rate_limited()`, then `pre_process_authentication()` — gating all provider POST actions equally.
- **Invalidate tokens on rate limit**: When rate-limited, calls `delete_token()` on providers that support it.
- **Tests** (5 total):
  - Email resend blocked while rate-limited.
  - Email token invalidated on rate-limited validation attempt.
  - Email token invalidated on provider switch while rate-limited (rate-limit state is per-user, not per-provider — related to the concurrency discussion in [#510](https://github.com/WordPress/two-factor/issues/510)).
  - GET request while rate-limited passes through without side effects (prevents email flooding via page reload — same class of issue as the `generate_and_email_token` bypass in [#847](https://github.com/WordPress/two-factor/issues/847)).
  - Revalidation flow respects rate limiting and token invalidation equally (both `_login_form_validate_2fa` and `_login_form_revalidate_2fa` share the same rate-limit state, per the design in [#510](https://github.com/WordPress/two-factor/issues/510)).

## Test plan

- [ ] Verify rate-limited users cannot trigger email resend via POST
- [ ] Verify rate-limited users see `two_factor_too_fast` error on both resend and validation POST requests
- [ ] Verify email token is invalidated when rate limit fires
- [ ] Verify page reload (GET) while rate-limited renders the form normally without deleting the token
- [ ] Verify provider switch while rate-limited invalidates the email token
- [ ] Verify legitimate users can retry with the same token before hitting the rate limit
- [ ] Run `vendor/bin/phpunit tests/class-two-factor-core.php`

Closes #847
Supersedes #848

Assisted by Claude Code (Opus 4.6) 🧑‍💻🤝🤖