### PR TITLE
Update email provider token-message hooks

### DIFF
--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -312,22 +312,46 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		 * Filters the token email subject.
 		 *
 		 * @since 0.5.2
+		 * @deprecated 0.17.0 Use {@see 'two_factor_email_token_subject'} instead.
 		 *
 		 * @param string $subject The email subject line.
 		 * @param int    $user_id The ID of the user.
 		 */
-		$subject = apply_filters( 'two_factor_token_email_subject', $subject, $user->ID );
+		$subject = apply_filters_deprecated( 'two_factor_token_email_subject', array( $subject, $user->ID ), '0.11.0', 'two_factor_email_token_subject' );
+
+		/**
+		 * Filters the token email subject.
+		 *
+		 * @since 0.17.0
+		 *
+		 * @param string $subject The email subject line.
+		 * @param string $token   The token.
+		 * @param int    $user_id The ID of the user.
+		 */
+		$subject = apply_filters( 'two_factor_email_token_subject', $subject, $token, $user->ID );
 
 		/**
 		 * Filters the token email message.
 		 *
 		 * @since 0.5.2
+		 * @deprecated 0.17.0 Use {@see 'two_factor_email_token_message'} instead.
 		 *
 		 * @param string $message The email message.
 		 * @param string $token   The token.
 		 * @param int    $user_id The ID of the user.
 		 */
-		$message = apply_filters( 'two_factor_token_email_message', $message, $token, $user->ID );
+		$message = apply_filters_deprecated( 'two_factor_token_email_message', array( $message, $token, $user->ID ), '0.11.0', 'two_factor_email_token_message' );
+
+		/**
+		 * Filters the token email message.
+		 *
+		 * @since 0.17.0
+		 *
+		 * @param string $message The email message.
+		 * @param string $token   The token.
+		 * @param int    $user_id The ID of the user.
+		 */
+		$message = apply_filters( 'two_factor_email_token_message', $message, $token, $user->ID );
 
 		return wp_mail( $user->user_email, $subject, $message ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
 	}

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -317,7 +317,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		 * @param string $subject The email subject line.
 		 * @param int    $user_id The ID of the user.
 		 */
-		$subject = apply_filters_deprecated( 'two_factor_token_email_subject', array( $subject, $user->ID ), '0.11.0', 'two_factor_email_token_subject' );
+		$subject = apply_filters_deprecated( 'two_factor_token_email_subject', array( $subject, $user->ID ), '0.17.0', 'two_factor_email_token_subject' );
 
 		/**
 		 * Filters the token email subject.

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,8 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_user_api_login_enable` filter restricts authentication for REST API and XML-RPC to application passwords only. Provides the user ID as the second argument.
 - `two_factor_email_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 - `two_factor_email_token_length` filter overrides the default 8 character count for email tokens.
+- `two_factor_email_token_subject` filter overrides the subject of messages sent by the email provider. Accepts the login token as the second argument.
+- `two_factor_email_token_message` filter overrides the body of messages sent by the email provider. Accepts the message text as the first argument, the login token as the second argument, and the user ID as the third argument.
 - `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Provides the `WP_User` of the associated user as the second argument.
 - `two_factor_rest_api_can_edit_user` filter overrides whether a user’s Two-Factor settings can be edited via the REST API. First argument is the current `$can_edit` boolean, the second argument is the user ID.
 - `two_factor_before_authentication_prompt` action which receives the provider object and fires prior to the prompt shown on the authentication input form.
@@ -140,15 +142,15 @@ The plugin previously supported FIDO U2F, which was a predecessor to WebAuthn. T
 Yes. For passkeys and hardware security keys, you can install the [Two-Factor Provider: WebAuthn plugin](https://wordpress.org/plugins/two-factor-provider-webauthn/). It integrates directly with Two-Factor and adds WebAuthn-based authentication as an additional two-factor option for users.
 
 = Does this plugin work on WordPress Multisite? =
- 
+
 Yes. The Two-Factor plugin is compatible with WordPress Multisite. Each user configures their own 2FA settings via their profile, and because authentication codes are stored in WordPress user meta, the configuration is tied to the user account and valid across all sites in the network. However, there are no network-wide settings — a super admin cannot enforce or configure 2FA globally from the Network Admin dashboard. To manage 2FA for a specific user, edit their profile on any site where they have an account.
- 
+
 = How do I disable 2FA for a user who is locked out? =
- 
+
 As an administrator, go to **Users → All Users** in the WordPress admin, click **Edit** on the affected user's profile, scroll down to the **Two-Factor Options** section, and uncheck all enabled methods, then click **Update User**. This will remove 2FA for that user, allowing them to log in with their password alone. You can also do this via WP-CLI with `wp user meta delete <user_id> _two_factor_enabled_providers`. Once they're back in, encourage them to re-enable 2FA and generate fresh backup codes.
- 
+
 = Can I require 2FA for all users or specific roles? =
- 
+
 Not through the plugin's interface — there are no built-in enforcement settings. However, developers can use the `two_factor_providers_for_user` filter to control which providers are available per user or role, and combine it with custom logic to redirect users who haven't set up 2FA. Native enforcement support is a known and tracked feature request — follow the discussion at [GitHub issue #255](https://github.com/WordPress/two-factor/issues/255).
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -96,7 +96,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_user_api_login_enable` filter restricts authentication for REST API and XML-RPC to application passwords only. Provides the user ID as the second argument.
 - `two_factor_email_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.
 - `two_factor_email_token_length` filter overrides the default 8 character count for email tokens.
-- `two_factor_email_token_subject` filter overrides the subject of messages sent by the email provider. Accepts the login token as the second argument.
+- `two_factor_email_token_subject` filter overrides the subject of messages sent by the email provider. Accepts the subject text as the first argument, the login token as the second argument, and the user ID as the third argument.
 - `two_factor_email_token_message` filter overrides the body of messages sent by the email provider. Accepts the message text as the first argument, the login token as the second argument, and the user ID as the third argument.
 - `two_factor_backup_code_length` filter overrides the default 8 character count for backup codes. Provides the `WP_User` of the associated user as the second argument.
 - `two_factor_rest_api_can_edit_user` filter overrides whether a user’s Two-Factor settings can be edited via the REST API. First argument is the current `$can_edit` boolean, the second argument is the user ID.

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -434,6 +434,99 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the token email subject can be filtered.
+	 *
+	 * @expectedDeprecated two_factor_token_email_subject
+	 */
+	public function test_email_token_subject_filter() {
+		$user = self::factory()->user->create_and_get();
+		$this->provider->generate_and_email_token( $user );
+		$default_email = end( self::$mockmailer->mock_sent );
+
+		// Test deprecated filter
+		add_filter(
+			'two_factor_token_email_subject',
+			function () {
+				return 'New Subject';
+			}
+		);
+
+		$this->provider->generate_and_email_token( $user );
+		$custom_email_deprecated = end( self::$mockmailer->mock_sent );
+
+		$this->assertNotEquals( $default_email['subject'], $custom_email_deprecated['subject'], 'Email subject modified by filter' );
+		$this->assertEquals( 'New Subject', $custom_email_deprecated['subject'], 'Email subject matches the filter value' );
+
+		remove_all_filters( 'two_factor_token_email_subject' );
+
+		// Test new filter
+		add_filter(
+			'two_factor_email_token_subject',
+			function ( $subject, $token ) {
+				return "Your token is: {$token}!";
+			},
+			10,
+			2
+		);
+
+		$this->provider->generate_and_email_token( $user );
+		$custom_email = end( self::$mockmailer->mock_sent );
+
+		$this->assertNotEquals( $default_email['subject'], $custom_email['subject'], 'Email subject modified by filter' );
+		$this->assertMatchesRegularExpression( '/Your token is: [0-9]+!/', $custom_email['subject'], 'Email subject matches the filter value' );
+
+		remove_all_filters( 'two_factor_email_token_subject' );
+	}
+
+	/**
+	 * Test that the token email message can be filtered.
+	 *
+	 * @expectedDeprecated two_factor_token_email_message
+	 */
+	public function test_email_token_message_filter() {
+		$user = self::factory()->user->create_and_get();
+		$this->provider->generate_and_email_token( $user );
+		$default_email = end( self::$mockmailer->mock_sent );
+
+		// deprecated filter was renamed, use the same callback to test both filters
+		$callback = function ( $message, $token ) {
+			return "<span>$token</span>";
+		};
+
+		// Test deprecated filter
+		add_filter(
+			'two_factor_token_email_message',
+			$callback,
+			10,
+			2
+		);
+
+		$this->provider->generate_and_email_token( $user );
+		$custom_email_deprecated = end( self::$mockmailer->mock_sent );
+
+		$this->assertNotEquals( $default_email['body'], $custom_email_deprecated['body'], 'Email message modified by filter' );
+		$this->assertMatchesRegularExpression( '/<span>[0-9]+<\/span>/', $custom_email_deprecated['body'], 'Email messages contains the wrapped token' );
+
+		remove_all_filters( 'two_factor_token_email_message' );
+
+		// Test new filter
+		add_filter(
+			'two_factor_email_token_message',
+			$callback,
+			10,
+			2
+		);
+
+		$this->provider->generate_and_email_token( $user );
+		$custom_email = end( self::$mockmailer->mock_sent );
+
+		$this->assertNotEquals( $default_email['body'], $custom_email['body'], 'Email message modified by filter' );
+		$this->assertMatchesRegularExpression( '/<span>[0-9]+<\/span>/', $custom_email['body'], 'Email messages contains the wrapped token' );
+
+		remove_all_filters( 'two_factor_email_token_message' );
+	}
+
+	/**
 	 * Verify the alternative provider label contains expected text.
 	 *
 	 * @covers Two_Factor_Email::get_alternative_provider_label

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -437,6 +437,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 	/**
 	 * Test that the token email subject can be filtered.
+	 * Tests cover current and deprecated filters.
 	 *
 	 * @expectedDeprecated two_factor_token_email_subject
 	 */
@@ -445,7 +446,6 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		$this->provider->generate_and_email_token( $user );
 		$default_email = end( self::$mockmailer->mock_sent );
 
-		// Test deprecated filter
 		add_filter(
 			'two_factor_token_email_subject',
 			function () {
@@ -461,7 +461,6 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		remove_all_filters( 'two_factor_token_email_subject' );
 
-		// Test new filter
 		add_filter(
 			'two_factor_email_token_subject',
 			function ( $subject, $token ) {
@@ -482,6 +481,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 	/**
 	 * Test that the token email message can be filtered.
+	 * Tests cover current and deprecated filters.
 	 *
 	 * @expectedDeprecated two_factor_token_email_message
 	 */
@@ -490,12 +490,11 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 		$this->provider->generate_and_email_token( $user );
 		$default_email = end( self::$mockmailer->mock_sent );
 
-		// deprecated filter was renamed, use the same callback to test both filters
+		// Deprecated filter was renamed, use the same callback to test both filters.
 		$callback = function ( $message, $token ) {
 			return "<span>$token</span>";
 		};
 
-		// Test deprecated filter
 		add_filter(
 			'two_factor_token_email_message',
 			$callback,
@@ -511,7 +510,6 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		remove_all_filters( 'two_factor_token_email_message' );
 
-		// Test new filter
 		add_filter(
 			'two_factor_email_token_message',
 			$callback,

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -448,7 +448,7 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 
 		add_filter(
 			'two_factor_token_email_subject',
-			function () {
+			function ( $subject ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required to match filter signature.
 				return 'New Subject';
 			}
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to the Two-Factor plugin for WordPress! Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions. -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The primary purpose of this PR is to provide the `$token` to the email provider's subject filter. It also brings consistency to the shape of Two Factor's email provider token-message hook arguments, and standardizes the namespaces used by those filters. Includes tests and documentation. 

Fixes: #898 

<!-- Please reference the issue this PR fixes -->

## Why?
<!-- Why is this PR necessary?  What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too. -->

Many services now include the login token in their email subject lines like "Your login code is 123456". This improves user-experience and speeds MFA logins. 

Previously, the  email _subject_ filter did not have access to`$token` and its arguments did not match the shape of the _message_ filter arguments. Developers wanting to include the token in email subjects had to use clumsy, fragile workarounds. 

This PR adds (renames) two hooks:

- `two_factor_email_token_subject`
- `two_factor_email_token_message`

This PR deprecates two existing hooks:

- `two_factor_token_email_subject`
- `two_factor_token_email_message`

New hook names provide a clean pathway for changing the signature of `two_factor_token_email_subject` without breaking existing functionality. The new filter adds a `$token` argument to match the shape of `two_factor_token_email_message`. This makes it very easy for developers to include `$token` in email subject lines.


## How?
<!-- How is your PR addressing the issue at hand?  What are the implementation details? -->

- The arguments to both the `two_factor_email_token_subject` and `two_factor_email_token_message` filters are now symmetrical: `$subject|$message, $token, $user_id`. 
- Old hooks have been deprecated for backwards compatibility. 
- The new filters have been added to **readme.txt**. They were not previously documented. 
- Added tests to cover both the new and deprecated filters. 

## Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:
-->

AI assistance: Yes
Tool(s): Opencode, browsers
Model(s): grok 4.3, gemini-3.1-pro-preview
Used for: Architectural suggestions, consistency and style-matching with existing code, and code review/QA. 

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Tests covering the changes were added. 
Add this line to a theme with Two Factor installed to add the token to the email subject. 
```php
add_filter( 'two_factor_email_token_subject', function( $subject, $token ) {
    return "{$token} is your login code";
}, 10, 2 );
 ```

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Change - Added `$token` to the token-email subject filter. 
> Deprecated - `two_factor_token_email_subject` and `two_factor_token_email_message`. Replaced with consistently named `two_factor_email_token_*` filters.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22email_filters%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->