### PR TITLE
Improve Playground blueprint with modern PHP and cleaner syntax

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -2,19 +2,17 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"landingPage": "/wp-admin/profile.php#two-factor-options",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.2",
 		"wp": "latest"
 	},
+	"login": true,
 	"plugins": [
-		{
-			"resource": "wordpress.org/plugins",
-			"slug": "two-factor"
-		}
+		"two-factor"
 	],
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin"
+			"step": "activatePlugin",
+			"pluginPath": "two-factor/two-factor.php"
 		}
 	]
 }


### PR DESCRIPTION
Updated the WordPress Playground blueprint with cleaner syntax, explicit plugin activation, and a modern PHP version.

### Changes

| Change | Before | After |
|--------|--------|-------|
| PHP version | `7.4` | `8.2` |
| Plugin reference | Verbose resource object | Simple slug string |
| Login step | Inline in `steps` | Top-level `login: true` shorthand |
| Activation | Implicit/unclear | Explicit `activatePlugin` step |

### Rationale

**1. PHP version update (7.4 → 8.2)**

PHP 7.4 reached end-of-life on **November 28, 2022** and no longer receives security updates. Using an EOL PHP version in the Playground demo:
- Sets a bad example for users exploring the plugin
- May cause warnings or compatibility issues as WordPress core continues to modernize

The plugin supports PHP 7.2+ per `composer.json`, so PHP 8.2 is fully compatible.

Ref: https://www.php.net/supported-versions.php

**2. Simplified plugin syntax**

The `plugins` shorthand accepts strings directly for WordPress.org plugins. Per the JSON schema:

```json
"plugins": {
  "type": "array",
  "items": {
    "anyOf": [
      { "type": "string" },
      { "$ref": "#/definitions/FileReference" }
    ]
  }
}
```

The schema explicitly allows `{ "type": "string" }` as a valid item type alongside `FileReference`. This means:

```json
// Before (verbose)
"plugins": [{ "resource": "wordpress.org/plugins", "slug": "two-factor" }]

// After (concise - valid per schema)
"plugins": ["two-factor"]
```

Ref: https://playground.wordpress.net/blueprint-schema.json (`#/properties/plugins`)

**3. Top-level `login` shorthand**

The schema defines `login` as a top-level property accepting boolean or object:

```json
"login": {
  "anyOf": [
    { "type": "boolean" },
    { "type": "object", "properties": { "username": { "type": "string" } } }
  ]
}
```

Using `login: true` is cleaner than embedding a login step in the `steps` array, and is the recommended shorthand for simple admin authentication.

Ref: https://playground.wordpress.net/blueprint-schema.json (`#/properties/login`)

**4. Explicit plugin activation**

The `activatePlugin` step is defined in the schema as:

```json
{
  "step": { "type": "string", "const": "activatePlugin" },
  "pluginPath": { "type": "string" },
  "required": ["pluginPath", "step"]
}
```

While `plugins` shorthand installs the plugin, adding an explicit `activatePlugin` step ensures the Two-Factor plugin is active when the user lands on the profile page, making the demo immediately usable.

Ref: https://playground.wordpress.net/blueprint-schema.json (step definition: `activatePlugin`)

### Testing

Tested inline via:
```
https://playground.wordpress.net/#{"$schema":"https://playground.wordpress.net/blueprint-schema.json","landingPage":"/wp-admin/profile.php#two-factor-options","preferredVersions":{"php":"8.2","wp":"latest"},"login":true,"plugins":["two-factor"],"steps":[{"step":"activatePlugin","pluginPath":"two-factor/two-factor.php"}]}
```

Confirmed the Playground loads, plugin activates, and user lands on the profile page with Two-Factor options visible.

### Generated with

This PR was created with assistance from [Claude Code](https://claude.ai/code) using the `blueprint` skill for WordPress Playground blueprint review and best practices.

Skill reference: https://github.com/WordPress/agent-skills/blob/trunk/skills/wp-playground/SKILL.md