### PR TITLE
fix(uninstall): remove two_factor_enabled_providers option on uninstall

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -29,6 +29,15 @@ class Two_Factor_Core {
 	const ENABLED_PROVIDERS_USER_META_KEY = '_two_factor_enabled_providers';
 
 	/**
+	 * The site-wide enabled providers option key.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @type string
+	 */
+	const ENABLED_PROVIDERS_OPTION_KEY = 'two_factor_enabled_providers';
+
+	/**
 	 * The user meta nonce key.
 	 *
 	 * @type string
@@ -189,7 +198,10 @@ class Two_Factor_Core {
 			self::USER_PASSWORD_WAS_RESET_KEY,
 		);
 
-		$option_keys = array();
+		// Keep this updated as plugin-level options are added or removed.
+		$option_keys = array(
+			self::ENABLED_PROVIDERS_OPTION_KEY,
+		);
 
 		$providers = self::get_default_providers();
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -31,7 +31,7 @@ class Two_Factor_Core {
 	/**
 	 * The site-wide enabled providers option key.
 	 *
-	 * @since 0.16.1
+	 * @since 0.17.0
 	 *
 	 * @type string
 	 */

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -39,7 +39,7 @@ class Two_Factor_Settings {
 			// Remove empty values.
 			$enabled = array_values( array_filter( $posted, 'strlen' ) );
 
-			update_option( 'two_factor_enabled_providers', array_values( array_unique( $enabled ) ) );
+			update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array_values( array_unique( $enabled ) ) );
 
 			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
 		}
@@ -55,7 +55,7 @@ class Two_Factor_Settings {
 
 		// Default to all providers enabled when the option has never been saved.
 		$all_provider_keys = array_keys( $provider_instances );
-		$saved_enabled     = get_option( 'two_factor_enabled_providers', $all_provider_keys );
+		$saved_enabled     = get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, $all_provider_keys );
 
 		echo '<div class="wrap two-factor-settings">';
 		echo '<h1>' . esc_html__( 'Two-Factor Settings', 'two-factor' ) . '</h1>';

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1891,6 +1891,28 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Plugin uninstall removes the site-wide enabled providers option.
+	 *
+	 * @covers Two_Factor_Core::uninstall
+	 */
+	public function test_uninstall_removes_enabled_providers_option() {
+		update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array( 'Two_Factor_Email' ) );
+
+		$this->assertSame(
+			array( 'Two_Factor_Email' ),
+			get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY ),
+			'Enabled providers option was set'
+		);
+
+		Two_Factor_Core::uninstall();
+
+		$this->assertFalse(
+			get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY ),
+			'Enabled providers option was deleted during uninstall'
+		);
+	}
+
+	/**
 	 * Test delete_login_nonce removes the nonce.
 	 *
 	 * @covers Two_Factor_Core::delete_login_nonce

--- a/two-factor.php
+++ b/two-factor.php
@@ -129,7 +129,7 @@ function two_factor_render_settings_page() {
  * @return array|null
  */
 function two_factor_get_enabled_providers_option() {
-	$enabled = get_option( 'two_factor_enabled_providers', null );
+	$enabled = get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, null );
 	if ( null === $enabled ) {
 		return null; // Never saved — allow everything.
 	}


### PR DESCRIPTION
## Summary

The `two_factor_enabled_providers` option (added in 0.16) was not being removed when the plugin is uninstalled, leaving an orphaned row in `wp_options`. This fix adds the option to the uninstall list and centralises the key in a class constant.

Fixes #902

## Changes

### `class-two-factor-core.php`

**Before:**
```php
$option_keys = array();
```

**After:**
```php
const ENABLED_PROVIDERS_OPTION_KEY = 'two_factor_enabled_providers';

// ...

// Keep this updated as plugin-level options are added or removed.
$option_keys = array(
    self::ENABLED_PROVIDERS_OPTION_KEY,
);
```

**Why:** Mirrors the existing pattern of constants-on-the-class for every other plugin meta/option key and adds the missing option to the uninstall list.

### `two-factor.php` and `settings/class-two-factor-settings.php`

Replaced the literal `'two_factor_enabled_providers'` with `Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY` so the key lives in one place.

### `tests/class-two-factor-core.php`

Added `test_uninstall_removes_enabled_providers_option` to cover the new cleanup path.

## Testing

**Test 1: Automated**
1. `npm test`
2. Filter to uninstall: `npm run composer -- test -- --filter test_uninstall`

Result: 185/185 pass (6 uninstall tests pass, including the new one).

**Test 2: Manual**
1. WP Admin → Settings → Two-Factor, save a non-default provider set.
2. WP Admin → Plugins → Deactivate then Delete "Two Factor".
3. Inspect `wp_options`: no `two_factor_enabled_providers` row.
4. Reinstall the plugin: settings page loads, "never saved" default applies.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22fix%2F902-uninstall-option-cleanup%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->