### PR TITLE
fix: reword mixed-audience login failure notice to be informational

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1022,10 +1022,10 @@ class Two_Factor_Core {
 			echo '<div id="login_notice" class="message"><strong>';
 			printf(
 				esc_html(
-					/* translators: 1: number of failed login attempts, 2: time since last failed attempt */
+					/* translators: 1: number of failed verification code attempts, 2: human-readable time since the last attempt, e.g. "5 minutes" */
 					_n(
-						'WARNING: Your account has attempted to login %1$s time without providing a valid two factor token. The last failed login occurred %2$s ago. If this wasn\'t you, you should reset your password.',
-						'WARNING: Your account has attempted to login %1$s times without providing a valid two factor token. The last failed login occurred %2$s ago. If this wasn\'t you, you should reset your password.',
+						'%1$s failed verification code attempt on this account. The last attempt was %2$s ago. If you did not make this attempt, review your account security after logging in.',
+						'%1$s failed verification code attempts on this account. The last attempt was %2$s ago. If you did not make these attempts, review your account security after logging in.',
 						$failed_login_count,
 						'two-factor'
 					)

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1024,8 +1024,8 @@ class Two_Factor_Core {
 				esc_html(
 					/* translators: 1: number of failed verification code attempts, 2: human-readable time since the last attempt, e.g. "5 minutes" */
 					_n(
-						'%1$s failed verification code attempt on this account. The last attempt was %2$s ago. If you did not make this attempt, review your account security after logging in.',
-						'%1$s failed verification code attempts on this account. The last attempt was %2$s ago. If you did not make these attempts, review your account security after logging in.',
+						'%1$s failed verification code attempt on this account. The last attempt was %2$s ago. If you did not make this attempt, someone else may know your password. Change your password after you log in.',
+						'%1$s failed verification code attempts on this account. The last attempt was %2$s ago. If you did not make these attempts, someone else may know your password. Change your password after you log in.',
 						$failed_login_count,
 						'two-factor'
 					)

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -796,8 +796,10 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$contents = ob_get_clean();
 
 		$this->assertNotEmpty( $contents );
-		$this->assertStringNotContainsString( '1 times', $contents );
-		$this->assertStringContainsString( 'failed verification code attempt', $contents );
+		// A single failure uses the singular form; assert the plural is absent, since
+		// "attempt" alone also matches "attempts".
+		$this->assertStringContainsString( '1 failed verification code attempt on this account', $contents );
+		$this->assertStringNotContainsString( 'failed verification code attempts', $contents );
 
 		// 5 failed login attempts 5 hours ago - User should be informed.
 		$five_hours_ago = time() - 5 * HOUR_IN_SECONDS;
@@ -808,7 +810,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$contents = ob_get_clean();
 
 		$this->assertNotEmpty( $contents );
-		$this->assertStringContainsString( 'failed verification code attempts', $contents );
+		$this->assertStringContainsString( '5 failed verification code attempts on this account', $contents );
 		$this->assertStringContainsString( human_time_diff( $five_hours_ago ), $contents );
 	}
 
@@ -820,7 +822,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	public function test_login_failure_notice_language_is_calm_and_informational() {
 		$user = $this->get_dummy_user();
 		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
-		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() - 60 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() - MINUTE_IN_SECONDS );
 
 		ob_start();
 		Two_Factor_Core::maybe_show_last_login_failure_notice( $user );

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -832,9 +832,10 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()
 	 */
 	public function test_login_failure_notice_language_is_calm_and_informational() {
-		$user = $this->get_dummy_user();
+		$user           = $this->get_dummy_user();
+		$one_minute_ago = time() - MINUTE_IN_SECONDS;
 		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
-		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() - MINUTE_IN_SECONDS );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, $one_minute_ago );
 
 		ob_start();
 		Two_Factor_Core::maybe_show_last_login_failure_notice( $user );
@@ -842,9 +843,13 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertStringNotContainsString( 'WARNING', $contents );
 		$this->assertStringNotContainsString( "wasn't you", $contents );
-		$this->assertStringNotContainsString( 'reset your password', $contents );
 		$this->assertStringContainsString( 'failed verification code', $contents );
-		$this->assertStringContainsString( 'review your account security', $contents );
+		$this->assertStringContainsString( 'someone else may know your password', $contents );
+		$this->assertStringContainsString( 'Change your password after you log in', $contents );
+		$this->assertStringContainsString(
+			'The last attempt was ' . human_time_diff( $one_minute_ago ) . ' ago',
+			$contents
+		);
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -797,8 +797,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $contents );
 		$this->assertStringNotContainsString( '1 times', $contents );
-		$this->assertStringContainsString( 'attempted to login', $contents );
-		$this->assertStringContainsString( 'without providing a valid two factor token', $contents );
+		$this->assertStringContainsString( 'failed verification code attempt', $contents );
 
 		// 5 failed login attempts 5 hours ago - User should be informed.
 		$five_hours_ago = time() - 5 * HOUR_IN_SECONDS;
@@ -809,8 +808,29 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$contents = ob_get_clean();
 
 		$this->assertNotEmpty( $contents );
-		$this->assertStringContainsString( '5 times', $contents );
+		$this->assertStringContainsString( 'failed verification code attempts', $contents );
 		$this->assertStringContainsString( human_time_diff( $five_hours_ago ), $contents );
+	}
+
+	/**
+	 * Test that the login failure notice uses calm, informational language.
+	 *
+	 * @covers Two_Factor_Core::maybe_show_last_login_failure_notice()
+	 */
+	public function test_login_failure_notice_language_is_calm_and_informational() {
+		$user = $this->get_dummy_user();
+		update_user_meta( $user->ID, Two_Factor_Core::USER_FAILED_LOGIN_ATTEMPTS_KEY, 3 );
+		update_user_meta( $user->ID, Two_Factor_Core::USER_RATE_LIMIT_KEY, time() - 60 );
+
+		ob_start();
+		Two_Factor_Core::maybe_show_last_login_failure_notice( $user );
+		$contents = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'WARNING', $contents );
+		$this->assertStringNotContainsString( "wasn't you", $contents );
+		$this->assertStringNotContainsString( 'reset your password', $contents );
+		$this->assertStringContainsString( 'failed verification code', $contents );
+		$this->assertStringContainsString( 'review your account security', $contents );
 	}
 
 	/**


### PR DESCRIPTION
Companion to [PR #917](https://github.com/WordPress/two-factor/pull/917) and [PR #921](https://github.com/WordPress/two-factor/pull/921).

Closes #919.

## What changed

`maybe_show_last_login_failure_notice()` in `class-two-factor-core.php`.

**Before:**
> WARNING: Your account has attempted to login %1$s times without providing a valid two factor token. The last failed login occurred %2$s ago. If this wasn't you, you should reset your password.

**After:**
> %1$s failed verification code attempts on this account. The last attempt was %2$s ago. If you did not make these attempts, someone else may know your password. Change your password after you log in.

### Why each change

**Remove "WARNING:"** — same rationale as [PR #921](https://github.com/WordPress/two-factor/pull/921): a severity prefix for a temporary informational notice is alarming and inappropriate.

**Reframe "if this wasn't you," and keep concrete advice** — This notice appears on the 2FA form, which is only reached after a correct password submission, and the failed-attempt counter increments only past that point (`process_provider()` runs after `verify_login_nonce()`). So if the account holder did not make these attempts, someone else submitted their correct password — and a password change is the correct remedy, because it invalidates the password the other party already has. The new copy drops the alarming `WARNING:` framing and the awkward "if this wasn't you," but states the implication plainly and gives the concrete action, deferred to after login because the password can't be changed mid-flow.

**"attempted to login … without providing a valid two factor token" → "failed verification code attempt on this account"** — shorter, plain-language phrasing that doesn't require the user to parse "two factor token" to understand what happened.

## Tests

- `test_maybe_show_last_login_failure_notice` — updated string assertions to match the new text, pinning both the singular and plural forms.
- `test_login_failure_notice_language_is_calm_and_informational` — asserts the absence of `WARNING` and `wasn't you`; asserts the concrete guidance (`someone else may know your password` / `Change your password after you log in`) and the rendered time (`The last attempt was … ago`) are present.

## Not addressed here

This notice is only shown when there is no rate-limit error already displayed (see the `elseif` condition in `login_html()`). The rate-limit error message itself was addressed in [PR #921](https://github.com/WordPress/two-factor/pull/921).

## Try it in Playground

[Try this change in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://gist.githubusercontent.com/dknauss/d4c2ea836ee261a4103e9b5f16b2ff5b/raw/abd72109f731b8aee96242d15b0bcd1757730d9c/two-factor-922-notice-mixed-audience.json) — boots the 2FA login showing the reworded failure notice.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22ux%2Fnotice-mixed-audience%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
