### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,17 @@ on:
       # For readme and asset updates.
       - master
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   deploy:
     name: Deploy to WordPress.org
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # Required to upload assets to the GitHub release.
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
   deploy:
     name: Deploy to WordPress.org
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: write # Required to upload assets to the GitHub release.
     steps:

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -50,9 +50,8 @@ jobs:
     name: Generate a list of props
     runs-on: ubuntu-24.04
     permissions:
-      # The action needs permission `write` permission for PRs in order to add a comment.
-      pull-requests: write
-      contents: read
+      pull-requests: write # Required to post the props comment on the pull request.
+      issues: write        # Required to remove the props-bot label.
     timeout-minutes: 20
     # The job will run when pull requests are open, ready for review and:
     #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,16 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
     cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
     lint-js-css:
         name: Lint JS & CSS
         runs-on: ubuntu-24.04
+        permissions:
+          contents: read # Required to clone the repo.
         steps:
             - name: Checkout
               uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -35,6 +41,8 @@ jobs:
     lint-php-and-compatibility:
         name: Lint PHP & PHP Compatibility checks.
         runs-on: ubuntu-24.04
+        permissions:
+          contents: read # Required to clone the repo.
         steps:
             - name: Checkout
               uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -65,6 +73,8 @@ jobs:
     test-php:
         name: Test PHP ${{ matrix.php }} ${{ matrix.wp != '' && format( ' (WP {0}) ', matrix.wp ) || '' }}
         runs-on: ubuntu-24.04
+        permissions:
+          contents: read # Required to clone the repo.
         strategy:
             matrix:
                 php:
@@ -144,6 +154,8 @@ jobs:
     build:
         name: Build
         runs-on: ubuntu-24.04
+        permissions:
+          contents: read # Required to clone the repo.
         steps:
             - name: Checkout
               uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     lint-js-css:
         name: Lint JS & CSS
         runs-on: ubuntu-24.04
+        timeout-minutes: 20
         permissions:
           contents: read # Required to clone the repo.
         steps:
@@ -41,6 +42,7 @@ jobs:
     lint-php-and-compatibility:
         name: Lint PHP & PHP Compatibility checks.
         runs-on: ubuntu-24.04
+        timeout-minutes: 20
         permissions:
           contents: read # Required to clone the repo.
         steps:
@@ -73,6 +75,7 @@ jobs:
     test-php:
         name: Test PHP ${{ matrix.php }} ${{ matrix.wp != '' && format( ' (WP {0}) ', matrix.wp ) || '' }}
         runs-on: ubuntu-24.04
+        timeout-minutes: 20
         permissions:
           contents: read # Required to clone the repo.
         strategy:
@@ -154,6 +157,7 @@ jobs:
     build:
         name: Build
         runs-on: ubuntu-24.04
+        timeout-minutes: 20
         permissions:
           contents: read # Required to clone the repo.
         steps:


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/two-factor/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Claude Code was used to create the initial changes. All permissions and timeouts changes were reviewed and adjusted by me where necessary.
