### PR TITLE
replace wp-login.php to wp_login_url

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1252,8 +1252,6 @@ class Two_Factor_Core {
 			$params = array();
 		}
 
-		$params = urlencode_deep( $params );
-
 		// Use WordPress's own wp_login_url() so that plugins like WPML which
 		// hook the `login_url` filter can translate or rewrite the URL correctly.
 		// wp_login_url() applies the `login_url` filter, giving multilingual

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -984,7 +984,9 @@ class Two_Factor_Core {
 			wp_die( esc_html__( 'Failed to create a login nonce.', 'two-factor' ) );
 		}
 
-		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : admin_url();
+		$redirect_to = isset( $_REQUEST['redirect_to'] )
+			? wp_unslash( $_REQUEST['redirect_to'] )
+			: apply_filters( 'login_redirect', admin_url(), '', null );
 
 		self::login_html( $user, $login_nonce['key'], $redirect_to );
 	}
@@ -1252,11 +1254,21 @@ class Two_Factor_Core {
 
 		$params = urlencode_deep( $params );
 
-		// Compat: Match WordPress's usage of `site_url( wp-login.php )` by always passing the action if known.
-		if ( isset( $params['action'] ) ) {
-			$url = site_url( 'wp-login.php?action=' . $params['action'], $scheme );
-		} else {
-			$url = site_url( 'wp-login.php', $scheme );
+		// Use WordPress's own wp_login_url() so that plugins like WPML which
+		// hook the `login_url` filter can translate or rewrite the URL correctly.
+		// wp_login_url() calls site_url( 'wp-login.php', $scheme ) internally and
+		// applies the `login_url` filter — giving multilingual plugins a chance to
+		// redirect to a translated login page.
+		$action = isset( $params['action'] ) ? $params['action'] : '';
+		$url    = wp_login_url( '', false );
+
+		// Re-apply the scheme since wp_login_url() doesn't expose it as a parameter.
+		$url = set_url_scheme( $url, $scheme );
+
+		// Compat: WordPress core passes action directly in the path for certain actions
+		// (e.g. wp-login.php?action=validate_2fa). Preserve that behaviour.
+		if ( $action ) {
+			$url = add_query_arg( 'action', $action, $url );
 		}
 
 		if ( $params ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1263,8 +1263,8 @@ class Two_Factor_Core {
 		// Re-apply the scheme since wp_login_url() doesn't expose it as a parameter.
 		$url = set_url_scheme( $url, $scheme );
 
-		// Compat: WordPress core passes action directly in the path for certain actions
-		// (e.g. wp-login.php?action=validate_2fa). Preserve that behaviour.
+		// Compat: WordPress core passes action as a query argument on the login URL
+		// for certain actions (e.g. wp-login.php?action=validate_2fa). Preserve that behaviour.
 		if ( $action ) {
 			$url = add_query_arg( 'action', $action, $url );
 		}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -986,7 +986,7 @@ class Two_Factor_Core {
 
 		$redirect_to = isset( $_REQUEST['redirect_to'] )
 			? wp_unslash( $_REQUEST['redirect_to'] )
-			: apply_filters( 'login_redirect', admin_url(), '', null );
+			: apply_filters( 'login_redirect', admin_url(), '', $user );
 
 		self::login_html( $user, $login_nonce['key'], $redirect_to );
 	}
@@ -1256,9 +1256,9 @@ class Two_Factor_Core {
 
 		// Use WordPress's own wp_login_url() so that plugins like WPML which
 		// hook the `login_url` filter can translate or rewrite the URL correctly.
-		// wp_login_url() calls site_url( 'wp-login.php', $scheme ) internally and
-		// applies the `login_url` filter — giving multilingual plugins a chance to
-		// redirect to a translated login page.
+		// wp_login_url() applies the `login_url` filter, giving multilingual
+		// plugins a chance to redirect to a translated login page. Any requested
+		// scheme is applied below with set_url_scheme().
 		$action = isset( $params['action'] ) ? $params['action'] : '';
 		$url    = wp_login_url( '', false );
 


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
Fixes #885

Rewrites `login_url()` to delegate to WordPress's native `wp_login_url()` instead of constructing URLs directly from `site_url( 'wp-login.php' )`. Also updates the `redirect_to` fallback in `show_two_factor_login()` to go through the `login_redirect` filter instead of a hardcoded `admin_url()`.

## Why?
On WPML multi-domain setups (e.g. `site.com`, `en.site.com`, `fr.site.com`), users on 0.15.0+ experience either "ERROR: Invalid verification code" on correct TOTP codes, or a session loop where every click after login logs them out again. Downgrading to 0.14.2 resolves both symptoms.

The root cause is that `login_url()` calls `site_url( 'wp-login.php' )` directly. WPML (and Polylang, TranslatePress) hook WordPress's `login_url` filter to rewrite login URLs per language/domain — but that filter only fires inside `wp_login_url()`, which this plugin never calls. As a result, the 2FA form action and all redirect URLs point to the wrong domain, breaking nonce validation and session continuity.

Reference: https://wordpress.org/support/topic/two-factor-0-14-2-works-0-15-0-doesnt/


## How?
```php
// login_url() — before
$url = site_url( 'wp-login.php?action=' . $params['action'], $scheme );

// login_url() — after
$url = set_url_scheme( wp_login_url( '', false ), $scheme );
if ( $action ) { $url = add_query_arg( 'action', $action, $url ); }

// show_two_factor_login() — before
$redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : admin_url();

// show_two_factor_login() — after
$redirect_to = isset( $_REQUEST['redirect_to'] )
    ? wp_unslash( $_REQUEST['redirect_to'] )
    : apply_filters( 'login_redirect', admin_url(), '', null );
```
No behaviour change on standard installs. WPML, Polylang, TranslatePress, and multisite mapped domains all benefit automatically.


## Use of AI Tools
AI assistance: Yes  
Tool(s): Claude (Anthropic)  
Model(s): Claude Sonnet 4.6  
Used for: Identifying root cause, drafting the code change. Final implementation reviewed and tested by me.


## Testing Instructions
**Standard single-site (regression check)**
1. Enable TOTP for a test user on a plain single-site install
2. Log out and log back in
3. Confirm 2FA challenge appears and TOTP code is accepted as before

**WPML multi-domain**
1. Install WPML, configure two languages on separate subdomains (e.g. `en.site.com`, 
   `fr.site.com`)
2. Enable TOTP for a test user
3. Log in from `en.site.com` — confirm the 2FA form action URL stays on `en.site.com`
4. Enter correct TOTP code — confirm successful login with no immediate logout
5. Repeat from `fr.site.com`

**Backup provider links**
1. Enable both TOTP and Email as providers for a test user
2. On the 2FA challenge screen confirm the "Try another method" links use the correct 
   domain/language URL

**Revalidation**
1. After login, trigger a revalidation prompt (`revalidate_2fa`)
2. Confirm the revalidation URL is on the correct domain

## Screenshots or screencast
No UI changes — not applicable.

## Changelog Entry

Fixed - `login_url()` now delegates to `wp_login_url()` so the WordPress `login_url` filter is respected, fixing session loops and invalid verification code errors on WPML and other multi-domain setups.