### PR TITLE
#906: add early notice for soon exhausting recovery codes

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -29,6 +29,14 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	const NUMBER_OF_CODES = 10;
 
 	/**
+	 * The default number of remaining codes at or below which the user is
+	 * warned to regenerate, before they run out entirely.
+	 *
+	 * @type int
+	 */
+	const LOW_CODES_THRESHOLD = 2;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @since 0.1-dev
@@ -97,7 +105,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	}
 
 	/**
-	 * Displays an admin notice when backup codes have run out.
+	 * Displays an admin notice when backup codes have run out, or are running low.
 	 *
 	 * @since 0.1-dev
 	 *
@@ -111,28 +119,70 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 			return;
 		}
 
-		// Return if we are not out of codes.
-		if ( $this->is_available_for_user( $user ) ) {
+		$count          = self::codes_remaining_for_user( $user );
+		$regenerate_url = esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' );
+
+		// Out of codes: show an error and bail.
+		if ( 0 === $count ) {
+			?>
+			<div class="error">
+				<p>
+					<span>
+						<?php
+						echo wp_kses(
+							sprintf(
+							/* translators: %s: URL for code regeneration */
+								__( 'Two-Factor: You are out of recovery codes and need to <a href="%s">regenerate!</a>', 'two-factor' ),
+								$regenerate_url
+							),
+							array( 'a' => array( 'href' => true ) )
+						);
+						?>
+					</span>
+				</p>
+			</div>
+			<?php
 			return;
 		}
-		?>
-		<div class="error">
-			<p>
-				<span>
-					<?php
-					echo wp_kses(
-						sprintf(
-						/* translators: %s: URL for code regeneration */
-							__( 'Two-Factor: You are out of recovery codes and need to <a href="%s">regenerate!</a>', 'two-factor' ),
-							esc_url( get_edit_user_link( $user->ID ) . '#two-factor-backup-codes' )
-						),
-						array( 'a' => array( 'href' => true ) )
-					);
-					?>
-				</span>
-			</p>
-		</div>
-		<?php
+
+		/**
+		 * Filters the number of remaining recovery codes at or below which the
+		 * user is warned to regenerate, before they run out entirely.
+		 *
+		 * @since 0.17.0
+		 *
+		 * @param int     $threshold Number of remaining codes that triggers the warning. Default 2.
+		 * @param WP_User $user      User object.
+		 */
+		$threshold = (int) apply_filters( 'two_factor_backup_codes_low_threshold', self::LOW_CODES_THRESHOLD, $user );
+
+		// Running low: warn the user before they hit zero.
+		if ( $count <= $threshold ) {
+			?>
+			<div class="notice notice-warning">
+				<p>
+					<span>
+						<?php
+						echo wp_kses(
+							sprintf(
+							/* translators: 1: number of recovery codes remaining, 2: URL for code regeneration */
+								_n(
+									'Two-Factor: You only have %1$s recovery code left. <a href="%2$s">Regenerate your codes</a> now before you run out.',
+									'Two-Factor: You only have %1$s recovery codes left. <a href="%2$s">Regenerate your codes</a> now before you run out.',
+									$count,
+									'two-factor'
+								),
+								number_format_i18n( $count ),
+								$regenerate_url
+							),
+							array( 'a' => array( 'href' => true ) )
+						);
+						?>
+					</span>
+				</p>
+			</div>
+			<?php
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What?

Adds a proactive "running low on Recovery Codes" admin notice that appears **before** a user exhausts their codes, rather than only warning them once they are completely out. While more than the threshold of codes remain, nothing shows; at or below the threshold (default 2) a dismissible-styled warning appears; at zero the existing error notice still shows.

Fixes #906 

## Why?

Today `Two_Factor_Backup_Codes::admin_notices()` only surfaces a notice **after** the user has used their last Recovery Code (balance = 0). By then the user has already lost their self-service path back into the account. There is no earlier nudge to regenerate, so it is easy to drift down to zero unnoticed and get locked out.

This closes **gap #5** in the account-recovery roadmap (`account-recovery-future-improvements.md`) and is the low-balance-warning half of **item C / Phase 1** in that document. It strengthens the one self-service recovery path users already have, without adding any new bypass or attack surface.

Related discussion:
- WordPress/two-factor#621 — Account recovery after losing 2FA key
- WordPress/two-factor#476 — Notify users on sensitive events

## How?

`admin_notices()` was restructured from a single zero-codes check into three states, keyed on `codes_remaining_for_user()`:

| Recovery Codes remaining | Notice | CSS class |
| --- | --- | --- |
| more than threshold | none | — |
| 1 – threshold (default 2) | warning — running low | `notice notice-warning` |
| 0 | error — out of codes (existing) | `error` |

- A new `LOW_CODES_THRESHOLD` constant (default `2`) sets the warning point.
- A new `two_factor_backup_codes_low_threshold` filter lets operators tune it per-site (receives the count and the `WP_User`). The name follows the existing internal `two_factor_backup_code_length` convention.
- The warning message is translatable and uses `_n()` for singular/plural ("1 recovery code" vs "2 recovery codes"), with the count run through `number_format_i18n()`.
- The existing "provider not enabled" early-return guard is unchanged, so notices only show when the Recovery Codes provider is active for the current user.
- All links point to `/wp-admin/profile.php#two-factor-backup-codes`, matching the existing notice.

Behaviour by state:

- More than two Recovery Codes left — no notice.

- Two Recovery Codes left
<img width="1895" height="587" alt="image" src="https://github.com/user-attachments/assets/ab88f0eb-c690-4531-b4da-9b5b8ca2d67f" />

- One Recovery Code left
<img width="1661" height="768" alt="image" src="https://github.com/user-attachments/assets/64a5eb77-5f6f-4281-aa6b-d6857446cc1f" />

- No Recovery Codes left, permanent error (even when logging in over another method)
<img width="1500" height="764" alt="image" src="https://github.com/user-attachments/assets/88b846fc-8e71-4aa7-8203-243e77f51a7b" />

Link goes to `/wp-admin/profile.php#two-factor-backup-codes`.

## Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Drafting the issue/PR text and the initial implementation of the low-balance notice. Final implementation and wording were reviewed and edited by me.

## Testing Instructions

1. Enable the Recovery Codes provider for your user and generate a set of codes.
2. Use Recovery Codes at login until **more than 2** remain — confirm **no** notice appears in wp-admin.
3. Continue until exactly **2** remain — confirm the yellow "running low" warning appears with the correct count and a working "Regenerate your codes" link to `profile.php#two-factor-backup-codes`.
4. Continue until **1** remains — confirm the warning shows the singular "1 recovery code left".
5. Use the last code so **0** remain — confirm the existing red error notice appears instead.
6. (Optional) Add `add_filter( 'two_factor_backup_codes_low_threshold', fn() => 5 );` and confirm the warning now triggers at 5 or fewer codes.
7. Confirm no notice appears for a user who does not have the Recovery Codes provider enabled.


## Changelog Entry

> Added - Admin notice that warns users when their Recovery Codes are running low, before they run out, with a `two_factor_backup_codes_low_threshold` filter to tune the threshold.
