### PR TITLE
Move rate-limit check before provider pre-processing, preserve email token

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1848,11 +1848,6 @@ class Two_Factor_Core {
 
 		// Rate limit two factor authentication attempts, including pre-processing (e.g. resend).
 		if ( true === self::is_user_rate_limited( $user ) ) {
-			// Invalidate any provider token to prevent reuse after rate limiting.
-			if ( method_exists( $provider, 'delete_token' ) ) {
-				$provider->delete_token( $user->ID );
-			}
-
 			$time_delay = self::get_user_time_delay( $user );
 			$last_login = get_user_meta( $user->ID, self::USER_RATE_LIMIT_KEY, true );
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1841,18 +1841,18 @@ class Two_Factor_Core {
 			);
 		}
 
-		// Allow the provider to re-send codes, etc.
-		if ( true === $provider->pre_process_authentication( $user ) ) {
-			return false;
-		}
-
 		// If it's not a POST request, there's no processing to perform.
 		if ( ! $is_post_request ) {
 			return false;
 		}
 
-		// Rate limit two factor authentication attempts.
+		// Rate limit two factor authentication attempts, including pre-processing (e.g. resend).
 		if ( true === self::is_user_rate_limited( $user ) ) {
+			// Invalidate any provider token to prevent reuse after rate limiting.
+			if ( method_exists( $provider, 'delete_token' ) ) {
+				$provider->delete_token( $user->ID );
+			}
+
 			$time_delay = self::get_user_time_delay( $user );
 			$last_login = get_user_meta( $user->ID, self::USER_RATE_LIMIT_KEY, true );
 
@@ -1864,6 +1864,11 @@ class Two_Factor_Core {
 					human_time_diff( $last_login + $time_delay )
 				)
 			);
+		}
+
+		// Allow the provider to re-send codes, etc.
+		if ( true === $provider->pre_process_authentication( $user ) ) {
+			return false;
 		}
 
 		// Ask the provider to verify the second factor.

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -782,7 +782,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$provider = Two_Factor_Email::get_instance();
 
 		$provider->generate_token( $user->ID );
-		$original_token = $provider->get_user_token( $user->ID );
 
 		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 1 );
 		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -818,11 +818,11 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
-		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated when rate limited' );
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token is preserved when rate limited to avoid triggering re-send on form re-render' );
 	}
 
 	/**
-	 * Test that switching providers while rate-limited invalidates email token.
+	 * Test that switching providers while rate-limited preserves the email token.
 	 *
 	 * If a user fails on TOTP triggering rate limiting, then switches back
 	 * to email, the rate-limit gate should invalidate the email token.
@@ -846,7 +846,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
-		$this->assertFalse( $email_provider->user_has_token( $user->ID ), 'Email token is invalidated when rate-limited via another provider' );
+		$this->assertTrue( $email_provider->user_has_token( $user->ID ), 'Email token is preserved when rate-limited via another provider' );
 	}
 
 	/**
@@ -898,7 +898,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
-		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated during rate-limited revalidation' );
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token is preserved during rate-limited revalidation' );
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -794,7 +794,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
-		$this->assertFalse( $provider->get_user_token( $user->ID ), 'Token is invalidated when rate limited' );
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token is preserved when resend is blocked, to prevent auto-send on form re-render' );
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -823,6 +823,86 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that switching providers while rate-limited invalidates email token.
+	 *
+	 * If a user fails on TOTP triggering rate limiting, then switches back
+	 * to email, the rate-limit gate should invalidate the email token.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_invalidates_email_token_on_provider_switch_while_rate_limited() {
+		$user          = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$email_provider = Two_Factor_Email::get_instance();
+
+		// Generate an email token.
+		$email_provider->generate_token( $user->ID );
+		$this->assertTrue( $email_provider->user_has_token( $user->ID ), 'Email token exists before TOTP failures' );
+
+		// Simulate rate-limited state from TOTP failures.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 5 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// User switches back to email provider while rate-limited.
+		$result = Two_Factor_Core::process_provider( $email_provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $email_provider->user_has_token( $user->ID ), 'Email token is invalidated when rate-limited via another provider' );
+	}
+
+	/**
+	 * Test that GET requests pass through without rate-limit side effects.
+	 *
+	 * Page reloads should not trigger rate limiting, token deletion, or
+	 * error messages — even when the user is rate-limited.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_get_request_bypasses_rate_limit() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before GET request' );
+
+		// Simulate a rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// GET request (is_post_request = false).
+		$result = Two_Factor_Core::process_provider( $provider, $user, false );
+
+		$this->assertFalse( $result, 'GET request returns false, not WP_Error' );
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token survives GET request while rate-limited' );
+	}
+
+	/**
+	 * Test that rate limiting applies during the revalidation flow.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_rate_limits_revalidation() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before revalidation' );
+
+		// Simulate rate-limited state from prior failures.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// Revalidation is also a POST through process_provider.
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated during rate-limited revalidation' );
+	}
+
+	/**
 	 * Test that the "invalid login attempts have occurred" login notice works as expected.
 	 *
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -773,6 +773,56 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that email resend requests are blocked while rate limited.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_blocks_email_resend_while_rate_limited() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+		$original_token = $provider->get_user_token( $user->ID );
+
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 1 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		$_REQUEST[ Two_Factor_Email::INPUT_NAME_RESEND_CODE ] = 1;
+
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		unset( $_REQUEST[ Two_Factor_Email::INPUT_NAME_RESEND_CODE ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->get_user_token( $user->ID ), 'Token is invalidated when rate limited' );
+	}
+
+	/**
+	 * Test that rate limiting invalidates the email token on validation attempts.
+	 *
+	 * @covers Two_Factor_Core::process_provider()
+	 */
+	public function test_process_provider_invalidates_email_token_when_rate_limited() {
+		$user     = $this->get_dummy_user( array( 'Two_Factor_Email' => 'Two_Factor_Email' ) );
+		$provider = Two_Factor_Email::get_instance();
+
+		$provider->generate_token( $user->ID );
+
+		$this->assertTrue( $provider->user_has_token( $user->ID ), 'Token exists before rate limiting' );
+
+		// Simulate a rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		$result = Two_Factor_Core::process_provider( $provider, $user, true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+		$this->assertFalse( $provider->user_has_token( $user->ID ), 'Token is invalidated when rate limited' );
+	}
+
+	/**
 	 * Test that the "invalid login attempts have occurred" login notice works as expected.
 	 *
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -496,6 +496,48 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify that a rate-limited POST does not trigger a new email when login_html()
+	 * re-renders the form via authentication_page().
+	 *
+	 * process_provider() blocks the attempt and returns WP_Error; login_html() then
+	 * calls authentication_page() to redisplay the form. If the token were deleted by
+	 * the rate-limit gate, authentication_page() would see no token and send a new email
+	 * on every blocked submission — recreating the flooding vector the rate-limit prevents.
+	 *
+	 * @covers Two_Factor_Email::authentication_page
+	 * @covers Two_Factor_Core::process_provider
+	 */
+	public function test_authentication_page_does_not_send_email_when_rate_limited() {
+		$user = self::factory()->user->create_and_get();
+		Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Email' );
+
+		// Generate an initial token (simulates the user already having a code).
+		$this->provider->generate_token( $user->ID );
+		$this->assertTrue( $this->provider->user_has_token( $user->ID ) );
+
+		// Force the rate-limited state.
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		// Step 1: process_provider() blocks the POST (as in login_form_validate_2fa).
+		$result = Two_Factor_Core::process_provider( $this->provider, $user, true );
+		$this->assertWPError( $result );
+		$this->assertSame( 'two_factor_too_fast', $result->get_error_code() );
+
+		// Step 2: login_html() calls authentication_page() to re-render the form.
+		$emails_before = count( self::$mockmailer->mock_sent );
+		ob_start();
+		$this->provider->authentication_page( $user );
+		ob_get_clean();
+
+		$this->assertCount(
+			$emails_before,
+			self::$mockmailer->mock_sent,
+			'No new email must be sent when re-rendering the form after a rate-limited POST'
+		);
+	}
+
+	/**
 	 * Verify user_options outputs the user's email address.
 	 *
 	 * @covers Two_Factor_Email::user_options


### PR DESCRIPTION
> **Note:** This is a rebase of [PR #859](https://github.com/WordPress/two-factor/pull/859), which was accidentally closed without comment on June 14. The branch has been rebased onto current master. Apologies for the confusion — the milestone, reviewer assignments, and discussion thread are in the original.

## Problem

Two-factor has a rate-limit that makes you wait longer after each wrong code you enter, if you keep failing retries, so it becomes a short-term ban or lockout. The lockout period starts at 2 seconds, then 4, 8, 16... up to 15 minutes if you keep failing repeated login attempts. 

**The bug:** clicking "Resend Code" remains available and operational for rate-limited users during the lockout period. Clicking "Resend Code" while locked out is possible because the resend logic runs before the rate-limit check. 

**Security and UX Impact:**
- An attacker can deliberately lock out and flood a known user with useless emailed codes.
- A valid user who locks themselves out can do the same thing to themself: if they keep clicking the "Resend Code" and trying to log in again, even with a valid code and the right credentials they will be blocked and the lockout period will be extended. 

## Solution

PR [#917](https://github.com/WordPress/two-factor/pull/917) simply moves the rate-limit check to run first, so Resend is blocked during a lockout just like a code submission is. 

- Runs the rate-limit check before any provider can resend or validate on POST requests. No provider-specific changes.
- Reorders `process_provider()` so the rate-limit gate runs before `pre_process_authentication()`, blocking all providers from resending or rotating state while rate-limited. Previously, the email provider could bypass the rate limit via the "Resend Code" button because `pre_process_authentication()` ran first.
- GET requests (page loads) are excluded from rate-limiting, so the login form renders normally when the rate limit expires.

Implements the core-level approach [suggested by @kasparsd in #848](https://github.com/WordPress/two-factor/pull/848#issuecomment-2755338046).

## Security Context

**Summary:** Moving the rate-limit gate before `pre_process_authentication()` closes the resend bypass. GET requests are excluded to avoid triggering token regeneration on page reload. Pre-existing concurrency races ([#510](https://github.com/WordPress/two-factor/issues/510)) are not worsened.

### Token handling during rate limiting

The email token is intentionally preserved when the rate limit fires. An earlier version of this PR deleted the token on rate-limit, reasoning that a captured code should not outlive the brute-force threshold. In practice this caused `authentication_page()` — called by `login_html()` immediately after the `WP_Error` return — to see no token and regenerate one, sending a new email on every blocked POST. That recreated the flooding vector the rate-limit was meant to stop.

The replay concern is already covered by the token TTL: the default `two_factor_email_token_ttl` and the max rate-limit cap are both 15 minutes, so a captured token expires at the same time the lockout lifts.

### Provider switching during rate limiting

Rate-limit state is per-user, not per-provider (`_two_factor_last_login_failure`, `_two_factor_failed_login_attempts`). If a user triggers the rate limit on TOTP then switches to the email provider, the rate-limit gate still fires. This is intentional — the account is under scrutiny regardless of which provider the failures came from.

### GET requests excluded

The `$is_post_request` early return is kept above the rate-limit check. Without this, a page reload while rate-limited would trigger `authentication_page()` on a GET, causing repeated token emails on every reload. The resend button is a POST form submission, so it is still gated.

### Concurrent request races

The read-modify-write race on the failure counter ([acknowledged by @dd32 in #510](https://github.com/WordPress/two-factor/issues/510)) and the TOCTOU window in `validate_token()` are pre-existing and not worsened by this change.

## Specific changes

- **Reorder `process_provider()`**: `$is_post_request` check first, then `is_user_rate_limited()`, then `pre_process_authentication()` — gating all provider POST actions equally.
- **Tests** (6 total):
  - Email resend blocked while rate-limited.
  - Email token preserved on rate-limited validation attempt (token deletion causes `authentication_page()` to re-send immediately — regression test added in email provider suite).
  - Email token preserved on provider switch while rate-limited.
  - GET request while rate-limited passes through without side effects.
  - Revalidation flow respects rate limiting equally (`_login_form_validate_2fa` and `_login_form_revalidate_2fa` share the same rate-limit state, per [#510](https://github.com/WordPress/two-factor/issues/510)).
  - `authentication_page()` does not send a new email when re-rendered after a rate-limited POST.

## Test plan

- [ ] Verify rate-limited users cannot trigger email resend via POST
- [ ] Verify rate-limited users see `two_factor_too_fast` error on both resend and validation POST requests
- [ ] Verify email token is preserved when rate limit fires (no re-send on blocked POST)
- [ ] Verify page reload (GET) while rate-limited renders the form normally
- [ ] Verify provider switch while rate-limited still blocks the attempt
- [ ] Verify legitimate users can retry with the same token before hitting the rate limit
- [ ] Run `vendor/bin/phpunit tests/class-two-factor-core.php tests/providers/class-two-factor-email.php`

Closes #847
Supersedes #848
Supersedes #859

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22rate-limit-gate%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->


---

The companion PR [#921](https://github.com/WordPress/two-factor/pull/921) has a [WordPress Playground demo](https://playground.wordpress.net/?blueprint-url=https://gist.githubusercontent.com/dknauss/2d9cc3e09b16cbbd2ff0072a91e45226/raw/927410265ea7f658a7741b9e02be17f4f1212d33/two-factor-921-rate-limit-messaging.json) that renders the locked-out 2FA login this gate produces — the Resend button is suppressed and only the rate-limit message shows.
