### PR TITLE
Add Playground PR preview workflows

### DIFF
--- a/.github/workflows/pr-playground-preview-publish.yml
+++ b/.github/workflows/pr-playground-preview-publish.yml
@@ -1,0 +1,42 @@
+name: PR Playground Preview Publish
+
+on:
+  workflow_run:
+    workflows:
+      - PR Playground Preview Build
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-publish.yml@v3
+    with:
+      blueprint: |
+        {
+          "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+          "landingPage": "/wp-admin/options-general.php?page=two-factor-settings",
+          "steps": [
+            {
+              "step": "login",
+              "username": "admin",
+              "password": "password"
+            },
+            {
+              "step": "installPlugin",
+              "pluginZipFile": {
+                "resource": "url",
+                "url": "{{ARTIFACT_URL:two-factor}}"
+              },
+              "options": { "activate": true }
+            }
+          ]
+        }

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -1,0 +1,26 @@
+name: PR Playground Preview Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-build.yml@v3
+    with:
+      artifacts: two-factor=build/two-factor.zip
+      node-version: '20'
+      php-version: '8.3'
+      build-command: |
+        set -euo pipefail
+        npm ci
+        rm -rf build
+        npm run build
+        mkdir -p build/two-factor
+        rsync -a --delete dist/ build/two-factor/
+        ( cd build && zip -qr two-factor.zip two-factor )


### PR DESCRIPTION
## Summary

- Add fork-safe WordPress Playground PR Preview workflows for Two Factor pull requests.
- Build the plugin with the existing `npm run build` process, package `dist/` as a slug-shaped `two-factor.zip`, and publish a Playground preview button after the read-only build workflow succeeds.
- Use a custom Blueprint so the preview logs in and opens the Two Factor settings page.

## Why

Two Factor needs generated preview files because the release build copies the QR code dependency from `node_modules` into `dist/`. The two-workflow setup keeps pull request code in a read-only build workflow, then lets the trusted `workflow_run` publish workflow expose the ZIP and update the PR description.

## Testing

- Parsed both workflow files as YAML.
- Parsed the embedded Blueprint JSON.
- Ran `npm ci`.
- Ran the configured build/ZIP steps and verified `build/two-factor.zip` extracts to a single `two-factor/` directory.
- Ran `npm run lint:js`.
- Ran `npm run lint:css`.
- Ran `composer validate --strict`.
- Ran `composer lint-compat`.
- Ran `composer lint-phpstan`.

PHPUnit was not run locally because `wp-env` could not connect to Docker in this environment.
