### PR TITLE
Add privacy policy content registration

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -425,7 +425,7 @@ class Two_Factor_Core {
 	/**
 	 * Attach Two-Factor profile errors to WordPress core profile update errors.
 	 *
-	 * @since NEXT
+	 * @since 0.16.0
 	 *
 	 * @param WP_Error $errors WP_Error object passed by core.
 	 *
@@ -2601,7 +2601,7 @@ class Two_Factor_Core {
 	/**
 	 * Adds suggested privacy policy text for the plugin.
 	 *
-	 * @since [version]
+	 * @since 0.17.0
 	 */
 	public static function add_privacy_policy_content() {
 		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -136,6 +136,7 @@ class Two_Factor_Core {
 
 		add_action( 'login_enqueue_scripts', array( __CLASS__, 'login_enqueue_scripts' ), 5 );
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
+		add_action( 'admin_init', array( __CLASS__, 'add_privacy_policy_content' ) );
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
 		// Add Settings link to plugin action links.
@@ -2595,6 +2596,53 @@ class Two_Factor_Core {
 		}
 
 		return $session;
+	}
+
+	/**
+	 * Adds suggested privacy policy text for the plugin.
+	 *
+	 * @since [version]
+	 */
+	public static function add_privacy_policy_content() {
+		if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+			return;
+		}
+
+		$content =
+			'<p class="privacy-policy-tutorial">'
+			. __( 'The Two Factor plugin stores authentication data for your account on this website to verify your identity at login. No data is transmitted to third parties. The suggested text below covers what is stored, why, and for how long.', 'two-factor' )
+			. '</p>'
+
+			. '<h3>' . __( 'Two-factor authentication data', 'two-factor' ) . '</h3>'
+			. '<p>'
+			. __( 'To protect your account we store the following personal data:', 'two-factor' )
+			. '</p>'
+			. '<ul>'
+			. '<li>' . __( '<strong>TOTP secret key</strong> – a unique cryptographic secret generated when you set up an authenticator app. It is stored encrypted in your user profile.', 'two-factor' ) . '</li>'
+			. '<li>' . __( '<strong>Backup codes</strong> – a set of one-time-use codes you can store offline. Hashed copies are kept in your user profile until they are used or regenerated.', 'two-factor' ) . '</li>'
+			. '<li>' . __( '<strong>Email address</strong> – your account email is used to send a one-time passcode when the email provider is active. The code itself is not stored after the login attempt concludes.', 'two-factor' ) . '</li>'
+			. '<li>' . __( '<strong>Enabled providers list</strong> – a record of which two-factor methods you have activated (e.g. TOTP, email, backup codes) is stored in your user profile.', 'two-factor' ) . '</li>'
+			. '</ul>'
+
+			. '<h3>' . __( 'Who we share your data with', 'two-factor' ) . '</h3>'
+			. '<p>'
+			. __( 'Two-factor authentication data is never shared with or transmitted to any third party. All data remains on this website.', 'two-factor' )
+			. '</p>'
+
+			. '<h3>' . __( 'How long we retain your data', 'two-factor' ) . '</h3>'
+			. '<p>'
+			. __( 'Authentication data (secret keys, backup codes, provider settings) is retained for as long as your user account exists. It is deleted automatically when your account is removed. You can also remove individual two-factor methods at any time from your profile page, which immediately deletes the associated data.', 'two-factor' )
+			. '</p>'
+
+			. '<h3>' . __( 'What rights you have over your data', 'two-factor' ) . '</h3>'
+			. '<p>'
+			. __( 'If you have an account on this site you can request an export of the personal data we hold about you, including all two-factor authentication data. You can also request that we erase any personal data we hold about you. This does not include data we are obliged to keep for administrative, legal, or security purposes.', 'two-factor' )
+			. '</p>';
+
+		wp_add_privacy_policy_content(
+			'Two Factor',
+			wp_kses_post( wpautop( $content, false ) )
+		);
 	}
 }
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2618,7 +2618,7 @@ class Two_Factor_Core {
 			. __( 'To protect your account we store the following personal data:', 'two-factor' )
 			. '</p>'
 			. '<ul>'
-			. '<li>' . __( '<strong>TOTP secret key</strong> – a unique cryptographic secret generated when you set up an authenticator app. It is stored encrypted in your user profile.', 'two-factor' ) . '</li>'
+			. '<li>' . __( '<strong>TOTP secret key</strong> – a unique cryptographic secret generated when you set up an authenticator app. It is stored in your user profile.', 'two-factor' ) . '</li>'
 			. '<li>' . __( '<strong>Backup codes</strong> – a set of one-time-use codes you can store offline. Hashed copies are kept in your user profile until they are used or regenerated.', 'two-factor' ) . '</li>'
 			. '<li>' . __( '<strong>Email address</strong> – your account email is used to send a one-time passcode when the email provider is active. The code itself is not stored after the login attempt concludes.', 'two-factor' ) . '</li>'
 			. '<li>' . __( '<strong>Enabled providers list</strong> – a record of which two-factor methods you have activated (e.g. TOTP, email, backup codes) is stored in your user profile.', 'two-factor' ) . '</li>'
@@ -2631,12 +2631,7 @@ class Two_Factor_Core {
 
 			. '<h3>' . __( 'How long we retain your data', 'two-factor' ) . '</h3>'
 			. '<p>'
-			. __( 'Authentication data (secret keys, backup codes, provider settings) is retained for as long as your user account exists. It is deleted automatically when your account is removed. You can also remove individual two-factor methods at any time from your profile page, which immediately deletes the associated data.', 'two-factor' )
-			. '</p>'
-
-			. '<h3>' . __( 'What rights you have over your data', 'two-factor' ) . '</h3>'
-			. '<p>'
-			. __( 'If you have an account on this site you can request an export of the personal data we hold about you, including all two-factor authentication data. You can also request that we erase any personal data we hold about you. This does not include data we are obliged to keep for administrative, legal, or security purposes.', 'two-factor' )
+			. __( 'Authentication data (secret keys, backup codes, provider settings) is retained for as long as your user account exists. It is deleted automatically when your account is removed.', 'two-factor' )
 			. '</p>';
 
 		wp_add_privacy_policy_content(
@@ -2645,4 +2640,3 @@ class Two_Factor_Core {
 		);
 	}
 }
-

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2620,7 +2620,7 @@ class Two_Factor_Core {
 			. '<ul>'
 			. '<li>' . __( '<strong>TOTP secret key</strong> – a unique cryptographic secret generated when you set up an authenticator app. It is stored in your user profile.', 'two-factor' ) . '</li>'
 			. '<li>' . __( '<strong>Backup codes</strong> – a set of one-time-use codes you can store offline. Hashed copies are kept in your user profile until they are used or regenerated.', 'two-factor' ) . '</li>'
-			. '<li>' . __( '<strong>Email address</strong> – your account email is used to send a one-time passcode when the email provider is active. The code itself is not stored after the login attempt concludes.', 'two-factor' ) . '</li>'
+			. '<li>' . __( '<strong>Email provider verification data</strong> – when the email provider is enabled, the plugin uses the email address already stored in your WordPress account to send a one-time login code. To validate the code, a hashed token and a timestamp are stored temporarily in your user profile metadata. The code itself is not stored.', 'two-factor' ) . '</li>'
 			. '<li>' . __( '<strong>Enabled providers list</strong> – a record of which two-factor methods you have activated (e.g. TOTP, email, backup codes) is stored in your user profile.', 'two-factor' ) . '</li>'
 			. '</ul>'
 


### PR DESCRIPTION
## What?

Fixes #868

Adds suggested privacy policy content for the Two Factor plugin via the WordPress Privacy Policy Guide (`wp_add_privacy_policy_content`).

## Why?

WordPress provides a built-in mechanism for plugins to contribute suggested text to a site's privacy policy page. The Two Factor plugin stores personal data (TOTP secret keys, backup codes, enabled provider settings) but has never registered suggested privacy policy text, leaving site administrators without guidance on what to disclose.

## How?

- Registers an `admin_init` action that calls a new static method `Two_Factor_Core::add_privacy_policy_content()`.
- The method calls `wp_add_privacy_policy_content()` with a suggested block of text covering:
  - What data is stored (TOTP secret key, backup codes, email address usage, enabled providers list)
  - Who data is shared with (no one)
  - How long data is retained (for the lifetime of the user account)
  - What rights users have over their data (export and erasure)

## Testing Instructions

1. Activate the Two Factor plugin on a WordPress site.
2. In the WordPress admin, go to **Settings → Privacy**.
3. Click **Check for guide suggestions** (or create/open a privacy policy page).
4. Confirm that a "Two Factor" section appears in the Privacy Policy Guide with the suggested text covering the four data categories above.
5. Confirm that the suggested text can be copied into the policy page.
6. Deactivate the plugin and confirm the section no longer appears in the guide.

## Screenshots or screencast
<img width="1741" height="1282" alt="image" src="https://github.com/user-attachments/assets/14ac9b04-2c90-4981-b939-6b0602cc3f5a" />

<!-- if applicable -->

## Changelog Entry

Added - Register suggested privacy policy content via `wp_add_privacy_policy_content` so site administrators are guided on disclosing Two Factor authentication data.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22868-privacy-policy-content%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->