### PR TITLE
Add network-level provider settings for WordPress Multisite

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -38,6 +38,24 @@ class Two_Factor_Core {
 	const ENABLED_PROVIDERS_OPTION_KEY = 'two_factor_enabled_providers';
 
 	/**
+	 * The network-wide enabled providers option key.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @type string
+	 */
+	const ENABLED_PROVIDERS_NETWORK_OPTION_KEY = 'two_factor_network_enabled_providers';
+
+	/**
+	 * The network option key that controls whether subsites can override provider settings.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @type string
+	 */
+	const NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY = 'two_factor_network_allow_site_override';
+
+	/**
 	 * The user meta nonce key.
 	 *
 	 * @type string
@@ -203,6 +221,12 @@ class Two_Factor_Core {
 			self::ENABLED_PROVIDERS_OPTION_KEY,
 		);
 
+		// Network options are stored in sitemeta on Multisite and in wp_options on single-site.
+		$network_option_keys = array(
+			self::ENABLED_PROVIDERS_NETWORK_OPTION_KEY,
+			self::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY,
+		);
+
 		$providers = self::get_default_providers();
 
 		/** This filter is documented in the get_providers() method */
@@ -241,6 +265,12 @@ class Two_Factor_Core {
 		if ( ! empty( $option_keys ) ) {
 			foreach ( $option_keys as $option_key ) {
 				delete_option( $option_key );
+			}
+		}
+
+		if ( ! empty( $network_option_keys ) ) {
+			foreach ( $network_option_keys as $option_key ) {
+				delete_site_option( $option_key );
 			}
 		}
 
@@ -1186,7 +1216,7 @@ class Two_Factor_Core {
 
 			foreach ( $backup_providers as $backup_provider_key => $backup_provider ) {
 				$backup_link_args['provider'] = $backup_provider_key;
-				$links[] = array(
+				$links[]                      = array(
 					'url'   => self::login_url( $backup_link_args ),
 					'label' => $backup_provider->get_alternative_provider_label(),
 				);

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -167,6 +167,7 @@ class Two_Factor_Core {
 
 		// Add Settings link to plugin action links.
 		add_filter( 'plugin_action_links_' . plugin_basename( TWO_FACTOR_DIR . 'two-factor.php' ), array( __CLASS__, 'add_settings_action_link' ) );
+		add_filter( 'network_admin_plugin_action_links', array( __CLASS__, 'add_network_settings_action_link' ), 10, 4 );
 
 		$compat->init();
 	}
@@ -428,7 +429,11 @@ class Two_Factor_Core {
 	 * @return string[] Modified array with the User Settings link added.
 	 */
 	public static function add_settings_action_link( $links ) {
-		$plugin_settings_url  = admin_url( 'options-general.php?page=two-factor-settings' );
+		if ( two_factor_is_network_mode() && current_user_can( 'manage_network_options' ) ) {
+			$plugin_settings_url = network_admin_url( 'settings.php?page=two-factor-network-settings' );
+		} else {
+			$plugin_settings_url = admin_url( 'options-general.php?page=two-factor-settings' );
+		}
 		$plugin_settings_link = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( $plugin_settings_url ),
@@ -450,6 +455,38 @@ class Two_Factor_Core {
 		}
 
 		return $links;
+	}
+
+	/**
+	 * Add Network Settings link to plugin action links on the Network Admin plugins screen.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @param string[] $actions     An array of plugin action links.
+	 * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+	 * @param array    $plugin_data An array of plugin data. Unused.
+	 * @param string   $context     The plugin context status. Unused.
+	 * @return string[] Modified array with the Network Settings link added.
+	 */
+	public static function add_network_settings_action_link( $actions, $plugin_file, $plugin_data, $context ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( plugin_basename( TWO_FACTOR_DIR . 'two-factor.php' ) !== $plugin_file ) {
+			return $actions;
+		}
+
+		if ( ! two_factor_is_network_mode() || ! current_user_can( 'manage_network_options' ) ) {
+			return $actions;
+		}
+
+		$network_settings_url = network_admin_url( 'settings.php?page=two-factor-network-settings' );
+		$settings_link        = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( $network_settings_url ),
+			esc_html__( 'Plugin Settings', 'two-factor' )
+		);
+
+		array_unshift( $actions, $settings_link );
+
+		return $actions;
 	}
 
 	/**

--- a/settings/class-two-factor-network-settings.php
+++ b/settings/class-two-factor-network-settings.php
@@ -57,10 +57,14 @@ class Two_Factor_Network_Settings {
 				)
 			);
 
-			update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, $enabled );
-			update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, ! empty( $_POST['two_factor_network_allow_site_override'] ) ? 1 : 0 );
+			if ( empty( $enabled ) ) {
+				echo '<div class="notice notice-error inline"><p>' . esc_html__( 'At least one provider must be enabled at the network level. No changes were saved.', 'two-factor' ) . '</p></div>';
+			} else {
+				update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, $enabled );
+				update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, ! empty( $_POST['two_factor_network_allow_site_override'] ) ? 1 : 0 );
 
-			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
+				echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
+			}
 		}
 
 		// Default to all providers enabled when the option has never been saved.

--- a/settings/class-two-factor-network-settings.php
+++ b/settings/class-two-factor-network-settings.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Network Admin settings UI for the Two-Factor plugin.
+ * Provides a network-wide settings screen for disabling individual Two-Factor
+ * providers and controlling whether subsites may override the network list.
+ *
+ * @since 0.17.0
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Network settings screen renderer for Two-Factor.
+ *
+ * @since 0.17.0
+ */
+class Two_Factor_Network_Settings {
+
+	/**
+	 * Render the network settings page.
+	 * Also handles saving of settings when the form is submitted.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @return void
+	 */
+	public static function render_settings_page() {
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			return;
+		}
+
+		// Build provider list for display and validation using public core API.
+		$provider_instances = array();
+		if ( class_exists( 'Two_Factor_Core' ) && method_exists( 'Two_Factor_Core', 'get_providers' ) ) {
+			$provider_instances = Two_Factor_Core::get_providers();
+			if ( ! is_array( $provider_instances ) ) {
+				$provider_instances = array();
+			}
+		}
+		$all_provider_keys = array_keys( $provider_instances );
+
+		// Handle save.
+		if ( isset( $_POST['two_factor_network_settings_submit'] ) ) {
+			check_admin_referer( 'two_factor_save_network_settings', 'two_factor_network_settings_nonce' );
+
+			$posted = isset( $_POST['two_factor_network_enabled_providers'] ) && is_array( $_POST['two_factor_network_enabled_providers'] ) ? wp_unslash( $_POST['two_factor_network_enabled_providers'] ) : array();
+
+			// Sanitize posted values immediately.
+			$posted = array_map( 'sanitize_text_field', (array) $posted );
+			// Remove empty values and keys that are not registered providers.
+			$enabled = array_values(
+				array_filter(
+					array_unique( $posted ),
+					function ( $key ) use ( $all_provider_keys ) {
+						return strlen( $key ) && in_array( $key, $all_provider_keys, true );
+					}
+				)
+			);
+
+			update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, $enabled );
+			update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, ! empty( $_POST['two_factor_network_allow_site_override'] ) ? 1 : 0 );
+
+			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
+		}
+
+		// Default to all providers enabled when the option has never been saved.
+		$saved_enabled  = get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, $all_provider_keys );
+		$allow_override = (bool) get_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, false );
+
+		echo '<div class="wrap two-factor-network-settings">';
+		echo '<h1>' . esc_html__( 'Two-Factor Network Settings', 'two-factor' ) . '</h1>';
+		echo '<h2>' . esc_html__( 'Enabled Providers', 'two-factor' ) . '</h2>';
+		echo '<p class="description">' . esc_html__( 'Choose which Two-Factor providers are available across the network. All providers are enabled by default.', 'two-factor' ) . '</p>';
+		echo '<form method="post" action="">';
+		wp_nonce_field( 'two_factor_save_network_settings', 'two_factor_network_settings_nonce' );
+
+		echo '<fieldset class="two-factor-providers"><legend class="screen-reader-text">' . esc_html__( 'Providers', 'two-factor' ) . '</legend>';
+		echo '<table class="form-table"><tbody>';
+
+		if ( empty( $provider_instances ) ) {
+			echo '<tr><td>' . esc_html__( 'No providers found.', 'two-factor' ) . '</td></tr>';
+		} else {
+			// Render a compact stacked list of provider checkboxes below the title/description.
+			echo '<tr>';
+			echo '<td>';
+			foreach ( $provider_instances as $provider_key => $instance ) {
+				$label = method_exists( $instance, 'get_label' ) ? $instance->get_label() : $provider_key;
+
+				echo '<p class="provider-item"><label for="network_provider_' . esc_attr( $provider_key ) . '">';
+				echo '<input type="checkbox" name="two_factor_network_enabled_providers[]" id="network_provider_' . esc_attr( $provider_key ) . '" value="' . esc_attr( $provider_key ) . '" ' . checked( in_array( $provider_key, (array) $saved_enabled, true ), true, false ) . ' /> ';
+				echo esc_html( $label );
+				echo '</label></p>';
+			}
+
+			echo '</td>';
+			echo '</tr>';
+		}
+
+		echo '</tbody></table>';
+		echo '</fieldset>';
+
+		echo '<h2>' . esc_html__( 'Subsite Override', 'two-factor' ) . '</h2>';
+		echo '<table class="form-table"><tbody><tr><td>';
+		echo '<p class="provider-item"><label for="two_factor_network_allow_site_override">';
+		echo '<input type="checkbox" name="two_factor_network_allow_site_override" id="two_factor_network_allow_site_override" value="1" ' . checked( $allow_override, true, false ) . ' /> ';
+		echo esc_html__( 'Allow subsites to override the network provider list', 'two-factor' );
+		echo '</label></p>';
+		echo '<p class="description">' . esc_html__( 'When enabled, a subsite can only narrow the network list. Subsites cannot enable providers that are disabled here.', 'two-factor' ) . '</p>';
+		echo '</td></tr></tbody></table>';
+
+		submit_button( __( 'Save Settings', 'two-factor' ), 'primary', 'two_factor_network_settings_submit' );
+		echo '</form>';
+
+		echo '</div>';
+	}
+}

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -28,23 +28,7 @@ class Two_Factor_Settings {
 			return;
 		}
 
-		// Handle save.
-		if ( isset( $_POST['two_factor_settings_submit'] ) ) {
-			check_admin_referer( 'two_factor_save_settings', 'two_factor_settings_nonce' );
-
-			$posted = isset( $_POST['two_factor_enabled_providers'] ) && is_array( $_POST['two_factor_enabled_providers'] ) ? wp_unslash( $_POST['two_factor_enabled_providers'] ) : array();
-
-			// Sanitize posted values immediately.
-			$posted = array_map( 'sanitize_text_field', (array) $posted );
-			// Remove empty values.
-			$enabled = array_values( array_filter( $posted, 'strlen' ) );
-
-			update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array_values( array_unique( $enabled ) ) );
-
-			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
-		}
-
-		// Build provider list for display using public core API.
+		// Build provider list for display and validation using public core API.
 		$provider_instances = array();
 		if ( class_exists( 'Two_Factor_Core' ) && method_exists( 'Two_Factor_Core', 'get_providers' ) ) {
 			$provider_instances = Two_Factor_Core::get_providers();
@@ -52,17 +36,75 @@ class Two_Factor_Settings {
 				$provider_instances = array();
 			}
 		}
-
-		// Default to all providers enabled when the option has never been saved.
 		$all_provider_keys = array_keys( $provider_instances );
-		$saved_enabled     = get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, $all_provider_keys );
+
+		// Determine whether the site is operating under a network-level policy.
+		$network_enabled  = null;
+		$network_override = false;
+		if ( function_exists( 'two_factor_is_network_mode' ) && two_factor_is_network_mode() ) {
+			$network_enabled = get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, null );
+			if ( null !== $network_enabled ) {
+				$network_override = (bool) get_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, false );
+			}
+		}
+		$network_managed = null !== $network_enabled && ! $network_override;
+
+		// Handle save. Site-level values are only meaningful when the network
+		// allows subsite overrides or when the network has not configured a list.
+		if ( ! $network_managed && isset( $_POST['two_factor_settings_submit'] ) ) {
+			check_admin_referer( 'two_factor_save_settings', 'two_factor_settings_nonce' );
+
+			$posted = isset( $_POST['two_factor_enabled_providers'] ) && is_array( $_POST['two_factor_enabled_providers'] ) ? wp_unslash( $_POST['two_factor_enabled_providers'] ) : array();
+
+			// Sanitize posted values immediately.
+			$posted = array_map( 'sanitize_text_field', (array) $posted );
+			// Remove empty values and keys that are not registered providers.
+			$enabled = array_values(
+				array_filter(
+					array_unique( $posted ),
+					function ( $key ) use ( $all_provider_keys ) {
+						return strlen( $key ) && in_array( $key, $all_provider_keys, true );
+					}
+				)
+			);
+
+			// When the network allows overrides, a subsite cannot expand beyond the network list.
+			if ( $network_override && is_array( $network_enabled ) ) {
+				$enabled = array_values( array_intersect( $enabled, $network_enabled ) );
+			}
+
+			update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, $enabled );
+
+			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
+		}
+
+		// Default to all providers enabled when the site option has never been saved.
+		$saved_enabled = get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, $all_provider_keys );
+		if ( $network_managed ) {
+			// Managed by network: show the network list, regardless of any stale site option.
+			$saved_enabled = $network_enabled;
+		} elseif ( $network_override && is_array( $network_enabled ) ) {
+			// Override allowed: show the effective intersection so disabled providers are unchecked.
+			$saved_enabled = array_values( array_intersect( (array) $saved_enabled, $network_enabled ) );
+		}
 
 		echo '<div class="wrap two-factor-settings">';
 		echo '<h1>' . esc_html__( 'Two-Factor Settings', 'two-factor' ) . '</h1>';
 		echo '<h2>' . esc_html__( 'Enabled Providers', 'two-factor' ) . '</h2>';
-		echo '<p class="description">' . esc_html__( 'Choose which Two-Factor providers are available on this site. All providers are enabled by default.', 'two-factor' ) . '</p>';
-		echo '<form method="post" action="">';
-		wp_nonce_field( 'two_factor_save_settings', 'two_factor_settings_nonce' );
+
+		if ( $network_managed ) {
+			echo '<div class="notice notice-info inline"><p>' . esc_html__( 'Provider settings are managed at the network level.', 'two-factor' ) . '</p></div>';
+			echo '<p class="description">' . esc_html__( 'The network administrator has chosen the providers available on this site.', 'two-factor' ) . '</p>';
+		} elseif ( $network_override ) {
+			echo '<div class="notice notice-info inline"><p>' . esc_html__( 'The network has enabled the following providers. This site can only narrow the list.', 'two-factor' ) . '</p></div>';
+		} else {
+			echo '<p class="description">' . esc_html__( 'Choose which Two-Factor providers are available on this site. All providers are enabled by default.', 'two-factor' ) . '</p>';
+		}
+
+		if ( ! $network_managed ) {
+			echo '<form method="post" action="">';
+			wp_nonce_field( 'two_factor_save_settings', 'two_factor_settings_nonce' );
+		}
 
 		echo '<fieldset class="two-factor-providers"><legend class="screen-reader-text">' . esc_html__( 'Providers', 'two-factor' ) . '</legend>';
 		echo '<table class="form-table"><tbody>';
@@ -74,10 +116,12 @@ class Two_Factor_Settings {
 			echo '<tr>';
 			echo '<td>';
 			foreach ( $provider_instances as $provider_key => $instance ) {
-				$label = method_exists( $instance, 'get_label' ) ? $instance->get_label() : $provider_key;
+				$label         = method_exists( $instance, 'get_label' ) ? $instance->get_label() : $provider_key;
+				$is_in_network = is_array( $network_enabled ) && in_array( $provider_key, $network_enabled, true );
+				$disabled      = $network_managed || ( $network_override && ! $is_in_network );
 
 				echo '<p class="provider-item"><label for="provider_' . esc_attr( $provider_key ) . '">';
-				echo '<input type="checkbox" name="two_factor_enabled_providers[]" id="provider_' . esc_attr( $provider_key ) . '" value="' . esc_attr( $provider_key ) . '" ' . checked( in_array( $provider_key, (array) $saved_enabled, true ), true, false ) . ' /> ';
+				echo '<input type="checkbox" ' . ( $network_managed ? '' : 'name="two_factor_enabled_providers[]" ' ) . 'id="provider_' . esc_attr( $provider_key ) . '" value="' . esc_attr( $provider_key ) . '" ' . checked( in_array( $provider_key, (array) $saved_enabled, true ), true, false ) . ( $disabled ? ' disabled="disabled"' : '' ) . ' /> ';
 				echo esc_html( $label );
 				echo '</label></p>';
 			}
@@ -89,8 +133,10 @@ class Two_Factor_Settings {
 		echo '</tbody></table>';
 		echo '</fieldset>';
 
-		submit_button( __( 'Save Settings', 'two-factor' ), 'primary', 'two_factor_settings_submit' );
-		echo '</form>';
+		if ( ! $network_managed ) {
+			submit_button( __( 'Save Settings', 'two-factor' ), 'primary', 'two_factor_settings_submit' );
+			echo '</form>';
+		}
 
 		echo '</div>';
 	}

--- a/tests/class-two-factor-network-settings.php
+++ b/tests/class-two-factor-network-settings.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Two Factor Network Settings Tests.
+ *
+ * @package Two_Factor
+ */
+
+/**
+ * Class Tests_Two_Factor_Network_Settings
+ *
+ * @package Two_Factor
+ * @group core
+ * @group network
+ */
+class Tests_Two_Factor_Network_Settings extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID for tests that render admin screens.
+	 *
+	 * @var int
+	 */
+	private $admin_user_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_user_id );
+	}
+
+	/**
+	 * Cleanup after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_set_current_user( 0 );
+
+		remove_filter( 'two_factor_network_mode', '__return_true' );
+		remove_filter( 'two_factor_network_mode', '__return_false' );
+
+		delete_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY );
+		delete_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY );
+		delete_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY );
+	}
+
+	/**
+	 * Render the site settings page without the provider-enforcement filter.
+	 *
+	 * @return string
+	 */
+	private function render_site_settings_page() {
+		remove_filter( 'two_factor_providers', 'two_factor_filter_enabled_providers' );
+		ob_start();
+		Two_Factor_Settings::render_settings_page();
+		$output = ob_get_clean();
+		add_filter( 'two_factor_providers', 'two_factor_filter_enabled_providers' );
+		return $output;
+	}
+
+	/**
+	 * Network mode is off by default in a single-site test environment.
+	 *
+	 * @covers two_factor_is_network_mode
+	 */
+	public function test_is_network_mode_false_by_default() {
+		$this->assertFalse( two_factor_is_network_mode() );
+	}
+
+	/**
+	 * The two_factor_network_mode filter can force network mode for tests.
+	 *
+	 * @covers two_factor_is_network_mode
+	 */
+	public function test_is_network_mode_true_with_filter() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		$this->assertTrue( two_factor_is_network_mode() );
+	}
+
+	/**
+	 * When no option is saved, the effective list is null (allow all providers).
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_returns_null_when_unsaved() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		$this->assertNull( two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * Site option is used when the plugin is not in network mode.
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_uses_site_option_when_not_network_mode() {
+		update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		$this->assertSame( array( 'Two_Factor_Email' ), two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * Site option remains effective when network mode is active but the network
+	 * option has never been saved.
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_uses_site_option_when_network_option_unsaved() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array( 'Two_Factor_Email', 'Two_Factor_Totp' ) );
+
+		$this->assertSame( array( 'Two_Factor_Email', 'Two_Factor_Totp' ), two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * Network option is the exact effective list when override is not allowed.
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_uses_network_option_when_no_override() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 0 );
+		update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array( 'Two_Factor_Totp' ) );
+
+		$this->assertSame( array( 'Two_Factor_Email' ), two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * When override is allowed, the effective list is the intersection of the
+	 * network and site lists.
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_intersects_when_override_allowed() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email', 'Two_Factor_Totp' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 1 );
+		update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array( 'Two_Factor_Totp', 'Two_Factor_Backup_Codes' ) );
+
+		$this->assertSame( array( 'Two_Factor_Totp' ), two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * When override is allowed but the subsite has never saved a list, the
+	 * network list is used.
+	 *
+	 * @covers two_factor_get_enabled_providers_option
+	 */
+	public function test_get_enabled_providers_option_uses_network_when_override_and_site_unsaved() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 1 );
+
+		$this->assertSame( array( 'Two_Factor_Email' ), two_factor_get_enabled_providers_option() );
+	}
+
+	/**
+	 * The registered providers filter enforces the network provider list.
+	 *
+	 * @covers two_factor_filter_enabled_providers
+	 */
+	public function test_filter_enabled_providers_enforces_network_option() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+
+		$providers = array(
+			'Two_Factor_Email'        => '/path/to/email.php',
+			'Two_Factor_Totp'         => '/path/to/totp.php',
+			'Two_Factor_Backup_Codes' => '/path/to/backup.php',
+		);
+		$filtered  = two_factor_filter_enabled_providers( $providers );
+
+		$this->assertSame( array( 'Two_Factor_Email' ), array_keys( $filtered ) );
+	}
+
+	/**
+	 * The per-user enabled providers filter enforces the network provider list.
+	 *
+	 * @covers two_factor_filter_enabled_providers_for_user
+	 */
+	public function test_filter_enabled_providers_for_user_enforces_network_option() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+
+		$user_enabled = array( 'Two_Factor_Email', 'Two_Factor_Totp' );
+		$filtered     = two_factor_filter_enabled_providers_for_user( $user_enabled, 0 );
+
+		$this->assertSame( array( 'Two_Factor_Email' ), $filtered );
+	}
+
+	/**
+	 * Plugin uninstall removes network options.
+	 *
+	 * @covers Two_Factor_Core::uninstall
+	 */
+	public function test_uninstall_removes_network_options() {
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 1 );
+
+		$this->assertSame(
+			array( 'Two_Factor_Email' ),
+			get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY ),
+			'Network enabled providers option was set'
+		);
+		$this->assertSame(
+			1,
+			get_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY ),
+			'Network override option was set'
+		);
+
+		Two_Factor_Core::uninstall();
+
+		$this->assertFalse(
+			get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, false ),
+			'Network enabled providers option was deleted during uninstall'
+		);
+		$this->assertFalse(
+			get_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, false ),
+			'Network override option was deleted during uninstall'
+		);
+	}
+
+	/**
+	 * Site settings page shows a network-managed notice when network override is disabled.
+	 *
+	 * @covers Two_Factor_Settings::render_settings_page
+	 */
+	public function test_site_settings_page_shows_network_managed_notice() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 0 );
+
+		$output = $this->render_site_settings_page();
+
+		$this->assertStringContainsString( 'Provider settings are managed at the network level.', $output );
+		$this->assertStringNotContainsString( 'name="two_factor_settings_submit"', $output );
+		$this->assertStringContainsString( 'disabled="disabled"', $output );
+	}
+
+	/**
+	 * Site settings page shows a narrowing notice when network override is enabled.
+	 *
+	 * @covers Two_Factor_Settings::render_settings_page
+	 */
+	public function test_site_settings_page_shows_override_notice() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 1 );
+
+		$output = $this->render_site_settings_page();
+
+		$this->assertStringContainsString( 'The network has enabled the following providers. This site can only narrow the list.', $output );
+		$this->assertStringContainsString( 'name="two_factor_settings_submit"', $output );
+		$this->assertStringContainsString( 'disabled="disabled"', $output );
+	}
+
+	/**
+	 * Site settings page remains editable when the network has not configured providers.
+	 *
+	 * @covers Two_Factor_Settings::render_settings_page
+	 */
+	public function test_site_settings_page_editable_when_network_unconfigured() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		// Intentionally not saving the network option.
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 0 );
+
+		$output = $this->render_site_settings_page();
+
+		$this->assertStringContainsString( 'Choose which Two-Factor providers are available on this site.', $output );
+		$this->assertStringContainsString( 'name="two_factor_settings_submit"', $output );
+		$this->assertStringNotContainsString( 'disabled="disabled"', $output );
+	}
+}

--- a/tests/class-two-factor-network-settings.php
+++ b/tests/class-two-factor-network-settings.php
@@ -29,6 +29,8 @@ class Tests_Two_Factor_Network_Settings extends WP_UnitTestCase {
 
 		$this->admin_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->admin_user_id );
+
+		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10, 4 );
 	}
 
 	/**
@@ -36,6 +38,8 @@ class Tests_Two_Factor_Network_Settings extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
+
+		remove_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10 );
 
 		wp_set_current_user( 0 );
 
@@ -45,6 +49,22 @@ class Tests_Two_Factor_Network_Settings extends WP_UnitTestCase {
 		delete_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY );
 		delete_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY );
 		delete_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY );
+	}
+
+	/**
+	 * Map manage_network_options to manage_options for the test admin in single-site.
+	 *
+	 * @param string[] $caps    Primitive caps required.
+	 * @param string   $cap     Capability being checked.
+	 * @param int      $user_id User ID.
+	 * @param array    $args    Extra args.
+	 * @return string[] Modified caps.
+	 */
+	public function filter_map_meta_cap( $caps, $cap, $user_id, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( 'manage_network_options' === $cap && $user_id === $this->admin_user_id ) {
+			return array( 'manage_options' );
+		}
+		return $caps;
 	}
 
 	/**
@@ -271,5 +291,66 @@ class Tests_Two_Factor_Network_Settings extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Choose which Two-Factor providers are available on this site.', $output );
 		$this->assertStringContainsString( 'name="two_factor_settings_submit"', $output );
 		$this->assertStringNotContainsString( 'disabled="disabled"', $output );
+	}
+
+	/**
+	 * Plugin Settings link points to the network settings page for network admins.
+	 *
+	 * @covers Two_Factor_Core::add_settings_action_link
+	 */
+	public function test_settings_action_link_points_to_network_settings_for_network_admin() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+
+		$links = Two_Factor_Core::add_settings_action_link( array() );
+
+		$this->assertStringContainsString( 'settings.php?page=two-factor-network-settings', $links[0] );
+		$this->assertStringNotContainsString( 'options-general.php?page=two-factor-settings', $links[0] );
+	}
+
+	/**
+	 * Plugin Settings link points to the site settings page for non-network admins.
+	 *
+	 * @covers Two_Factor_Core::add_settings_action_link
+	 */
+	public function test_settings_action_link_points_to_site_settings_for_non_network_admin() {
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		remove_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10 );
+
+		$links = Two_Factor_Core::add_settings_action_link( array() );
+
+		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10, 4 );
+
+		$this->assertStringContainsString( 'options-general.php?page=two-factor-settings', $links[0] );
+		$this->assertStringNotContainsString( 'settings.php?page=two-factor-network-settings', $links[0] );
+	}
+
+	/**
+	 * Empty network provider list is rejected and the existing option is preserved.
+	 *
+	 * @covers Two_Factor_Network_Settings::render_settings_page
+	 */
+	public function test_network_settings_empty_provider_list_not_saved() {
+		get_userdata( $this->admin_user_id )->add_cap( 'manage_network_options', true );
+
+		add_filter( 'two_factor_network_mode', '__return_true' );
+		update_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, array( 'Two_Factor_Email' ) );
+		update_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, 0 );
+
+		$_POST['two_factor_network_settings_submit']   = '1';
+		$_POST['two_factor_network_settings_nonce']    = wp_create_nonce( 'two_factor_save_network_settings' );
+		$_REQUEST['two_factor_network_settings_nonce'] = $_POST['two_factor_network_settings_nonce'];
+
+		ob_start();
+		Two_Factor_Network_Settings::render_settings_page();
+		$output = ob_get_clean();
+
+		unset( $_POST['two_factor_network_settings_submit'], $_POST['two_factor_network_settings_nonce'], $_REQUEST['two_factor_network_settings_nonce'] );
+
+		$this->assertSame(
+			array( 'Two_Factor_Email' ),
+			get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY ),
+			'Network provider list must not be changed when saving an empty list.'
+		);
+		$this->assertStringContainsString( 'At least one provider must be enabled at the network level.', $output );
 	}
 }

--- a/two-factor.php
+++ b/two-factor.php
@@ -51,8 +51,9 @@ require_once TWO_FACTOR_DIR . 'class-two-factor-core.php';
  */
 require_once TWO_FACTOR_DIR . 'class-two-factor-compat.php';
 
-// Load settings UI class so the settings page can be rendered.
+// Load settings UI classes so the settings pages can be rendered.
 require_once TWO_FACTOR_DIR . 'settings/class-two-factor-settings.php';
+require_once TWO_FACTOR_DIR . 'settings/class-two-factor-network-settings.php';
 
 $two_factor_compat = new Two_Factor_Compat();
 
@@ -69,6 +70,10 @@ register_uninstall_hook( __FILE__, array( Two_Factor_Core::class, 'uninstall' ) 
 function two_factor_register_admin_hooks() {
 	if ( is_admin() ) {
 		add_action( 'admin_menu', 'two_factor_add_settings_page' );
+	}
+
+	if ( two_factor_is_network_mode() ) {
+		add_action( 'network_admin_menu', 'two_factor_add_network_settings_page' );
 	}
 
 	// Load settings page assets when in admin.
@@ -98,6 +103,23 @@ function two_factor_add_settings_page() {
 
 
 /**
+ * Add the Two Factor network settings page under Network Admin Settings.
+ *
+ * @since 0.17.0
+ */
+function two_factor_add_network_settings_page() {
+	add_submenu_page(
+		'settings.php',
+		__( 'Two-Factor Settings', 'two-factor' ),
+		__( 'Two-Factor', 'two-factor' ),
+		'manage_network_options',
+		'two-factor-network-settings',
+		'two_factor_render_network_settings_page'
+	);
+}
+
+
+/**
  * Render the settings page via the settings class if available.
  *
  * @since 0.16
@@ -120,6 +142,54 @@ function two_factor_render_settings_page() {
 
 
 /**
+ * Render the network settings page via the network settings class if available.
+ *
+ * @since 0.17.0
+ */
+function two_factor_render_network_settings_page() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		return;
+	}
+
+	if ( class_exists( 'Two_Factor_Network_Settings' ) && is_callable( array( 'Two_Factor_Network_Settings', 'render_settings_page' ) ) ) {
+		Two_Factor_Network_Settings::render_settings_page();
+		return;
+	}
+
+	// Fallback: no UI available.
+	echo '<div class="wrap"><h1>' . esc_html__( 'Two-Factor Network Settings', 'two-factor' ) . '</h1>';
+	echo '<p>' . esc_html__( 'Settings not available.', 'two-factor' ) . '</p></div>';
+}
+
+
+/**
+ * Determine whether the plugin is running in network-activated mode on Multisite.
+ *
+ * @since 0.17.0
+ *
+ * @return bool
+ */
+function two_factor_is_network_mode() {
+	$network_mode = false;
+	if ( is_multisite() ) {
+		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$network_mode = is_plugin_active_for_network( plugin_basename( TWO_FACTOR_DIR . 'two-factor.php' ) );
+	}
+
+	/**
+	 * Filter whether the plugin is running in network-activated mode.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @param bool $network_mode Whether the plugin is network-activated.
+	 */
+	return (bool) apply_filters( 'two_factor_network_mode', $network_mode );
+}
+
+
+/**
  * Helper: retrieve the site-enabled providers option.
  * Returns null when the option has never been saved (meaning all providers are allowed).
  * Returns an array (possibly empty) when the admin has explicitly saved a selection.
@@ -128,7 +198,7 @@ function two_factor_render_settings_page() {
  *
  * @return array|null
  */
-function two_factor_get_enabled_providers_option() {
+function two_factor_get_site_enabled_providers_option() {
 	$enabled = get_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, null );
 	if ( null === $enabled ) {
 		return null; // Never saved — allow everything.
@@ -138,29 +208,69 @@ function two_factor_get_enabled_providers_option() {
 
 
 /**
- * Filter the registered providers to only those in the site-enabled list.
+ * Helper: retrieve the effective enabled providers list for the current context.
+ *
+ * In network-activated mode, the network option wins unless subsites are allowed
+ * to override. If override is allowed and the subsite has saved a list, the
+ * effective list is the intersection of the network and site lists (subsite can
+ * only narrow, never expand).
+ *
+ * @since 0.17.0
+ *
+ * @return array|null Array of allowed provider classnames, or null when no option has been saved.
+ */
+function two_factor_get_enabled_providers_option() {
+	$site_enabled = two_factor_get_site_enabled_providers_option();
+
+	if ( ! two_factor_is_network_mode() ) {
+		return $site_enabled;
+	}
+
+	$network_enabled = get_site_option( Two_Factor_Core::ENABLED_PROVIDERS_NETWORK_OPTION_KEY, null );
+	if ( null === $network_enabled ) {
+		return $site_enabled;
+	}
+
+	$network_enabled = is_array( $network_enabled ) ? $network_enabled : array();
+	$override        = (bool) get_site_option( Two_Factor_Core::NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY, false );
+
+	if ( ! $override ) {
+		return $network_enabled;
+	}
+
+	if ( null === $site_enabled ) {
+		return $network_enabled;
+	}
+
+	return array_values( array_intersect( $network_enabled, $site_enabled ) );
+}
+
+
+/**
+ * Filter the registered providers to only those in the effective enabled list.
  * This filter receives providers in core format: classname => path.
  *
  * @since 0.16
- * 
+ *
  * @param array $providers Registered providers in classname => path format.
  * @return array Filtered list of enabled providers.
  */
 function two_factor_filter_enabled_providers( $providers ) {
-	$site_enabled = two_factor_get_enabled_providers_option();
+	$enabled = two_factor_get_enabled_providers_option();
 
 	// null means the option was never saved — allow all providers.
-	if ( null === $site_enabled ) {
+	if ( null === $enabled ) {
 		return $providers;
 	}
 
-	// On the settings page itself, show all providers so admins can change the selection.
-	if ( is_admin() && isset( $_GET['page'] ) && 'two-factor-settings' === $_GET['page'] ) {
+	// On the settings pages, show all providers so admins can change the selection.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( is_admin() && isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'two-factor-settings', 'two-factor-network-settings' ), true ) ) {
 		return $providers;
 	}
 
 	foreach ( $providers as $key => $path ) {
-		if ( ! in_array( $key, $site_enabled, true ) ) {
+		if ( ! in_array( $key, $enabled, true ) ) {
 			unset( $providers[ $key ] );
 		}
 	}
@@ -170,21 +280,21 @@ function two_factor_filter_enabled_providers( $providers ) {
 
 
 /**
- * Filter enabled providers for a user (classnames array) to enforce the site-enabled list.
+ * Filter enabled providers for a user (classnames array) to enforce the effective enabled list.
  *
  * @since 0.16
  *
- * @param array $enabled  Enabled provider classnames for the user.
- * @param int   $user_id  ID of the user being filtered.
- * @return array Filtered list of provider classnames allowed by the site.
+ * @param array $enabled   Enabled provider classnames for the user.
+ * @param int   $user_id  ID of the user being filtered. Unused, but required by the filter signature.
+ * @return array Filtered list of provider classnames allowed by the site or network.
  */
-function two_factor_filter_enabled_providers_for_user( $enabled, $user_id ) {
-	$site_enabled = two_factor_get_enabled_providers_option();
+function two_factor_filter_enabled_providers_for_user( $enabled, $user_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	$allowed = two_factor_get_enabled_providers_option();
 
 	// null means the option was never saved — allow all.
-	if ( null === $site_enabled ) {
+	if ( null === $allowed ) {
 		return $enabled;
 	}
 
-	return array_values( array_intersect( (array) $enabled, $site_enabled ) );
+	return array_values( array_intersect( (array) $enabled, $allowed ) );
 }


### PR DESCRIPTION
## Summary

This PR adds a Network Admin settings page for Two-Factor provider configuration. When the plugin is network-activated, a Super Admin can choose which providers are available across the network and decide whether subsites may override that list. The change keeps the existing site-level settings screen intact for non-network mode or when no network policy is configured.

Fixes #894

## Changes

### `class-two-factor-core.php`
- Added network option constants: `ENABLED_PROVIDERS_NETWORK_OPTION_KEY` and `NETWORK_ALLOW_SITE_OVERRIDE_OPTION_KEY`.
- Extended `uninstall()` to delete the new network options with `delete_site_option()`.

### `two-factor.php`
- Added `two_factor_is_network_mode()` with a `two_factor_network_mode` filter so the network logic can be unit-tested without a Multisite install.
- Network settings page is registered under `network_admin_menu` only when the plugin is network-activated.
- Added `two_factor_get_site_enabled_providers_option()` and rewrote `two_factor_get_enabled_providers_option()` to return the effective provider list: network option first, with subsite intersection when override is allowed.
- Updated the provider and user-provider filters to use the effective list.

### `settings/class-two-factor-network-settings.php` (new)
- Network Admin settings page that saves provider list and the override toggle with nonces and capability checks.
- Provider keys are validated against the registered providers before being saved.

### `settings/class-two-factor-settings.php`
- When the network has taken over provider settings:
  - Override disabled: the page is read-only, shows a network-managed notice, and hides the Save button.
  - Override enabled: shows a narrowing notice and disables checkboxes for providers not enabled at the network level.
- When the network has not configured a policy, the page behaves as before.

### `tests/class-two-factor-network-settings.php` (new)
- Covers network mode detection, effective option logic, provider filtering, uninstall cleanup, and the site settings page read-only/override notices.

## Testing

**Test 1: Network-managed provider list**
1. Network-activate the plugin.
2. Go to Network Admin → Settings → Two-Factor.
3. Disable "Email Codes" and save.
4. On a subsite, edit a user profile.
5. Result: Email Codes is not available; TOTP and Backup Codes remain available.

**Test 2: Subsite override disabled**
1. On the network settings page, leave "Allow subsites to override" unchecked.
2. On a subsite, go to Settings → Two-Factor.
3. Result: a notice appears, all checkboxes are disabled, and the Save button is hidden.

**Test 3: Subsite override enabled**
1. On the network settings page, enable only Email and TOTP, and check "Allow subsites to override".
2. On a subsite, go to Settings → Two-Factor.
3. Result: Backup Codes is disabled/unchecked; the site can narrow the list to TOTP only.

**Automated tests**
```bash
npm run composer -- test
npm run lint:php
npm run lint:phpstan
```
All 203 tests pass, PHPStan reports no errors, and no new PHPCS errors are introduced in the changed files.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22fix%2F894-network-provider-settings%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->