### PR TITLE
#233: Add WP-CLI support with `wp two-factor` commands

### DIFF
--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -543,6 +543,16 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 		}
 
 		$count = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
+		if ( $count < 1 ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %d: provided count */
+					__( 'Invalid value for --count: %d. It must be 1 or greater.', 'two-factor' ),
+					$count
+				)
+			);
+		}
+
 		$codes = Two_Factor_Backup_Codes::get_instance()->generate_codes(
 			$user,
 			array(

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -19,6 +19,15 @@
 class Two_Factor_CLI_Command extends WP_CLI_Command {
 
 	/**
+	 * Maximum number of backup codes that can be generated in one command.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @var int
+	 */
+	const BACKUP_CODES_MAX_GENERATE_COUNT = 100;
+
+	/**
 	 * Resolve a user from an ID, login, or email address.
 	 *
 	 * Resolution order is ID, then login, then email.
@@ -230,6 +239,13 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 		);
 
 		if ( Two_Factor_Core::disable_provider_for_user( $user->ID, $provider ) ) {
+			if ( 'Two_Factor_Totp' === $provider ) {
+				$providers = Two_Factor_Core::get_providers();
+				if ( isset( $providers[ $provider ] ) && is_object( $providers[ $provider ] ) && method_exists( $providers[ $provider ], 'delete_user_totp_key' ) ) {
+					$providers[ $provider ]->delete_user_totp_key( $user->ID );
+				}
+			}
+
 			$this->destroy_sessions_if_providers_changed( $user, $enabled );
 
 			WP_CLI::success(
@@ -491,7 +507,10 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * : User ID, login, or email.
 	 *
 	 * [--count=<n>]
-	 * : Number of codes to generate. Defaults to 10.
+	 * : Number of codes to generate. Must be a decimal integer between 1 and 100. Defaults to 10.
+	 *
+	 * [--yes]
+	 * : Skip confirmation when replacing an existing set of backup codes.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -500,6 +519,9 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *
 	 *     # Generate 5 backup codes
 	 *     $ wp two-factor backup-codes generate admin --count=5
+	 *
+	 *     # Replace an existing set without a prompt
+	 *     $ wp two-factor backup-codes generate admin --count=5 --yes
 	 *
 	 * @subcommand backup-codes
 	 *
@@ -522,7 +544,7 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 		}
 
 		if ( ! isset( $args[1] ) ) {
-			WP_CLI::error( __( 'Usage: wp two-factor backup-codes generate <user> [--count=<n>]', 'two-factor' ) );
+			WP_CLI::error( __( 'Usage: wp two-factor backup-codes generate <user> [--count=<n>] [--yes]', 'two-factor' ) );
 		}
 
 		$user_identifier = $args[1];
@@ -542,14 +564,53 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'The Two_Factor_Backup_Codes provider is not available.', 'two-factor' ) );
 		}
 
-		$count = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
-		if ( $count < 1 ) {
+		$raw_count = WP_CLI\Utils\get_flag_value( $assoc_args, 'count', (string) Two_Factor_Backup_Codes::NUMBER_OF_CODES );
+		if ( ! is_scalar( $raw_count ) ) {
 			WP_CLI::error(
 				sprintf(
-					/* translators: %d: provided count */
-					__( 'Invalid value for --count: %d. It must be 1 or greater.', 'two-factor' ),
-					$count
+					/* translators: 1: provided count, 2: maximum allowed count */
+					__( 'Invalid value for --count: %1$s. It must be a decimal integer between 1 and %2$d.', 'two-factor' ),
+					wp_json_encode( $raw_count ),
+					self::BACKUP_CODES_MAX_GENERATE_COUNT
 				)
+			);
+		}
+
+		$raw_count = trim( (string) $raw_count );
+		if ( '' === $raw_count || ! preg_match( '/^\d+$/', $raw_count ) ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: 1: provided count, 2: maximum allowed count */
+					__( 'Invalid value for --count: %1$s. It must be a decimal integer between 1 and %2$d.', 'two-factor' ),
+					$raw_count,
+					self::BACKUP_CODES_MAX_GENERATE_COUNT
+				)
+			);
+		}
+
+		$count = (int) $raw_count;
+		if ( $count < 1 || $count > self::BACKUP_CODES_MAX_GENERATE_COUNT ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: 1: provided count, 2: maximum allowed count */
+					__( 'Invalid value for --count: %1$d. It must be a decimal integer between 1 and %2$d.', 'two-factor' ),
+					$count,
+					self::BACKUP_CODES_MAX_GENERATE_COUNT
+				)
+			);
+		}
+
+		$existing_codes     = get_user_meta( $user->ID, Two_Factor_Backup_Codes::BACKUP_CODES_META_KEY, true );
+		$has_existing_codes = is_array( $existing_codes ) && ! empty( $existing_codes );
+		if ( $has_existing_codes ) {
+			WP_CLI::confirm(
+				sprintf(
+					/* translators: 1: user login, 2: number of existing codes */
+					__( 'User %1$s already has %2$d backup codes. Regenerating will invalidate all existing backup codes. Continue?', 'two-factor' ),
+					$user->user_login,
+					count( $existing_codes )
+				),
+				$assoc_args
 			);
 		}
 

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -19,25 +19,20 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Resolve a user from an ID, login, or email address.
 	 *
-	 * ID is tried first when the identifier is numeric, then login, then email.
+	 * Resolution order is ID, then login, then email.
 	 *
 	 * @param string $identifier User ID, login, or email.
 	 * @return WP_User|false WP_User on success, false if not found.
 	 */
 	private function resolve_user( $identifier ) {
-		if ( ctype_digit( (string) $identifier ) ) {
-			$user = get_user_by( 'id', (int) $identifier );
+		foreach ( array( 'id', 'login', 'email' ) as $field ) {
+			$user = get_user_by( $field, $identifier );
 			if ( $user ) {
 				return $user;
 			}
 		}
 
-		$user = get_user_by( 'login', $identifier );
-		if ( $user ) {
-			return $user;
-		}
-
-		return get_user_by( 'email', $identifier );
+		return false;
 	}
 
 	/**
@@ -375,18 +370,19 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'Usage: wp two-factor enable <user> <provider>', 'two-factor' ) );
 		}
 
-		$user = $this->resolve_user( $args[0] );
+		$user_identifier = $args[0];
+		$provider        = $args[1];
+
+		$user = $this->resolve_user( $user_identifier );
 		if ( ! $user ) {
 			WP_CLI::error(
 				sprintf(
 					/* translators: %s: user identifier */
 					__( 'User not found: %s', 'two-factor' ),
-					$args[0]
+					$user_identifier
 				)
 			);
 		}
-
-		$provider = $args[1];
 
 		// TOTP requires a pre-shared secret that cannot be set up from the CLI alone.
 		if ( 'Two_Factor_Totp' === $provider ) {
@@ -455,7 +451,7 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function backup_codes( $args, $assoc_args ) {
-		$action = array_shift( $args );
+		$action = isset( $args[0] ) ? $args[0] : '';
 
 		if ( 'generate' !== $action ) {
 			WP_CLI::error(
@@ -467,17 +463,19 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			);
 		}
 
-		if ( empty( $args ) ) {
+		if ( ! isset( $args[1] ) ) {
 			WP_CLI::error( __( 'Usage: wp two-factor backup-codes generate <user> [--count=<n>]', 'two-factor' ) );
 		}
 
-		$user = $this->resolve_user( $args[0] );
+		$user_identifier = $args[1];
+
+		$user = $this->resolve_user( $user_identifier );
 		if ( ! $user ) {
 			WP_CLI::error(
 				sprintf(
 					/* translators: %s: user identifier */
 					__( 'User not found: %s', 'two-factor' ),
-					$args[0]
+					$user_identifier
 				)
 			);
 		}
@@ -486,14 +484,13 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'The Two_Factor_Backup_Codes provider is not available.', 'two-factor' ) );
 		}
 
-		$count    = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
-		$provider = Two_Factor_Backup_Codes::get_instance();
-		$codes    = $provider->generate_codes(
+		$count = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
+		$codes = Two_Factor_Backup_Codes::get_instance()->generate_codes(
 			$user,
 			array(
 				'number' => $count,
 				'method' => 'replace',
-			) 
+			)
 		);
 
 		WP_CLI::log(
@@ -532,13 +529,15 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function unlock( $args, $assoc_args ) {
-		$user = $this->resolve_user( $args[0] );
+		$user_identifier = $args[0];
+
+		$user = $this->resolve_user( $user_identifier );
 		if ( ! $user ) {
 			WP_CLI::error(
 				sprintf(
 					/* translators: %s: user identifier */
 					__( 'User not found: %s', 'two-factor' ),
-					$args[0]
+					$user_identifier
 				)
 			);
 		}

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -12,6 +12,8 @@
  * On Multisite, user meta is network-global — a reset applies to the user's
  * account across every site in the network without needing --url.
  *
+ * @since 0.17.0
+ *
  * @package Two_Factor
  */
 class Two_Factor_CLI_Command extends WP_CLI_Command {
@@ -20,6 +22,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * Resolve a user from an ID, login, or email address.
 	 *
 	 * Resolution order is ID, then login, then email.
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param string $identifier User ID, login, or email.
 	 * @return WP_User|false WP_User on success, false if not found.
@@ -42,6 +46,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * Two_Factor_Core::user_two_factor_options_update()) when 2FA settings
 	 * change. A configuration change made out-of-band via the CLI should take
 	 * effect immediately and force any active session to re-authenticate.
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param WP_User $user             Target user.
 	 * @param array   $providers_before Enabled provider keys captured before the change.
@@ -83,6 +89,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *
 	 *     # Output as JSON
 	 *     $ wp two-factor status 1 --format=json
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
@@ -163,6 +171,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *     # Remove only TOTP, leaving backup codes in place
 	 *     $ wp two-factor disable admin Two_Factor_Totp
 	 *
+	 * @since 0.17.0
+	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
@@ -191,6 +201,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * @param WP_User $user       Target user.
 	 * @param string  $provider   Provider class name.
 	 * @param array   $assoc_args CLI flags.
+	 *
+	 * @since 0.17.0
 	 */
 	private function disable_single_provider( $user, $provider, $assoc_args ) {
 		$enabled = Two_Factor_Core::get_enabled_providers_for_user( $user );
@@ -245,6 +257,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *
 	 * @param WP_User $user       Target user.
 	 * @param array   $assoc_args CLI flags.
+	 *
+	 * @since 0.17.0
 	 */
 	private function disable_all_providers( $user, $assoc_args ) {
 		$enabled = Two_Factor_Core::get_enabled_providers_for_user( $user );
@@ -353,6 +367,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand list-providers
 	 *
+	 * @since 0.17.0
+	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
@@ -395,6 +411,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp two-factor enable admin Two_Factor_Email
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
@@ -484,6 +502,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 *     $ wp two-factor backup-codes generate admin --count=5
 	 *
 	 * @subcommand backup-codes
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param array $args       Positional arguments: action, user.
 	 * @param array $assoc_args Associative arguments.
@@ -577,6 +597,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp two-factor unlock admin
+	 *
+	 * @since 0.17.0
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -488,7 +488,13 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 
 		$count    = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
 		$provider = Two_Factor_Backup_Codes::get_instance();
-		$codes    = $provider->generate_codes( $user, array( 'number' => $count, 'method' => 'replace' ) );
+		$codes    = $provider->generate_codes(
+			$user,
+			array(
+				'number' => $count,
+				'method' => 'replace',
+			) 
+		);
 
 		WP_CLI::log(
 			sprintf(

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * WP-CLI commands for Two-Factor authentication management.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Manage two-factor authentication for users.
+ *
+ * All commands target a single, explicitly named user (by ID, login, or email).
+ * On Multisite, user meta is network-global — a reset applies to the user's
+ * account across every site in the network without needing --url.
+ *
+ * @package Two_Factor
+ */
+class Two_Factor_CLI_Command extends WP_CLI_Command {
+
+	/**
+	 * Resolve a user from an ID, login, or email address.
+	 *
+	 * ID is tried first when the identifier is numeric, then login, then email.
+	 *
+	 * @param string $identifier User ID, login, or email.
+	 * @return WP_User|false WP_User on success, false if not found.
+	 */
+	private function resolve_user( $identifier ) {
+		if ( ctype_digit( (string) $identifier ) ) {
+			$user = get_user_by( 'id', (int) $identifier );
+			if ( $user ) {
+				return $user;
+			}
+		}
+
+		$user = get_user_by( 'login', $identifier );
+		if ( $user ) {
+			return $user;
+		}
+
+		return get_user_by( 'email', $identifier );
+	}
+
+	/**
+	 * Show two-factor authentication status for a user.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show 2FA status for "admin"
+	 *     $ wp two-factor status admin
+	 *
+	 *     # Output as JSON
+	 *     $ wp two-factor status 1 --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function status( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] );
+		if ( ! $user ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user identifier */
+					__( 'User not found: %s', 'two-factor' ),
+					$args[0]
+				)
+			);
+		}
+
+		$using_2fa         = Two_Factor_Core::is_user_using_two_factor( $user->ID );
+		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user );
+		$primary           = Two_Factor_Core::get_primary_provider_for_user( $user->ID );
+
+		$backup_codes_remaining = 0;
+		if ( class_exists( 'Two_Factor_Backup_Codes' ) ) {
+			$backup_codes_remaining = Two_Factor_Backup_Codes::codes_remaining_for_user( $user );
+		}
+
+		$items = array(
+			array(
+				'user_id'                => $user->ID,
+				'user_login'             => $user->user_login,
+				'using_2fa'              => $using_2fa ? 'true' : 'false',
+				'primary_provider'       => $primary ? $primary->get_key() : '',
+				'enabled_providers'      => implode( ', ', $enabled_providers ),
+				'backup_codes_remaining' => $backup_codes_remaining,
+			),
+		);
+
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+		WP_CLI\Utils\format_items(
+			$format,
+			$items,
+			array( 'user_id', 'user_login', 'using_2fa', 'primary_provider', 'enabled_providers', 'backup_codes_remaining' )
+		);
+	}
+
+	/**
+	 * Disable two-factor authentication for a user.
+	 *
+	 * Without a provider argument every factor is disabled and the user is
+	 * returned to a clean, pre-2FA baseline (nonce, lockout timers, the
+	 * password-was-reset flag, and all provider secrets are also cleared). With
+	 * a provider argument only that single factor is removed and the others are
+	 * left intact.
+	 *
+	 * The command is idempotent: disabling an already-disabled user or provider
+	 * succeeds and makes no changes.
+	 *
+	 * On Multisite, user meta is network-global — this reset affects the user's
+	 * account across every site in the network.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * [<provider>]
+	 * : Provider class name to disable (e.g. Two_Factor_Totp). Omit to disable all.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Fully disable 2FA for a locked-out user (no prompt)
+	 *     $ wp two-factor disable admin --yes
+	 *
+	 *     # Remove only TOTP, leaving backup codes in place
+	 *     $ wp two-factor disable admin Two_Factor_Totp
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function disable( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] );
+		if ( ! $user ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user identifier */
+					__( 'User not found: %s', 'two-factor' ),
+					$args[0]
+				)
+			);
+		}
+
+		if ( isset( $args[1] ) ) {
+			$this->disable_single_provider( $user, $args[1], $assoc_args );
+		} else {
+			$this->disable_all_providers( $user, $assoc_args );
+		}
+	}
+
+	/**
+	 * Disable a single 2FA provider for a user.
+	 *
+	 * @param WP_User $user       Target user.
+	 * @param string  $provider   Provider class name.
+	 * @param array   $assoc_args CLI flags.
+	 */
+	private function disable_single_provider( $user, $provider, $assoc_args ) {
+		$enabled = Two_Factor_Core::get_enabled_providers_for_user( $user );
+
+		if ( ! in_array( $provider, $enabled, true ) ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: 1: provider class name, 2: user login */
+					__( 'Provider %1$s is not enabled for %2$s — no changes made.', 'two-factor' ),
+					$provider,
+					$user->user_login
+				)
+			);
+			return;
+		}
+
+		WP_CLI::confirm(
+			sprintf(
+				/* translators: 1: provider class name, 2: user login */
+				__( 'Disable provider %1$s for user %2$s?', 'two-factor' ),
+				$provider,
+				$user->user_login
+			),
+			$assoc_args
+		);
+
+		if ( Two_Factor_Core::disable_provider_for_user( $user->ID, $provider ) ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: 1: provider class name, 2: user login */
+					__( 'Provider %1$s disabled for user %2$s.', 'two-factor' ),
+					$provider,
+					$user->user_login
+				)
+			);
+		} else {
+			WP_CLI::error(
+				sprintf(
+					/* translators: 1: provider class name, 2: user login */
+					__( 'Could not disable provider %1$s for user %2$s.', 'two-factor' ),
+					$provider,
+					$user->user_login
+				)
+			);
+		}
+	}
+
+	/**
+	 * Disable all 2FA providers and clean up all residual state for a user.
+	 *
+	 * @param WP_User $user       Target user.
+	 * @param array   $assoc_args CLI flags.
+	 */
+	private function disable_all_providers( $user, $assoc_args ) {
+		$enabled = Two_Factor_Core::get_enabled_providers_for_user( $user );
+		$raw     = get_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true );
+
+		if ( empty( $enabled ) && empty( $raw ) ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: %s: user login */
+					__( 'Two-factor is already disabled for user %s — no changes made.', 'two-factor' ),
+					$user->user_login
+				)
+			);
+			return;
+		}
+
+		WP_CLI::confirm(
+			sprintf(
+				/* translators: %s: user login */
+				__( 'Disable all two-factor authentication for user %s?', 'two-factor' ),
+				$user->user_login
+			),
+			$assoc_args
+		);
+
+		// Disable each provider through the core API.
+		$disabled = array();
+		foreach ( $enabled as $provider_key ) {
+			Two_Factor_Core::disable_provider_for_user( $user->ID, $provider_key );
+			$disabled[] = $provider_key;
+		}
+
+		// Force-clear the authoritative switches to handle any stale raw meta not
+		// covered by the loop above (e.g. a provider class that no longer exists).
+		delete_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY );
+		delete_user_meta( $user->ID, Two_Factor_Core::PROVIDER_USER_META_KEY );
+
+		// Clear session and throttle state.
+		delete_user_meta( $user->ID, Two_Factor_Core::USER_META_NONCE_KEY );
+		delete_user_meta( $user->ID, Two_Factor_Core::USER_PASSWORD_WAS_RESET_KEY );
+		Two_Factor_Core::clear_login_rate_limit( $user );
+
+		// Clear provider-specific secrets for a clean baseline.
+		if ( class_exists( 'Two_Factor_Totp' ) ) {
+			Two_Factor_Totp::get_instance()->delete_user_totp_key( $user->ID );
+			delete_user_meta( $user->ID, Two_Factor_Totp::LAST_SUCCESSFUL_LOGIN_META_KEY );
+		}
+		if ( class_exists( 'Two_Factor_Backup_Codes' ) ) {
+			delete_user_meta( $user->ID, Two_Factor_Backup_Codes::BACKUP_CODES_META_KEY );
+		}
+		if ( class_exists( 'Two_Factor_Email' ) ) {
+			delete_user_meta( $user->ID, Two_Factor_Email::TOKEN_META_KEY );
+			delete_user_meta( $user->ID, Two_Factor_Email::TOKEN_META_KEY_TIMESTAMP );
+		}
+
+		// Guard: assert the fail-closed fallback did not silently re-enable email.
+		$still_available = Two_Factor_Core::get_available_providers_for_user( $user );
+		if ( ! empty( $still_available ) && ! is_wp_error( $still_available ) ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user login */
+					__( '2FA is still active for user %s after reset — manual inspection required.', 'two-factor' ),
+					$user->user_login
+				)
+			);
+		}
+
+		WP_CLI::success(
+			sprintf(
+				/* translators: 1: comma-separated provider names, 2: user login */
+				__( 'All 2FA disabled for user %2$s (providers removed: %1$s).', 'two-factor' ),
+				$disabled ? implode( ', ', $disabled ) : __( 'none', 'two-factor' ),
+				$user->user_login
+			)
+		);
+	}
+
+	/**
+	 * List all registered two-factor authentication providers.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp two-factor list-providers
+	 *     $ wp two-factor list-providers --format=json
+	 *
+	 * @subcommand list-providers
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function list_providers( $args, $assoc_args ) {
+		$providers = Two_Factor_Core::get_providers();
+		$items     = array();
+
+		foreach ( $providers as $key => $provider ) {
+			$items[] = array(
+				'class' => $key,
+				'label' => $provider->get_label(),
+			);
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::log( __( 'No providers registered.', 'two-factor' ) );
+			return;
+		}
+
+		$format = WP_CLI\Utils\get_flag_value( $assoc_args, 'format', 'table' );
+		WP_CLI\Utils\format_items( $format, $items, array( 'class', 'label' ) );
+	}
+
+	/**
+	 * Enable a two-factor authentication provider for a user.
+	 *
+	 * Fully meaningful for providers that need no pre-shared secret, such as
+	 * Two_Factor_Email. For providers that require a secret (Two_Factor_Totp)
+	 * or generated material (Two_Factor_Backup_Codes) this command refuses with
+	 * a pointer to the appropriate setup command.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * <provider>
+	 * : Provider class name to enable (e.g. Two_Factor_Email).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp two-factor enable admin Two_Factor_Email
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function enable( $args, $assoc_args ) {
+		if ( ! isset( $args[1] ) ) {
+			WP_CLI::error( __( 'Usage: wp two-factor enable <user> <provider>', 'two-factor' ) );
+		}
+
+		$user = $this->resolve_user( $args[0] );
+		if ( ! $user ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user identifier */
+					__( 'User not found: %s', 'two-factor' ),
+					$args[0]
+				)
+			);
+		}
+
+		$provider = $args[1];
+
+		// TOTP requires a pre-shared secret that cannot be set up from the CLI alone.
+		if ( 'Two_Factor_Totp' === $provider ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: provider class name */
+					__( 'Provider %s requires a pre-shared secret and cannot be enabled from the CLI. Set it up via the user profile page or the totp subcommand (Phase 3).', 'two-factor' ),
+					$provider
+				)
+			);
+		}
+
+		// Backup codes must be generated first via the dedicated command.
+		if ( 'Two_Factor_Backup_Codes' === $provider ) {
+			WP_CLI::error(
+				__( 'Use "wp two-factor backup-codes generate <user>" to generate and enable backup codes.', 'two-factor' )
+			);
+		}
+
+		if ( Two_Factor_Core::enable_provider_for_user( $user->ID, $provider ) ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: 1: provider class name, 2: user login */
+					__( 'Provider %1$s enabled for user %2$s.', 'two-factor' ),
+					$provider,
+					$user->user_login
+				)
+			);
+		} else {
+			WP_CLI::error(
+				sprintf(
+					/* translators: 1: provider class name, 2: user login */
+					__( 'Could not enable provider %1$s for user %2$s. Is it a registered provider?', 'two-factor' ),
+					$provider,
+					$user->user_login
+				)
+			);
+		}
+	}
+
+	/**
+	 * Manage backup recovery codes for a user.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Action to perform. Supported: generate.
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * [--count=<n>]
+	 * : Number of codes to generate. Defaults to 10.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Generate 10 backup codes for "admin"
+	 *     $ wp two-factor backup-codes generate admin
+	 *
+	 *     # Generate 5 backup codes
+	 *     $ wp two-factor backup-codes generate admin --count=5
+	 *
+	 * @subcommand backup-codes
+	 *
+	 * @param array $args       Positional arguments: action, user.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function backup_codes( $args, $assoc_args ) {
+		$action = array_shift( $args );
+
+		if ( 'generate' !== $action ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: provided action */
+					__( 'Unknown action "%s". Use: wp two-factor backup-codes generate <user>', 'two-factor' ),
+					(string) $action
+				)
+			);
+		}
+
+		if ( empty( $args ) ) {
+			WP_CLI::error( __( 'Usage: wp two-factor backup-codes generate <user> [--count=<n>]', 'two-factor' ) );
+		}
+
+		$user = $this->resolve_user( $args[0] );
+		if ( ! $user ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user identifier */
+					__( 'User not found: %s', 'two-factor' ),
+					$args[0]
+				)
+			);
+		}
+
+		if ( ! class_exists( 'Two_Factor_Backup_Codes' ) ) {
+			WP_CLI::error( __( 'The Two_Factor_Backup_Codes provider is not available.', 'two-factor' ) );
+		}
+
+		$count    = (int) WP_CLI\Utils\get_flag_value( $assoc_args, 'count', Two_Factor_Backup_Codes::NUMBER_OF_CODES );
+		$provider = Two_Factor_Backup_Codes::get_instance();
+		$codes    = $provider->generate_codes( $user, array( 'number' => $count, 'method' => 'replace' ) );
+
+		WP_CLI::log(
+			sprintf(
+				/* translators: 1: number of codes, 2: user login */
+				__( 'Generated %1$d backup codes for %2$s. Store these somewhere safe — they will not be shown again:', 'two-factor' ),
+				count( $codes ),
+				$user->user_login
+			)
+		);
+
+		foreach ( $codes as $code ) {
+			WP_CLI::log( '  ' . $code );
+		}
+
+		WP_CLI::success( __( 'Backup codes generated and stored (existing codes replaced).', 'two-factor' ) );
+	}
+
+	/**
+	 * Clear the login throttle for a user without modifying their 2FA setup.
+	 *
+	 * Use this when a user has been temporarily locked out by too many bad codes
+	 * but still has their authenticator device available. For a full reset use
+	 * "wp two-factor disable <user>".
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp two-factor unlock admin
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function unlock( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] );
+		if ( ! $user ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user identifier */
+					__( 'User not found: %s', 'two-factor' ),
+					$args[0]
+				)
+			);
+		}
+
+		$was_limited = Two_Factor_Core::is_user_rate_limited( $user );
+		Two_Factor_Core::clear_login_rate_limit( $user );
+
+		if ( $was_limited ) {
+			WP_CLI::success(
+				sprintf(
+					/* translators: %s: user login */
+					__( 'Login throttle cleared for user %s.', 'two-factor' ),
+					$user->user_login
+				)
+			);
+		} else {
+			WP_CLI::success(
+				sprintf(
+					/* translators: %s: user login */
+					__( 'User %s was not rate-limited — no changes made.', 'two-factor' ),
+					$user->user_login
+				)
+			);
+		}
+	}
+}

--- a/CLI/class-two-factor-cli-command.php
+++ b/CLI/class-two-factor-cli-command.php
@@ -36,6 +36,28 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Destroy all of a user's sessions when their enabled providers changed.
+	 *
+	 * Mirrors the session invalidation the profile-page path performs (see
+	 * Two_Factor_Core::user_two_factor_options_update()) when 2FA settings
+	 * change. A configuration change made out-of-band via the CLI should take
+	 * effect immediately and force any active session to re-authenticate.
+	 *
+	 * @param WP_User $user             Target user.
+	 * @param array   $providers_before Enabled provider keys captured before the change.
+	 */
+	private function destroy_sessions_if_providers_changed( $user, $providers_before ) {
+		$providers_after = Two_Factor_Core::get_enabled_providers_for_user( $user );
+
+		sort( $providers_before );
+		sort( $providers_after );
+
+		if ( $providers_before !== $providers_after ) {
+			WP_Session_Tokens::get_instance( $user->ID )->destroy_all();
+		}
+	}
+
+	/**
 	 * Show two-factor authentication status for a user.
 	 *
 	 * ## OPTIONS
@@ -109,9 +131,11 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 	 * Disable two-factor authentication for a user.
 	 *
 	 * Without a provider argument every factor is disabled and the user is
-	 * returned to a clean, pre-2FA baseline (nonce, lockout timers, the
-	 * password-was-reset flag, and all provider secrets are also cleared). With
-	 * a provider argument only that single factor is removed and the others are
+	 * returned to a clean, pre-2FA baseline (nonce, lockout timers, and all
+	 * provider secrets are also cleared, and existing sessions are destroyed).
+	 * The compromised-password-reset flag is intentionally preserved so the
+	 * rescued user still sees why their old password stopped working. With a
+	 * provider argument only that single factor is removed and the others are
 	 * left intact.
 	 *
 	 * The command is idempotent: disabling an already-disabled user or provider
@@ -194,6 +218,8 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 		);
 
 		if ( Two_Factor_Core::disable_provider_for_user( $user->ID, $provider ) ) {
+			$this->destroy_sessions_if_providers_changed( $user, $enabled );
+
 			WP_CLI::success(
 				sprintf(
 					/* translators: 1: provider class name, 2: user login */
@@ -256,10 +282,14 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 		delete_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY );
 		delete_user_meta( $user->ID, Two_Factor_Core::PROVIDER_USER_META_KEY );
 
-		// Clear session and throttle state.
+		// Clear login nonce and throttle state.
 		delete_user_meta( $user->ID, Two_Factor_Core::USER_META_NONCE_KEY );
-		delete_user_meta( $user->ID, Two_Factor_Core::USER_PASSWORD_WAS_RESET_KEY );
 		Two_Factor_Core::clear_login_rate_limit( $user );
+
+		// Preserve USER_PASSWORD_WAS_RESET_KEY: it records that the password was
+		// reset after a compromise and drives the login notice explaining why the
+		// old password stopped working. That is independent of 2FA configuration
+		// and a rescued user should still see it after a reset.
 
 		// Clear provider-specific secrets for a clean baseline.
 		if ( class_exists( 'Two_Factor_Totp' ) ) {
@@ -285,6 +315,10 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 				)
 			);
 		}
+
+		// The 2FA configuration changed, so drop every existing session and force
+		// re-authentication, matching the profile-page behaviour.
+		WP_Session_Tokens::get_instance( $user->ID )->destroy_all();
 
 		WP_CLI::success(
 			sprintf(
@@ -389,7 +423,7 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			WP_CLI::error(
 				sprintf(
 					/* translators: %s: provider class name */
-					__( 'Provider %s requires a pre-shared secret and cannot be enabled from the CLI. Set it up via the user profile page or the totp subcommand (Phase 3).', 'two-factor' ),
+					__( 'Provider %s requires a pre-shared secret and cannot be enabled from the CLI. Set it up via the user profile page.', 'two-factor' ),
 					$provider
 				)
 			);
@@ -402,7 +436,11 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 			);
 		}
 
+		$providers_before = Two_Factor_Core::get_enabled_providers_for_user( $user );
+
 		if ( Two_Factor_Core::enable_provider_for_user( $user->ID, $provider ) ) {
+			$this->destroy_sessions_if_providers_changed( $user, $providers_before );
+
 			WP_CLI::success(
 				sprintf(
 					/* translators: 1: provider class name, 2: user login */
@@ -492,6 +530,21 @@ class Two_Factor_CLI_Command extends WP_CLI_Command {
 				'method' => 'replace',
 			)
 		);
+
+		// Enable the provider so the codes are actually usable at login, mirroring
+		// rest_generate_codes(). Without this the codes are stored but the provider
+		// is never offered, so the user is rejected at the 2FA step.
+		$providers_before = Two_Factor_Core::get_enabled_providers_for_user( $user );
+		if ( ! Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Backup_Codes' ) ) {
+			WP_CLI::error(
+				sprintf(
+					/* translators: %s: user login */
+					__( 'Backup codes were generated but the provider could not be enabled for user %s.', 'two-factor' ),
+					$user->user_login
+				)
+			);
+		}
+		$this->destroy_sessions_if_providers_changed( $user, $providers_before );
 
 		WP_CLI::log(
 			sprintf(

--- a/TESTS.md
+++ b/TESTS.md
@@ -35,6 +35,7 @@ npm run composer -- test -- --group email
 npm run composer -- test -- --group backup-codes
 npm run composer -- test -- --group providers
 npm run composer -- test -- --group core
+npm run composer -- test -- --group cli
 
 # Run a single file
 npm run composer -- test -- tests/providers/class-two-factor-totp.php
@@ -56,7 +57,7 @@ The largest test file. Covers the full authentication lifecycle managed by `Two_
 - Provider registration and retrieval (`get_providers`, `get_enabled_providers_for_user`, `get_available_providers_for_user`, `get_primary_provider_for_user`)
 - Login interception (`filter_authenticate`, `show_two_factor_login`, `process_provider`)
 - Login nonce creation, verification, and deletion
-- Rate limiting (`get_user_time_delay`, `is_user_rate_limited`)
+- Rate limiting (`get_user_time_delay`, `is_user_rate_limited`, `clear_login_rate_limit`)
 - Session management: two-factor factored vs. non-factored sessions, session destruction on 2FA enable/disable, revalidation
 - Password reset flow (compromise detection, email notifications, reset notices)
 - REST API permission callbacks (`rest_api_can_edit_user_and_update_two_factor_options`)
@@ -154,7 +155,25 @@ Tests `Two_Factor_Dummy_Secure` (a fixture that always _fails_ authentication, u
 - `validate_authentication` always returns false
 - `two_factor_provider_classname` filter
 
+### WP-CLI Commands — `tests/cli/class-two-factor-cli-command.php`
+
+**Class:** `Tests_Two_Factor_CLI_Command` · **Group:** `cli`
+Tests the `Two_Factor_CLI_Command` WP-CLI command class. The WP-CLI runtime is
+not loaded during PHPUnit, so the suite loads lightweight test doubles for
+`WP_CLI`, `WP_CLI_Command`, and the `WP_CLI\Utils` helpers (see Test Helpers)
+that capture output for assertions and throw on `error()`/`confirm()`:
+
+- User resolution by ID, login, and email; "user not found" errors
+- `status` — output for users with and without 2FA, backup-code count, `--format` passthrough
+- `list-providers` — registered providers listed, `--format` passthrough
+- `enable` — enabling secret-free providers; session destruction on change; refusing TOTP (no stale "Phase 3" pointer) and backup codes; unknown provider and missing-argument errors
+- `disable` (single provider) — removal leaves others intact, session destruction on change, idempotent no-op, confirmation required without `--yes`
+- `disable` (all) — full reset clears providers/throttle/nonce state and destroys sessions, preserves the compromised-password-reset flag, idempotent no-op, stale-meta cleanup guarding the fail-closed email fallback, confirmation required without `--yes`
+- `backup-codes generate` — default and `--count` code counts, regeneration replaces the set, enables the provider so codes are usable at login, session destruction when first enabled, unknown-action and missing-argument errors
+- `unlock` — clears the login throttle for a rate-limited user; no-op message otherwise
+
 ## Test Helpers
 
 - **`tests/bootstrap.php`** — Locates the WordPress test library (via `WP_TESTS_DIR` env var, relative path, or `/tmp/wordpress-tests-lib`), loads the plugin via `muplugins_loaded`, then boots the WP test environment.
 - **`tests/class-two-factor-dummy-secure.php`** — Defines `Two_Factor_Dummy_Secure`, a test-only provider class that spoofs the key of `Two_Factor_Dummy` but always fails `validate_authentication`. Used by `Tests_Two_Factor_Dummy_Secure` and some core tests.
+- **`tests/cli/`** — WP-CLI test doubles loaded by `Tests_Two_Factor_CLI_Command`: `class-wp-cli-command.php` (empty base-class stub), `class-wp-cli.php` (captures output into `WP_CLI::$logger`, throws on `error()`/`confirm()`), `class-wp-cli-mock-exit-exception.php` (stands in for a process exit), and `wp-cli-utils.php` (`WP_CLI\Utils\get_flag_value()` and `format_items()`).

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1451,6 +1451,22 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Clear the login rate-limit and failed-attempt counter for a user.
+	 *
+	 * Used by the WP-CLI `unlock` and `disable` (all) commands so there is one
+	 * tested code path for clearing throttle state rather than deleting the meta
+	 * keys directly from each call site.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @param WP_User $user The user whose throttle state should be cleared.
+	 */
+	public static function clear_login_rate_limit( $user ) {
+		delete_user_meta( $user->ID, self::USER_RATE_LIMIT_KEY );
+		delete_user_meta( $user->ID, self::USER_FAILED_LOGIN_ATTEMPTS_KEY );
+	}
+
+	/**
 	 * Determine if the current user session is logged in with 2FA.
 	 *
 	 * @since 0.9.0

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1162,7 +1162,7 @@ class Two_Factor_Core {
 
 			foreach ( $backup_providers as $backup_provider_key => $backup_provider ) {
 				$backup_link_args['provider'] = $backup_provider_key;
-				$links[] = array(
+				$links[]                      = array(
 					'url'   => self::login_url( $backup_link_args ),
 					'label' => $backup_provider->get_alternative_provider_label(),
 				);

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "php-stubs/wp-cli-stubs": "^2.12",
     "phpcompatibility/phpcompatibility-wp": "3.0.0-alpha2",
     "phpunit/phpunit": "^8.5|^9.6",
     "spatie/phpunit-watcher": "^1.23",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require-dev": {
     "automattic/vipwpcs": "^3.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "php-stubs/wp-cli-stubs": "^2.12",
+    "php-stubs/wp-cli-stubs": "dev-master",
     "phpcompatibility/phpcompatibility-wp": "3.0.0-alpha2",
     "phpunit/phpunit": "^8.5|^9.6",
     "spatie/phpunit-watcher": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3df3fd602fb474fac8ef78f583ae835",
+    "content-hash": "232ab16488a5c30e556876771f6ae4b8",
     "packages": [],
     "packages-dev": [
         {
@@ -733,16 +733,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
             },
             "conflict": {
@@ -752,7 +752,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
+                "php-stubs/generator": "^0.8.6",
                 "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
@@ -779,9 +779,53 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2026-02-03T19:29:21+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.12.0"
+            },
+            "time": "2025-06-10T09:58:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45aaa806c870a59b7d9aef39b8e569dc",
+    "content-hash": "157edd3a51da8fea925b10deea9246f7",
     "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/9c47cd036754e0e5f354a9914568f052043c3f30",
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.11",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
-                "squizlabs/php_codesniffer": "^3.9.2",
-                "wp-coding-standards/wpcs": "^3.1.0"
+                "php": ">=7.4",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "sirbrillig/phpcs-variable-analysis": "^2.13.0",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -59,33 +59,33 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2024-05-10T20:31:09+00:00"
+            "time": "2026-07-27T14:33:48+00:00"
         },
         {
             "name": "clue/stdio-react",
-            "version": "v2.6.0",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/reactphp-stdio.git",
-                "reference": "dfa6c378aabdff718202d4e2453f752c38ea3399"
+                "reference": "d8ced39f09f1f062e4a7f006aa6739f870eefb37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/reactphp-stdio/zipball/dfa6c378aabdff718202d4e2453f752c38ea3399",
-                "reference": "dfa6c378aabdff718202d4e2453f752c38ea3399",
+                "url": "https://api.github.com/repos/clue/reactphp-stdio/zipball/d8ced39f09f1f062e4a7f006aa6739f870eefb37",
+                "reference": "d8ced39f09f1f062e4a7f006aa6739f870eefb37",
                 "shasum": ""
             },
             "require": {
                 "clue/term-react": "^1.0 || ^0.1.1",
                 "clue/utf8-react": "^1.0 || ^0.1",
                 "php": ">=5.3",
-                "react/event-loop": "^1.2",
-                "react/stream": "^1.2"
+                "react/event-loop": "^1.6",
+                "react/stream": "^1.4"
             },
             "require-dev": {
                 "clue/arguments": "^2.0",
                 "clue/commander": "^1.2",
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36"
             },
             "suggest": {
                 "ext-mbstring": "Using ext-mbstring should provide slightly better performance for handling I/O"
@@ -123,7 +123,7 @@
             ],
             "support": {
                 "issues": "https://github.com/clue/reactphp-stdio/issues",
-                "source": "https://github.com/clue/reactphp-stdio/tree/v2.6.0"
+                "source": "https://github.com/clue/reactphp-stdio/tree/v2.7.0"
             },
             "funding": [
                 {
@@ -135,7 +135,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-18T15:09:30+00:00"
+            "time": "2026-06-14T21:56:40+00:00"
         },
         {
             "name": "clue/term-react",
@@ -488,36 +488,31 @@
         },
         {
             "name": "jolicode/jolinotif",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jolicode/JoliNotif.git",
-                "reference": "9cca717bbc47aa2ffeca51d77daa13b824a489ee"
+                "reference": "a15bfc0d5aef432f150385924ede4e099643edb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/9cca717bbc47aa2ffeca51d77daa13b824a489ee",
-                "reference": "9cca717bbc47aa2ffeca51d77daa13b824a489ee",
+                "url": "https://api.github.com/repos/jolicode/JoliNotif/zipball/a15bfc0d5aef432f150385924ede4e099643edb7",
+                "reference": "a15bfc0d5aef432f150385924ede4e099643edb7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "symfony/process": "^3.3|^4.0|^5.0"
+                "php": ">=7.4",
+                "symfony/process": "^4.0|^5.0|^6.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.0",
-                "symfony/finder": "^3.3|^4.0|^5.0",
-                "symfony/phpunit-bridge": "^3.4.26|^4.0|^5.0"
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "symfony/finder": "^5.0",
+                "symfony/phpunit-bridge": "^5.0"
             },
             "bin": [
                 "jolinotif"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joli\\JoliNotif\\": "src/"
@@ -543,7 +538,7 @@
             ],
             "support": {
                 "issues": "https://github.com/jolicode/JoliNotif/issues",
-                "source": "https://github.com/jolicode/JoliNotif/tree/v2.3.0"
+                "source": "https://github.com/jolicode/JoliNotif/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -551,7 +546,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-07T12:30:00+00:00"
+            "time": "2021-12-01T16:20:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -612,6 +607,63 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -733,16 +785,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.4",
+            "version": "v7.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+                "reference": "394570301894799e69a4aa117c9c995427e3ba04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
-                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/394570301894799e69a4aa117c9c995427e3ba04",
+                "reference": "394570301894799e69a4aa117c9c995427e3ba04",
                 "shasum": ""
             },
             "conflict": {
@@ -752,13 +804,13 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.6",
+                "php-stubs/generator": "^0.9",
                 "phpdocumentor/reflection-docblock": "^6.0",
-                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^9.5",
                 "symfony/polyfill-php80": "*",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
-                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.2",
+                "wp-coding-standards/wpcs": "3.4.1 as 2.3.0"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -779,26 +831,26 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v7.1.0"
             },
-            "time": "2026-05-01T20:36:01+00:00"
+            "time": "2026-08-28T00:32:06+00:00"
         },
         {
             "name": "php-stubs/wp-cli-stubs",
-            "version": "v2.12.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wp-cli-stubs.git",
-                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d"
+                "reference": "335d4890308f9fbb3427c56412d30f157d21f697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/af16401e299a3fd2229bd0fa9a037638a4174a9d",
-                "reference": "af16401e299a3fd2229bd0fa9a037638a4174a9d",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/335d4890308f9fbb3427c56412d30f157d21f697",
+                "reference": "335d4890308f9fbb3427c56412d30f157d21f697",
                 "shasum": ""
             },
             "require": {
-                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+                "php-stubs/wordpress-stubs": ">=4.7"
             },
             "require-dev": {
                 "php": "~7.3 || ~8.0",
@@ -808,6 +860,7 @@
                 "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
+            "default-branch": true,
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -823,9 +876,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
-                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.12.0"
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/master"
             },
-            "time": "2025-06-10T09:58:05+00:00"
+            "time": "2026-05-26T12:27:53+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1296,40 +1349,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.17",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
-                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -1357,7 +1414,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.17"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -1365,32 +1423,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:09:37+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.6",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "69deeb8664f611f156a924154985fbd4911eb36b"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/69deeb8664f611f156a924154985fbd4911eb36b",
-                "reference": "69deeb8664f611f156a924154985fbd4911eb36b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1417,7 +1475,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1425,26 +1483,97 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:39:50+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1468,34 +1597,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.4",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a691211e94ff39a34811abd521c31bd5b305b0bb",
-                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1521,7 +1656,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.4"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1529,112 +1664,54 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:42:41+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
-                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "abandoned": true,
-            "time": "2021-07-26T12:15:06+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.52",
+            "version": "9.6.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858"
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1015741814413c156abb0f53d7db7bbd03c6e858",
-                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.2",
-                "phpunit/php-code-coverage": "^7.0.17",
-                "phpunit/php-file-iterator": "^2.0.6",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.4",
-                "sebastian/comparator": "^3.0.7",
-                "sebastian/diff": "^3.0.6",
-                "sebastian/environment": "^4.2.5",
-                "sebastian/exporter": "^3.1.8",
-                "sebastian/global-state": "^3.0.6",
-                "sebastian/object-enumerator": "^3.0.5",
-                "sebastian/resource-operations": "^2.0.3",
-                "sebastian/type": "^1.1.5",
-                "sebastian/version": "^2.0.1"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage",
-                "phpunit/php-invoker": "To allow enforcing time limits"
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1642,10 +1719,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -1671,48 +1751,32 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.52"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:20:18+00:00"
+            "time": "2026-07-06T14:48:07+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -1741,9 +1805,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "react/event-loop",
@@ -1896,29 +1960,141 @@
             "time": "2024-06-11T12:45:25+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.3",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
-                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1940,7 +2116,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1948,34 +2124,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:45:45+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.7",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
-                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2014,7 +2190,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.7"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -2034,33 +2210,90 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:20:25+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.6",
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/98ff311ca519c3aa73ccd3de053bdb377171d7b6",
-                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2092,7 +2325,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2100,27 +2333,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:16:36+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.5",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "56932f6049a0482853056ffd617c91ffcc754205"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/56932f6049a0482853056ffd617c91ffcc754205",
-                "reference": "56932f6049a0482853056ffd617c91ffcc754205",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2128,7 +2361,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2155,7 +2388,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.5"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2163,34 +2396,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:49:59+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.8",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64cfeaa341951ceb2019d7b98232399d57bb2296",
-                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2225,14 +2458,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.8"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
@@ -2252,30 +2485,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T05:55:14+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.6",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
-                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2283,7 +2516,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2308,7 +2541,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
@@ -2328,34 +2561,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:40:12+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.5",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "ac5b293dba925751b808e02923399fb44ff0d541"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/ac5b293dba925751b808e02923399fb44ff0d541",
-                "reference": "ac5b293dba925751b808e02923399fb44ff0d541",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2377,7 +2667,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2385,32 +2675,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:54:02+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/1d439c229e61f244ff1f211e5c99737f90c67def",
-                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2432,7 +2722,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.3"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -2440,32 +2730,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:56:04+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/8fe7e75986a9d24b4cceae847314035df7703a5a",
-                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2492,10 +2782,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2515,29 +2805,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T05:25:53+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/72a7f7674d053d548003b16ff5a106e7e0e06eee",
-                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2558,7 +2851,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -2566,32 +2859,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T13:59:09+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "1.1.5",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/18f071c3a29892b037d35e6b20ddf3ea39b42874",
-                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2614,7 +2907,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/1.1.5"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -2622,29 +2915,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-01T14:04:07+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2667,9 +2960,15 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
-            "time": "2016-10-03T07:35:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -3184,16 +3483,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
                 "shasum": ""
             },
             "require": {
@@ -3242,7 +3541,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
             },
             "funding": [
                 {
@@ -3262,20 +3561,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-07-28T08:25:59+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -3327,7 +3626,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -3347,20 +3646,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -3412,7 +3711,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -3432,7 +3731,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -4214,7 +4513,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "php-stubs/wp-cli-stubs": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,8 +3,11 @@ includes:
 parameters:
 	level: 0
 	paths:
+		- CLI
 		- includes
 		- providers
 		- class-two-factor-compat.php
 		- class-two-factor-core.php
 		- two-factor.php
+	scanFiles:
+		- vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -469,7 +469,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @param int    $user_id User ID.
 	 * @param string $key TOTP secret key.
 	 *
-	 * @return boolean If the key was stored successfully.
+	 * @return int|bool Meta ID if the key did not exist, true on update, false on failure.
 	 */
 	public function set_user_totp_key( $user_id, $key ) {
 		return update_user_meta( $user_id, self::SECRET_META_KEY, $key );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -749,6 +749,30 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that clearing the login rate limit removes the throttle state.
+	 *
+	 * @covers Two_Factor_Core::clear_login_rate_limit
+	 */
+	public function test_clear_login_rate_limit() {
+		$user = $this->get_dummy_user();
+
+		// Put the user into a rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 5 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+		$this->assertTrue( Two_Factor_Core::is_user_rate_limited( $user ) );
+
+		Two_Factor_Core::clear_login_rate_limit( $user );
+
+		$this->assertFalse( Two_Factor_Core::is_user_rate_limited( $user ) );
+		$this->assertEmpty( get_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, true ) );
+		$this->assertEmpty( get_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, true ) );
+
+		// Clearing an already-clean user is a harmless no-op.
+		Two_Factor_Core::clear_login_rate_limit( $user );
+		$this->assertFalse( Two_Factor_Core::is_user_rate_limited( $user ) );
+	}
+
+	/**
 	 * Test that the "invalid login attempts have occurred" login notice works as expected.
 	 *
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -425,6 +425,23 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Disabling TOTP via CLI also removes the stored TOTP secret.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_single_totp_clears_stored_secret() {
+		$this->enable_provider( 'Two_Factor_Totp' );
+		$totp = Two_Factor_Totp::get_instance();
+
+		$this->assertTrue( $totp->set_user_totp_key( $this->user->ID, Two_Factor_Totp::generate_key() ) );
+		$this->assertNotSame( '', $totp->get_user_totp_key( $this->user->ID ) );
+
+		$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array( 'yes' => true ) );
+
+		$this->assertSame( '', $totp->get_user_totp_key( $this->user->ID ) );
+	}
+
+	/**
 	 * Disabling one provider while others remain destroys the user's sessions.
 	 *
 	 * @covers Two_Factor_CLI_Command::disable
@@ -688,15 +705,69 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Count values with non-digit suffixes are rejected.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_rejects_non_decimal_count() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => '2garbage' ) );
+			}
+		);
+
+		$this->assertStringContainsString( 'Invalid value for --count', $message );
+		$this->assertSame( 0, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
+	 * Count values above the safety cap are rejected.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_rejects_count_above_maximum() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes(
+					array( 'generate', 'cli_test_user' ),
+					array( 'count' => Two_Factor_CLI_Command::BACKUP_CODES_MAX_GENERATE_COUNT + 1 )
+				);
+			}
+		);
+
+		$this->assertStringContainsString( 'Invalid value for --count', $message );
+		$this->assertStringContainsString( (string) Two_Factor_CLI_Command::BACKUP_CODES_MAX_GENERATE_COUNT, $message );
+		$this->assertSame( 0, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
 	 * Regenerating replaces the previous set of codes.
 	 *
 	 * @covers Two_Factor_CLI_Command::backup_codes
 	 */
 	public function test_backup_codes_generate_replaces_existing() {
 		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 8 ) );
-		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 3 ) );
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 3, 'yes' => true ) );
 
 		$this->assertSame( 3, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
+	 * Regenerating existing backup codes requires confirmation without --yes.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_replacing_existing_requires_confirmation() {
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 8 ) );
+
+		$this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 3 ) );
+			}
+		);
+
+		$this->assertNotEmpty( WP_CLI::get_logs( 'confirm' ), 'Expected a confirmation prompt without --yes.' );
+		$this->assertSame( 8, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
 	}
 
 	/**

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -1,0 +1,731 @@
+<?php
+/**
+ * Test the Two_Factor_CLI_Command WP-CLI commands.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Tests_Two_Factor_CLI_Command
+ *
+ * @package Two_Factor
+ * @group cli
+ */
+class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
+
+	/**
+	 * The command instance under test.
+	 *
+	 * @var Two_Factor_CLI_Command
+	 */
+	protected $command;
+
+	/**
+	 * Load the WP-CLI test doubles and the command under test.
+	 *
+	 * The WP-CLI runtime is absent during PHPUnit runs, so the stub classes and
+	 * namespaced helper functions must be loaded before the command class, whose
+	 * declaration extends WP_CLI_Command.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once __DIR__ . '/class-wp-cli-command.php';
+		require_once __DIR__ . '/class-wp-cli-mock-exit-exception.php';
+		require_once __DIR__ . '/wp-cli-utils.php';
+		require_once __DIR__ . '/class-wp-cli.php';
+		require_once dirname( dirname( __DIR__ ) ) . '/CLI/class-two-factor-cli-command.php';
+	}
+
+	/**
+	 * A user with no two-factor configuration.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * Set up a test case.
+	 *
+	 * @see WP_UnitTestCase_Base::set_up()
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		WP_CLI::reset();
+
+		$this->command = new Two_Factor_CLI_Command();
+		$this->user    = self::factory()->user->create_and_get(
+			array(
+				'user_login' => 'cli_test_user',
+				'user_email' => 'cli_test_user@example.com',
+				'role'       => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Run a command callback that is expected to abort via WP_CLI::error()/confirm().
+	 *
+	 * @param callable $callback The command invocation.
+	 * @return string The message from the last captured error entry.
+	 */
+	protected function assert_command_aborts( $callback ) {
+		try {
+			$callback();
+		} catch ( WP_CLI_Mock_Exit_Exception $e ) {
+			return $e->getMessage();
+		}
+
+		$this->fail( 'Expected the command to abort with WP_CLI::error() or a declined confirmation.' );
+	}
+
+	/**
+	 * Return the message string from the most recent captured entry of a level.
+	 *
+	 * @param string $level Message level (success|error|log|warning).
+	 * @return string
+	 */
+	protected function last_message( $level ) {
+		$entries = WP_CLI::get_logs( $level );
+		$last    = end( $entries );
+
+		return $last ? ( is_array( $last['message'] ) ? implode( "\n", $last['message'] ) : (string) $last['message'] ) : '';
+	}
+
+	/**
+	 * Return the most recent captured format_items() payload.
+	 *
+	 * @return array|null
+	 */
+	protected function last_format() {
+		$entries = WP_CLI::get_logs( 'format' );
+
+		return $entries ? end( $entries ) : null;
+	}
+
+	/**
+	 * Enable a provider for the test user directly through the core API.
+	 *
+	 * @param string $provider Provider class name.
+	 */
+	protected function enable_provider( $provider ) {
+		$this->assertTrue(
+			Two_Factor_Core::enable_provider_for_user( $this->user->ID, $provider ),
+			"Failed to enable {$provider} for the test user."
+		);
+	}
+
+	/**
+	 * Create a live session for the test user and assert it exists.
+	 */
+	protected function create_user_session() {
+		$manager = WP_Session_Tokens::get_instance( $this->user->ID );
+		$manager->create( time() + HOUR_IN_SECONDS );
+
+		$this->assertNotEmpty( $manager->get_all(), 'Expected a session to exist before the command runs.' );
+	}
+
+	/**
+	 * Count the test user's active sessions.
+	 *
+	 * @return int
+	 */
+	protected function count_user_sessions() {
+		return count( WP_Session_Tokens::get_instance( $this->user->ID )->get_all() );
+	}
+
+	/**
+	 * The command class extends the WP-CLI base command.
+	 */
+	public function test_extends_wp_cli_command() {
+		$this->assertInstanceOf( 'WP_CLI_Command', $this->command );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * User resolution
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * The user can be resolved by numeric ID.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_resolve_user_by_id() {
+		$this->command->status( array( (string) $this->user->ID ), array() );
+
+		$format = $this->last_format();
+		$this->assertNotNull( $format );
+		$this->assertSame( $this->user->ID, $format['items'][0]['user_id'] );
+	}
+
+	/**
+	 * The user can be resolved by login.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_resolve_user_by_login() {
+		$this->command->status( array( 'cli_test_user' ), array() );
+
+		$format = $this->last_format();
+		$this->assertSame( $this->user->ID, $format['items'][0]['user_id'] );
+	}
+
+	/**
+	 * The user can be resolved by email.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_resolve_user_by_email() {
+		$this->command->status( array( 'cli_test_user@example.com' ), array() );
+
+		$format = $this->last_format();
+		$this->assertSame( $this->user->ID, $format['items'][0]['user_id'] );
+	}
+
+	/**
+	 * An unknown identifier aborts with a "User not found" error.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_unknown_user_errors() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->status( array( 'nobody-here' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'User not found: nobody-here', $message );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * status
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * A user without 2FA reports using_2fa false and no providers.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_status_without_two_factor() {
+		$this->command->status( array( 'cli_test_user' ), array() );
+
+		$item = $this->last_format()['items'][0];
+		$this->assertSame( 'false', $item['using_2fa'] );
+		$this->assertSame( '', $item['enabled_providers'] );
+		$this->assertSame( '', $item['primary_provider'] );
+		$this->assertSame( 0, $item['backup_codes_remaining'] );
+	}
+
+	/**
+	 * A user with providers enabled reports them in the status output.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_status_with_providers() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		$this->enable_provider( 'Two_Factor_Totp' );
+
+		$this->command->status( array( 'cli_test_user' ), array() );
+
+		$item = $this->last_format()['items'][0];
+		$this->assertSame( 'true', $item['using_2fa'] );
+		$this->assertStringContainsString( 'Two_Factor_Email', $item['enabled_providers'] );
+		$this->assertStringContainsString( 'Two_Factor_Totp', $item['enabled_providers'] );
+		$this->assertNotEmpty( $item['primary_provider'] );
+	}
+
+	/**
+	 * The --format flag is passed through to the formatter.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_status_honors_format_flag() {
+		$this->command->status( array( 'cli_test_user' ), array( 'format' => 'json' ) );
+
+		$this->assertSame( 'json', $this->last_format()['format'] );
+	}
+
+	/**
+	 * The backup code count is reported in status output.
+	 *
+	 * @covers Two_Factor_CLI_Command::status
+	 */
+	public function test_status_reports_backup_code_count() {
+		Two_Factor_Backup_Codes::get_instance()->generate_codes(
+			$this->user,
+			array(
+				'number' => 4,
+				'method' => 'replace',
+			)
+		);
+
+		$this->command->status( array( 'cli_test_user' ), array() );
+
+		$this->assertSame( 4, $this->last_format()['items'][0]['backup_codes_remaining'] );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * list-providers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * The command lists the registered providers.
+	 *
+	 * @covers Two_Factor_CLI_Command::list_providers
+	 */
+	public function test_list_providers() {
+		$this->command->list_providers( array(), array() );
+
+		$format  = $this->last_format();
+		$classes = wp_list_pluck( $format['items'], 'class' );
+
+		$this->assertContains( 'Two_Factor_Email', $classes );
+		$this->assertContains( 'Two_Factor_Totp', $classes );
+		$this->assertContains( 'Two_Factor_Backup_Codes', $classes );
+
+		foreach ( $format['items'] as $item ) {
+			$this->assertArrayHasKey( 'label', $item );
+			$this->assertNotEmpty( $item['label'] );
+		}
+	}
+
+	/**
+	 * The --format flag is passed through when listing providers.
+	 *
+	 * @covers Two_Factor_CLI_Command::list_providers
+	 */
+	public function test_list_providers_honors_format_flag() {
+		$this->command->list_providers( array(), array( 'format' => 'json' ) );
+
+		$this->assertSame( 'json', $this->last_format()['format'] );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * enable
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Enabling a secret-free provider succeeds and shows in status.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_email_provider() {
+		$this->command->enable( array( 'cli_test_user', 'Two_Factor_Email' ), array() );
+
+		$this->assertStringContainsString( 'enabled', $this->last_message( 'success' ) );
+		$this->assertContains( 'Two_Factor_Email', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
+	}
+
+	/**
+	 * Enabling a provider destroys the user's existing sessions.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_destroys_sessions() {
+		$this->create_user_session();
+
+		$this->command->enable( array( 'cli_test_user', 'Two_Factor_Email' ), array() );
+
+		$this->assertSame( 0, $this->count_user_sessions() );
+	}
+
+	/**
+	 * Enabling TOTP is refused because it needs a pre-shared secret.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_totp_is_refused() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->enable( array( 'cli_test_user', 'Two_Factor_Totp' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'pre-shared secret', $message );
+		// The error must not reference the non-existent "Phase 3" totp subcommand.
+		$this->assertStringNotContainsString( 'Phase 3', $message );
+		$this->assertNotContains( 'Two_Factor_Totp', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
+	}
+
+	/**
+	 * Enabling backup codes is refused with a pointer to the generate command.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_backup_codes_is_refused() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->enable( array( 'cli_test_user', 'Two_Factor_Backup_Codes' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'backup-codes generate', $message );
+	}
+
+	/**
+	 * Enabling an unregistered provider aborts with an error.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_unknown_provider_errors() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->enable( array( 'cli_test_user', 'Not_A_Real_Provider' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'registered provider', $message );
+	}
+
+	/**
+	 * Enable requires a provider argument.
+	 *
+	 * @covers Two_Factor_CLI_Command::enable
+	 */
+	public function test_enable_requires_provider_argument() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->enable( array( 'cli_test_user' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'Usage:', $message );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * disable (single provider)
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Disabling a single provider leaves the others intact.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_single_provider() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		$this->enable_provider( 'Two_Factor_Totp' );
+
+		$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array( 'yes' => true ) );
+
+		$enabled = Two_Factor_Core::get_enabled_providers_for_user( $this->user );
+		$this->assertNotContains( 'Two_Factor_Totp', $enabled );
+		$this->assertContains( 'Two_Factor_Email', $enabled );
+		$this->assertStringContainsString( 'disabled', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * Disabling one provider while others remain destroys the user's sessions.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_single_provider_destroys_sessions() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		$this->enable_provider( 'Two_Factor_Totp' );
+		$this->create_user_session();
+
+		$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array( 'yes' => true ) );
+
+		$this->assertSame( 0, $this->count_user_sessions() );
+	}
+
+	/**
+	 * Disabling a provider that is not enabled is a no-op success.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_single_provider_not_enabled() {
+		$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'no changes made', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * Disabling a single provider requires confirmation without --yes.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_single_provider_requires_confirmation() {
+		$this->enable_provider( 'Two_Factor_Totp' );
+
+		$this->assert_command_aborts(
+			function () {
+				$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array() );
+			}
+		);
+
+		// Provider remains enabled because the prompt was declined.
+		$this->assertContains( 'Two_Factor_Totp', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * disable (all)
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * A full disable clears all providers and residual state.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		$this->enable_provider( 'Two_Factor_Totp' );
+		Two_Factor_Backup_Codes::get_instance()->generate_codes( $this->user, array( 'method' => 'replace' ) );
+		update_user_meta( $this->user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+		update_user_meta( $this->user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+
+		$this->command->disable( array( 'cli_test_user' ), array( 'yes' => true ) );
+
+		$this->assertFalse( Two_Factor_Core::is_user_using_two_factor( $this->user->ID ) );
+		$this->assertEmpty( Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
+		$this->assertEmpty( get_user_meta( $this->user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, true ) );
+		$this->assertEmpty( get_user_meta( $this->user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, true ) );
+		$this->assertStringContainsString( 'All 2FA disabled', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * A full disable destroys the user's existing sessions.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers_destroys_sessions() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		$this->create_user_session();
+
+		$this->command->disable( array( 'cli_test_user' ), array( 'yes' => true ) );
+
+		$this->assertSame( 0, $this->count_user_sessions() );
+	}
+
+	/**
+	 * A full disable preserves the compromised-password-reset flag and its notice.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers_preserves_password_reset_flag() {
+		$this->enable_provider( 'Two_Factor_Email' );
+		update_user_meta( $this->user->ID, Two_Factor_Core::USER_PASSWORD_WAS_RESET_KEY, true );
+
+		$this->command->disable( array( 'cli_test_user' ), array( 'yes' => true ) );
+
+		$this->assertNotEmpty(
+			get_user_meta( $this->user->ID, Two_Factor_Core::USER_PASSWORD_WAS_RESET_KEY, true ),
+			'The password-was-reset flag should survive a full 2FA reset.'
+		);
+	}
+
+	/**
+	 * Disabling an already-disabled user is an idempotent no-op.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers_when_already_disabled() {
+		$this->command->disable( array( 'cli_test_user' ), array( 'yes' => true ) );
+
+		$this->assertStringContainsString( 'already disabled', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * A full disable clears stale meta even when the provider class no longer exists.
+	 *
+	 * Guards the fail-closed email fallback: a stale enabled-providers meta value
+	 * must not leave email 2FA active after a reset.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers_clears_stale_meta() {
+		update_user_meta(
+			$this->user->ID,
+			Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY,
+			array( 'Some_Removed_Provider_Class' )
+		);
+
+		$this->command->disable( array( 'cli_test_user' ), array( 'yes' => true ) );
+
+		$this->assertEmpty( get_user_meta( $this->user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, true ) );
+		$this->assertFalse( Two_Factor_Core::is_user_using_two_factor( $this->user->ID ) );
+		$this->assertStringContainsString( 'All 2FA disabled', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * A full disable requires confirmation without --yes.
+	 *
+	 * @covers Two_Factor_CLI_Command::disable
+	 */
+	public function test_disable_all_providers_requires_confirmation() {
+		$this->enable_provider( 'Two_Factor_Email' );
+
+		$this->assert_command_aborts(
+			function () {
+				$this->command->disable( array( 'cli_test_user' ), array() );
+			}
+		);
+
+		$this->assertContains( 'Two_Factor_Email', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * backup-codes generate
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Generating backup codes prints the default number of codes.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_default_count() {
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array() );
+
+		$this->assertSame(
+			Two_Factor_Backup_Codes::NUMBER_OF_CODES,
+			Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user )
+		);
+		$this->assertStringContainsString( 'Backup codes generated', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * Codes generated through the CLI must be usable at login.
+	 *
+	 * Generating codes without enabling the provider leaves the user looking
+	 * set up in `status` while being rejected at the 2FA step, because the
+	 * provider is only offered at login when it is both enabled and configured
+	 * (present in get_available_providers_for_user()).
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_enables_provider_for_login() {
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array() );
+
+		$this->assertContains(
+			'Two_Factor_Backup_Codes',
+			Two_Factor_Core::get_enabled_providers_for_user( $this->user ),
+			'The backup codes provider should be enabled after generation.'
+		);
+
+		$available = Two_Factor_Core::get_available_providers_for_user( $this->user );
+		$this->assertArrayHasKey(
+			'Two_Factor_Backup_Codes',
+			$available,
+			'Backup codes generated via the CLI must be usable at login.'
+		);
+		$this->assertTrue( Two_Factor_Core::is_user_using_two_factor( $this->user->ID ) );
+	}
+
+	/**
+	 * Generating backup codes for a user without 2FA destroys their sessions.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_destroys_sessions_when_first_enabled() {
+		$this->create_user_session();
+
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array() );
+
+		$this->assertSame( 0, $this->count_user_sessions() );
+	}
+
+	/**
+	 * The --count flag controls how many codes are generated.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_custom_count() {
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 5 ) );
+
+		$this->assertSame( 5, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+
+		$printed = count( WP_CLI::get_logs( 'log' ) );
+		// One header line plus five code lines.
+		$this->assertSame( 6, $printed );
+	}
+
+	/**
+	 * Regenerating replaces the previous set of codes.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_replaces_existing() {
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 8 ) );
+		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 3 ) );
+
+		$this->assertSame( 3, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
+	 * An unknown backup-codes action aborts with an error.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_unknown_action_errors() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'destroy', 'cli_test_user' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'Unknown action', $message );
+	}
+
+	/**
+	 * The backup-codes generate action requires a user argument.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_requires_user_argument() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'generate' ), array() );
+			}
+		);
+
+		$this->assertStringContainsString( 'Usage:', $message );
+	}
+
+	/*
+	 * ---------------------------------------------------------------------
+	 * unlock
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Unlocking a rate-limited user clears the throttle.
+	 *
+	 * @covers Two_Factor_CLI_Command::unlock
+	 */
+	public function test_unlock_rate_limited_user() {
+		update_user_meta( $this->user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+		update_user_meta( $this->user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 5 );
+		$this->assertTrue( Two_Factor_Core::is_user_rate_limited( $this->user ) );
+
+		$this->command->unlock( array( 'cli_test_user' ), array() );
+
+		$this->assertFalse( Two_Factor_Core::is_user_rate_limited( $this->user ) );
+		$this->assertEmpty( get_user_meta( $this->user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, true ) );
+		$this->assertStringContainsString( 'Login throttle cleared', $this->last_message( 'success' ) );
+	}
+
+	/**
+	 * Unlocking a user who is not rate-limited reports no changes.
+	 *
+	 * @covers Two_Factor_CLI_Command::unlock
+	 */
+	public function test_unlock_not_rate_limited_user() {
+		$this->command->unlock( array( 'cli_test_user' ), array() );
+
+		$this->assertStringContainsString( 'was not rate-limited', $this->last_message( 'success' ) );
+	}
+}

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -656,6 +656,38 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A count lower than 1 is rejected.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_rejects_zero_count() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 0 ) );
+			}
+		);
+
+		$this->assertStringContainsString( 'Invalid value for --count', $message );
+		$this->assertSame( 0, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
+	 * Negative count values are rejected.
+	 *
+	 * @covers Two_Factor_CLI_Command::backup_codes
+	 */
+	public function test_backup_codes_generate_rejects_negative_count() {
+		$message = $this->assert_command_aborts(
+			function () {
+				$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => -5 ) );
+			}
+		);
+
+		$this->assertStringContainsString( 'Invalid value for --count', $message );
+		$this->assertSame( 0, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
+	}
+
+	/**
 	 * Regenerating replaces the previous set of codes.
 	 *
 	 * @covers Two_Factor_CLI_Command::backup_codes

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -464,7 +464,8 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 			}
 		);
 
-		// Provider remains enabled because the prompt was declined.
+		// The prompt was shown, and the provider remains enabled because it was declined.
+		$this->assertNotEmpty( WP_CLI::get_logs( 'confirm' ), 'Expected a confirmation prompt without --yes.' );
 		$this->assertContains( 'Two_Factor_Totp', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
 	}
 
@@ -573,6 +574,7 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 			}
 		);
 
+		$this->assertNotEmpty( WP_CLI::get_logs( 'confirm' ), 'Expected a confirmation prompt without --yes.' );
 		$this->assertContains( 'Two_Factor_Email', Two_Factor_Core::get_enabled_providers_for_user( $this->user ) );
 	}
 

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -432,9 +432,10 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	public function test_disable_single_totp_clears_stored_secret() {
 		$this->enable_provider( 'Two_Factor_Totp' );
 		$totp = Two_Factor_Totp::get_instance();
+		$key  = Two_Factor_Totp::generate_key();
 
-		$this->assertTrue( $totp->set_user_totp_key( $this->user->ID, Two_Factor_Totp::generate_key() ) );
-		$this->assertNotSame( '', $totp->get_user_totp_key( $this->user->ID ) );
+		$this->assertNotFalse( $totp->set_user_totp_key( $this->user->ID, $key ) );
+		$this->assertSame( $key, $totp->get_user_totp_key( $this->user->ID ) );
 
 		$this->command->disable( array( 'cli_test_user', 'Two_Factor_Totp' ), array( 'yes' => true ) );
 

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -750,8 +750,8 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 		$this->command->backup_codes(
 			array( 'generate', 'cli_test_user' ),
 			array(
-			'count' => 3,
-			'yes'   => true,
+				'count' => 3,
+				'yes'   => true,
 			)
 		);
 

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -747,7 +747,13 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	 */
 	public function test_backup_codes_generate_replaces_existing() {
 		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 8 ) );
-		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 3, 'yes' => true ) );
+		$this->command->backup_codes(
+		array( 'generate', 'cli_test_user' ),
+		array(
+			'count' => 3,
+			'yes'   => true,
+		)
+	);
 
 		$this->assertSame( 3, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
 	}

--- a/tests/cli/class-two-factor-cli-command.php
+++ b/tests/cli/class-two-factor-cli-command.php
@@ -748,12 +748,12 @@ class Tests_Two_Factor_CLI_Command extends WP_UnitTestCase {
 	public function test_backup_codes_generate_replaces_existing() {
 		$this->command->backup_codes( array( 'generate', 'cli_test_user' ), array( 'count' => 8 ) );
 		$this->command->backup_codes(
-		array( 'generate', 'cli_test_user' ),
-		array(
+			array( 'generate', 'cli_test_user' ),
+			array(
 			'count' => 3,
 			'yes'   => true,
-		)
-	);
+			)
+		);
 
 		$this->assertSame( 3, Two_Factor_Backup_Codes::codes_remaining_for_user( $this->user ) );
 	}

--- a/tests/cli/class-wp-cli-command.php
+++ b/tests/cli/class-wp-cli-command.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Stub of the WP-CLI base command class for the PHPUnit environment.
+ *
+ * The WP-CLI runtime is not loaded during PHPUnit runs, so this empty stub lets
+ * `Two_Factor_CLI_Command extends WP_CLI_Command` load.
+ *
+ * @package Two_Factor
+ */
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	/**
+	 * Minimal stand-in for the real WP_CLI_Command base class.
+	 */
+	class WP_CLI_Command {}
+}

--- a/tests/cli/class-wp-cli-mock-exit-exception.php
+++ b/tests/cli/class-wp-cli-mock-exit-exception.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Exception used by the WP-CLI test double to stand in for a process exit.
+ *
+ * @package Two_Factor
+ */
+
+if ( ! class_exists( 'WP_CLI_Mock_Exit_Exception' ) ) {
+	/**
+	 * Thrown by the mocked WP_CLI::error() and WP_CLI::confirm() so tests can
+	 * assert on the "exit" behaviour instead of the process actually terminating.
+	 */
+	class WP_CLI_Mock_Exit_Exception extends Exception {}
+}

--- a/tests/cli/class-wp-cli.php
+++ b/tests/cli/class-wp-cli.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Test double for the WP-CLI facade class.
+ *
+ * Captures output into WP_CLI::$logger so tests can assert on it, throws from
+ * error()/confirm() to mimic a process exit, and otherwise no-ops. Only the
+ * surface used by Two_Factor_CLI_Command is implemented.
+ *
+ * @package Two_Factor
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	/**
+	 * Minimal stand-in for the real WP_CLI class.
+	 */
+	class WP_CLI {
+
+		/**
+		 * Ordered list of captured messages.
+		 *
+		 * Each entry has a `level` key (log|success|warning|error|confirm|format)
+		 * plus level-specific data.
+		 *
+		 * @var array
+		 */
+		public static $logger = array();
+
+		/**
+		 * Reset the captured output between tests.
+		 */
+		public static function reset() {
+			self::$logger = array();
+		}
+
+		/**
+		 * Record an informational message.
+		 *
+		 * @param string $message Message text.
+		 */
+		public static function log( $message ) {
+			self::$logger[] = array(
+				'level'   => 'log',
+				'message' => $message,
+			);
+		}
+
+		/**
+		 * Record a success message.
+		 *
+		 * @param string $message Message text.
+		 */
+		public static function success( $message ) {
+			self::$logger[] = array(
+				'level'   => 'success',
+				'message' => $message,
+			);
+		}
+
+		/**
+		 * Record a warning message.
+		 *
+		 * @param string $message Message text.
+		 */
+		public static function warning( $message ) {
+			self::$logger[] = array(
+				'level'   => 'warning',
+				'message' => $message,
+			);
+		}
+
+		/**
+		 * Record an error message and, by default, abort like the real WP_CLI::error().
+		 *
+		 * @param string $message   Message text.
+		 * @param bool   $exit_flag Whether to throw to mimic a process exit.
+		 *
+		 * @throws WP_CLI_Mock_Exit_Exception When $exit_flag is true.
+		 */
+		public static function error( $message, $exit_flag = true ) {
+			self::$logger[] = array(
+				'level'   => 'error',
+				'message' => $message,
+			);
+
+			if ( $exit_flag ) {
+				$text = is_array( $message ) ? implode( "\n", $message ) : (string) $message;
+				throw new WP_CLI_Mock_Exit_Exception( $text ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Test double; message is not rendered to a browser.
+			}
+		}
+
+		/**
+		 * Mimic WP_CLI::confirm(): proceed when --yes is set, otherwise abort.
+		 *
+		 * @param string $question   Confirmation prompt.
+		 * @param array  $assoc_args Associative CLI args.
+		 *
+		 * @throws WP_CLI_Mock_Exit_Exception When --yes is not present.
+		 */
+		public static function confirm( $question, $assoc_args = array() ) {
+			self::$logger[] = array(
+				'level'   => 'confirm',
+				'message' => $question,
+			);
+
+			if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'yes' ) ) {
+				return;
+			}
+
+			throw new WP_CLI_Mock_Exit_Exception( 'confirmation declined' );
+		}
+
+		/**
+		 * No-op command registration used by the plugin bootstrap.
+		 *
+		 * @param string $name    Command name.
+		 * @param mixed  $handler Command handler.
+		 * @param array  $args    Registration args.
+		 */
+		public static function add_command( $name, $handler, $args = array() ) {}
+
+		/**
+		 * Return the captured messages, optionally filtered by level.
+		 *
+		 * @param string|null $level Optional level filter.
+		 * @return array
+		 */
+		public static function get_logs( $level = null ) {
+			if ( null === $level ) {
+				return self::$logger;
+			}
+
+			return array_values(
+				array_filter(
+					self::$logger,
+					function ( $entry ) use ( $level ) {
+						return $entry['level'] === $level;
+					}
+				)
+			);
+		}
+	}
+}

--- a/tests/cli/wp-cli-utils.php
+++ b/tests/cli/wp-cli-utils.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Test doubles for the WP_CLI\Utils helper functions.
+ *
+ * Provides just the two helpers used by Two_Factor_CLI_Command. Kept in a
+ * dedicated namespaced file so the fully-qualified `WP_CLI\Utils\...` calls in
+ * the command resolve during PHPUnit runs.
+ *
+ * @package Two_Factor
+ */
+
+namespace WP_CLI\Utils;
+
+if ( ! function_exists( 'WP_CLI\Utils\get_flag_value' ) ) {
+	/**
+	 * Read an associative flag with a fallback default.
+	 *
+	 * @param array  $assoc_args Associative CLI args.
+	 * @param string $flag       Flag name.
+	 * @param mixed  $fallback   Value to return when the flag is absent.
+	 * @return mixed
+	 */
+	function get_flag_value( $assoc_args, $flag, $fallback = null ) {
+		return isset( $assoc_args[ $flag ] ) ? $assoc_args[ $flag ] : $fallback;
+	}
+}
+
+if ( ! function_exists( 'WP_CLI\Utils\format_items' ) ) {
+	/**
+	 * Capture a formatted-items request for assertions.
+	 *
+	 * @param string $format Output format (table|json|csv|yaml).
+	 * @param array  $items  Row data.
+	 * @param array  $fields Field list.
+	 */
+	function format_items( $format, $items, $fields ) {
+		\WP_CLI::$logger[] = array(
+			'level'  => 'format',
+			'format' => $format,
+			'items'  => $items,
+			'fields' => $fields,
+		);
+	}
+}

--- a/two-factor.php
+++ b/two-factor.php
@@ -58,6 +58,11 @@ $two_factor_compat = new Two_Factor_Compat();
 
 Two_Factor_Core::add_hooks( $two_factor_compat );
 
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once TWO_FACTOR_DIR . 'cli/class-two-factor-cli-command.php';
+	WP_CLI::add_command( 'two-factor', 'Two_Factor_CLI_Command' );
+}
+
 // Delete our options and user meta during uninstall.
 register_uninstall_hook( __FILE__, array( Two_Factor_Core::class, 'uninstall' ) );
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -59,7 +59,7 @@ $two_factor_compat = new Two_Factor_Compat();
 Two_Factor_Core::add_hooks( $two_factor_compat );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once TWO_FACTOR_DIR . 'cli/class-two-factor-cli-command.php';
+	require_once TWO_FACTOR_DIR . 'CLI/class-two-factor-cli-command.php';
 	WP_CLI::add_command( 'two-factor', 'Two_Factor_CLI_Command' );
 }
 


### PR DESCRIPTION
## What?

Adds a `wp two-factor` WP-CLI namespace with six subcommands for inspecting and managing two-factor authentication on a per-user basis.

Fixes #233

## Why?

The plugin ships no WP-CLI commands today. This PR adds support for it.

## How?

- New file `cli/class-two-factor-cli-command.php` containing `Two_Factor_CLI_Command extends WP_CLI_Command`. Registered under `WP_CLI::add_command( 'two-factor', ... )` in the plugin bootstrap behind a `defined( 'WP_CLI' ) && WP_CLI` guard.
- New public static helper `Two_Factor_Core::clear_login_rate_limit( $user )` added to `class-two-factor-core.php`. Both the `disable` (full reset) and `unlock` commands call this single method rather than deleting the rate-limit meta keys at each call site.
- All commands are thin wrappers over the existing `Two_Factor_Core` and provider APIs — no raw SQL, no duplicated logic.

**Commands:**

| Command | Description |
|---|---|
| `wp two-factor status <user>` | Read-only status; honours `--format` |
| `wp two-factor disable <user> [<provider>]` | Full reset or single-provider disable; `--yes` skips prompt |
| `wp two-factor list-providers` | Lists all registered providers |
| `wp two-factor enable <user> <provider>` | Enables a provider; refuses secret-based providers with a pointer |
| `wp two-factor backup-codes generate <user> [--count=<n>]` | (Re)generates recovery codes via the provider API |
| `wp two-factor unlock <user>` | Clears login throttle without touching 2FA config |

All commands accept user by ID, login, or email. `disable` (full reset) asserts `get_available_providers_for_user()` is empty after clearing state, guarding against the fail-closed email fallback.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Full implementation of the CLI class, helper method, and bootstrap wiring, based on the given specification from my side. All generated code was reviewed and tested manually before submission.

## Testing Instructions

**Setup:** Activate the Two-Factor plugin. Create a test user and enable at least one 2FA provider (TOTP or Email) via their profile page.

1. **Registration**
   - `wp help two-factor` — confirm all six subcommands are listed
   - `wp help two-factor disable` — confirm OPTIONS and EXAMPLES are shown

2. **User resolution**
   - `wp two-factor status 1` — resolves by numeric ID
   - `wp two-factor status <login>` — resolves by login
   - `wp two-factor status <email>` — resolves by email
   - `wp two-factor status nobody` — prints `Error: User not found: nobody`

3. **`status`**
   - Run against a user with no 2FA → `using_2fa` is `false`
   - Run against a user with TOTP + backup codes → correct providers and code count
   - `--format=json` returns valid JSON

4. **`list-providers`**
   - Lists Email, TOTP, Backup Codes; Dummy absent when `WP_DEBUG` is off
   - `--format=json` works

5. **`disable` — full reset**
   - `wp two-factor disable <user>` → prompts for confirmation
   - `wp two-factor disable <user> --yes` → no prompt; `status` shows `using_2fa: false`
   - User can now log in with password only (no 2FA challenge)
   - Running again on the same user → "already disabled — no changes made"
   - **Fail-closed guard:** manually set `_two_factor_enabled_providers` in the DB to a non-existent class name, then run `disable --yes` — command should succeed and not leave email 2FA active

6. **`disable` — single provider**
   - `wp two-factor disable <user> Two_Factor_Totp` → only TOTP removed; backup codes still appear in `status`
   - Run same command again → "not enabled — no changes made"

7. **`enable`**
   - `wp two-factor enable <user> Two_Factor_Email` → success; appears in `status`
   - `wp two-factor enable <user> Two_Factor_Totp` → error referencing profile page
   - `wp two-factor enable <user> Two_Factor_Backup_Codes` → error pointing to `backup-codes generate`
   - `wp two-factor enable <user> FakeClass` → error "Is it a registered provider?"

8. **`backup-codes generate`**
   - `wp two-factor backup-codes generate <user>` → prints 10 codes
   - `--count=5` → prints exactly 5 codes
   - Running again replaces the previous set

9. **`unlock`**
   - Trigger rate-limit with repeated bad login attempts, then `wp two-factor unlock <user>` → "Login throttle cleared"
   - On a non-rate-limited user → "was not rate-limited — no changes made"
   - After unlock: user can attempt login immediately without waiting

## Screenshots or screencast
N/A — CLI only, no UI changes.

## Changelog Entry
Added - WP-CLI `wp two-factor` commands for per-user 2FA status, disable, enable, backup-code generation, and login-throttle reset.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22233-add-wpcli-foundation%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->