### PR TITLE
Improve rate-limit UX: calm error message and hide resend button during lockout

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1859,8 +1859,8 @@ class Two_Factor_Core {
 			return new WP_Error(
 				'two_factor_too_fast',
 				sprintf(
-					/* translators: %s: human-readable time delay until another attempt can be made. */
-					__( 'ERROR: Too many invalid verification codes, you can try again in %s. This limit protects your account against automated attacks.', 'two-factor' ),
+					/* translators: %s: human-readable time until another attempt is allowed, e.g. "2 minutes". */
+					__( 'Too many incorrect verification codes. Please wait %s and reload this page to try again.', 'two-factor' ),
 					human_time_diff( $last_login + $time_delay )
 				)
 			);

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -344,8 +344,12 @@ class Two_Factor_Email extends Two_Factor_Provider {
 			return;
 		}
 
-		if ( ! $this->user_has_token( $user->ID ) || $this->user_token_has_expired( $user->ID ) ) {
-			$this->generate_and_email_token( $user );
+		$is_rate_limited = Two_Factor_Core::is_user_rate_limited( $user );
+
+		if ( ! $is_rate_limited ) {
+			if ( ! $this->user_has_token( $user->ID ) || $this->user_token_has_expired( $user->ID ) ) {
+				$this->generate_and_email_token( $user );
+			}
 		}
 
 		$token_length      = $this->get_token_length();
@@ -357,7 +361,9 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		/** This action is documented in providers/class-two-factor-backup-codes.php */
 		do_action( 'two_factor_before_authentication_prompt', $this );
 		?>
+		<?php if ( ! $is_rate_limited ) : ?>
 		<p class="two-factor-prompt"><?php esc_html_e( 'A verification code has been sent to the email address associated with your account.', 'two-factor' ); ?></p>
+		<?php endif; ?>
 		<?php
 		/** This action is documented in providers/class-two-factor-backup-codes.php */
 		do_action( 'two_factor_after_authentication_prompt', $this );
@@ -371,9 +377,11 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		do_action( 'two_factor_after_authentication_input', $this );
 		?>
 		<?php submit_button( __( 'Verify', 'two-factor' ) ); ?>
+		<?php if ( ! $is_rate_limited ) : ?>
 		<p class="two-factor-email-resend">
 			<input type="submit" class="button" name="<?php echo esc_attr( self::INPUT_NAME_RESEND_CODE ); ?>" value="<?php esc_attr_e( 'Resend Code', 'two-factor' ); ?>" />
 		</p>
+		<?php endif; ?>
 		<?php wp_enqueue_script( 'two-factor-login' ); ?>
 		<?php
 	}

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2477,6 +2477,28 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify the rate-limit error message does not use alarming language.
+	 *
+	 * "ERROR:" and "automated attacks" are alarming to a legitimate user who
+	 * simply mistyped their code. The message should be calm and actionable.
+	 *
+	 * @covers Two_Factor_Core::process_provider
+	 */
+	public function test_rate_limit_error_message_is_calm_and_actionable() {
+		$user     = self::factory()->user->create_and_get();
+		$provider = Two_Factor_Dummy::get_instance();
+
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 1 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		$result  = Two_Factor_Core::process_provider( $provider, $user, true );
+		$message = $result->get_error_message();
+
+		$this->assertStringNotContainsString( 'ERROR:', $message, 'Rate-limit message must not use the ERROR: prefix' );
+		$this->assertStringNotContainsString( 'automated attacks', $message, 'Rate-limit message must not mention automated attacks' );
+	}
+
+	/**
 	 * Verify process_provider() returns WP_Error and increments the failed-attempts
 	 * counter when authentication fails.
 	 *

--- a/tests/providers/class-two-factor-email.php
+++ b/tests/providers/class-two-factor-email.php
@@ -496,6 +496,56 @@ class Tests_Two_Factor_Email extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify the Resend Code button is hidden when the user is rate-limited.
+	 *
+	 * Showing an interactive resend button during a lockout misleads the user
+	 * into thinking it will work.
+	 *
+	 * @covers Two_Factor_Email::authentication_page
+	 */
+	public function test_authentication_page_hides_resend_button_when_rate_limited() {
+		$user = self::factory()->user->create_and_get();
+		$this->provider->generate_token( $user->ID );
+
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+
+		ob_start();
+		$this->provider->authentication_page( $user );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			Two_Factor_Email::INPUT_NAME_RESEND_CODE,
+			$output,
+			'Resend Code button must not be rendered while the user is rate-limited'
+		);
+	}
+
+	/**
+	 * Verify no email is sent when authentication_page() is called while rate-limited and no token exists.
+	 *
+	 * @covers Two_Factor_Email::authentication_page
+	 */
+	public function test_authentication_page_does_not_send_email_when_rate_limited_and_no_token() {
+		$user = self::factory()->user->create_and_get();
+
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() );
+		$this->assertFalse( $this->provider->user_has_token( $user->ID ) );
+
+		$emails_before = count( self::$mockmailer->mock_sent );
+		ob_start();
+		$this->provider->authentication_page( $user );
+		ob_get_clean();
+
+		$this->assertCount(
+			$emails_before,
+			self::$mockmailer->mock_sent,
+			'No email must be sent when authentication_page() is called while rate-limited'
+		);
+	}
+
+	/**
 	 * Verify user_options outputs the user's email address.
 	 *
 	 * @covers Two_Factor_Email::user_options


### PR DESCRIPTION
Companion to [PR #917](https://github.com/WordPress/two-factor/pull/917). Addresses [#918](https://github.com/WordPress/two-factor/issues/918) and [#920](https://github.com/WordPress/two-factor/issues/920).

## What changed

### Error message wording (`class-two-factor-core.php`)

**Before:**
> ERROR: Too many invalid verification codes, you can try again in %s. This limit protects your account against automated attacks.

**After:**
> Too many incorrect verification codes. Please wait %s and reload this page to try again.

The old message used an `ERROR:` severity prefix appropriate for system failures, not a temporary delay. "Automated attacks" frames a lockout caused by mistyped codes as a security incident, which is alarming and inaccurate for the legitimate user almost always reading it. The new message is calm, drops the attack framing, and tells the user what to do (wait and reload).

### Resend Code button (`providers/class-two-factor-email.php`)

`authentication_page()` now checks `Two_Factor_Core::is_user_rate_limited()` before rendering the resend button and the "A verification code has been sent" prompt. While rate-limited, both are suppressed.

Showing an interactive resend button during a lockout implied it would work. Clicking it only returned the same rate-limit error. The button reappears normally once the lockout expires.

The rate-limit check in `authentication_page()` also prevents token regeneration while locked out — a user without a token will not receive a new email until the lockout expires and they reload.

## Tests

Three new tests, all passing:

- `test_rate_limit_error_message_is_calm_and_actionable` — asserts no `ERROR:` prefix and no "automated attacks"
- `test_authentication_page_hides_resend_button_when_rate_limited` — asserts `INPUT_NAME_RESEND_CODE` absent from output
- `test_authentication_page_does_not_send_email_when_rate_limited_and_no_token` — asserts no email sent when called without a token during lockout

## Not addressed here

[Issue #919](https://github.com/WordPress/two-factor/issues/919) (the "if this wasn't you, reset your password" warning that addresses two mutually exclusive audiences) is a separate concern affecting all providers, handled in [PR #922](https://github.com/WordPress/two-factor/pull/922).

Closes #918
Closes #920


## Try it in Playground

[Try this change in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://gist.githubusercontent.com/dknauss/2d9cc3e09b16cbbd2ff0072a91e45226/raw/927410265ea7f658a7741b9e02be17f4f1212d33/two-factor-921-rate-limit-messaging.json) — boots a locked-out 2FA login showing the calm rate-limit message with the Resend button suppressed.
