### PR TITLE
docs: Add FAQ entries for Multisite, locked-out users, and role enforcement

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -133,12 +133,24 @@ If you have backup codes enabled, you can use one of those to regain access. If 
 
 = Can I use this plugin with WebAuthn? =
 
-The plugin previously supported FIDO U2F, which was a predecessor to WebAuthn. There is an open issue to add WebAuthn support here: https://github.com/WordPress/two-factor/pull/427
+The plugin previously supported FIDO U2F, which was a predecessor to WebAuthn. There is an open issue to [add WebAuthn support here](https://github.com/WordPress/two-factor/pull/427).
 
 = Is there a recommended way to use passkeys or hardware security keys with Two-Factor? =
 
-Yes. For passkeys and hardware security keys, you can install the Two-Factor Provider: WebAuthn plugin: https://wordpress.org/plugins/two-factor-provider-webauthn/
-. It integrates directly with Two-Factor and adds WebAuthn-based authentication as an additional two-factor option for users.
+Yes. For passkeys and hardware security keys, you can install the [Two-Factor Provider: WebAuthn plugin](https://wordpress.org/plugins/two-factor-provider-webauthn/). It integrates directly with Two-Factor and adds WebAuthn-based authentication as an additional two-factor option for users.
+
+= Does this plugin work on WordPress Multisite? =
+ 
+Yes. The Two-Factor plugin is compatible with WordPress Multisite. Each user configures their own 2FA settings via their profile, and because authentication codes are stored in WordPress user meta, the configuration is tied to the user account and valid across all sites in the network. However, there are no network-wide settings — a super admin cannot enforce or configure 2FA globally from the Network Admin dashboard. To manage 2FA for a specific user, edit their profile on any site where they have an account.
+ 
+= How do I disable 2FA for a user who is locked out? =
+ 
+As an administrator, go to **Users → All Users** in the WordPress admin, click **Edit** on the affected user's profile, scroll down to the **Two-Factor Options** section, and uncheck all enabled methods, then click **Update User**. This will remove 2FA for that user, allowing them to log in with their password alone. You can also do this via WP-CLI with `wp user meta delete <user_id> _two_factor_enabled_providers`. Once they're back in, encourage them to re-enable 2FA and generate fresh backup codes.
+ 
+= Can I require 2FA for all users or specific roles? =
+ 
+Not through the plugin's interface — there are no built-in enforcement settings. However, developers can use the `two_factor_providers_for_user` filter to control which providers are available per user or role, and combine it with custom logic to redirect users who haven't set up 2FA. Native enforcement support is a known and tracked feature request — follow the discussion at [GitHub issue #255](https://github.com/WordPress/two-factor/issues/255).
+
 
 == Screenshots ==
 


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Adds three missing FAQ entries to `readme.txt`.


## Why?
Checked a few support requests lately that we've had. The FAQ section lacked answers to several commonly asked questions. Users and site administrators frequently ask about Multisite compatibility, how to recover a locked-out user's account, and whether 2FA can be enforced across all users or roles. Without these entries, users are left to search the support forums or GitHub issues for answers that could be surfaced directly in the plugin docs.


## How?
Three new FAQ entries were added to the `== Frequently Asked Questions ==` section of `readme.txt`:

- **Does this plugin work on WordPress Multisite?** — Confirms compatibility and clarifies that 2FA settings are stored in user meta (making them valid across all network sites), while noting there are no network-wide enforcement settings.
- **How do I disable 2FA for a user who is locked out?** — Walks administrators through disabling 2FA via the user profile editor or WP-CLI.
- **Can I require 2FA for all users or specific roles?** — Explains there are no built-in enforcement settings, points developers to the `two_factor_providers_for_user` filter, and references issue #255 for the native enforcement feature request.

## Use of AI Tools
AI assistance: Yes  
Tool(s): Claude (Anthropic)  
Model(s): Claude Sonnet 4.6  
Used for: Drafting the FAQ content based on existing plugin documentation and known feature gaps; final wording reviewed and approved by me.

## Changelog Entry
> Added - Three new FAQ entries covering Multisite compatibility, admin-side 2FA removal for locked-out users, and role-based enforcement.
