### PR TITLE
tests: add coverage for provider-specific fallback notices (#855)

### DIFF
--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -160,6 +160,30 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reset stored profile errors between tests.
+	 */
+	private function reset_profile_errors() {
+		$reflection = new ReflectionClass( Two_Factor_Core::class );
+		$prop       = $reflection->getProperty( 'profile_errors' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, array() );
+	}
+
+	/**
+	 * Render the user two-factor settings UI and return the markup.
+	 *
+	 * @param WP_User $user User instance.
+	 * @return string
+	 */
+	private function render_user_two_factor_options( WP_User $user ) {
+		$this->reset_profile_errors();
+
+		ob_start();
+		Two_Factor_Core::user_two_factor_options( $user );
+		return ob_get_clean();
+	}
+
+	/**
 	 * Verify adding hooks.
 	 *
 	 * @covers Two_Factor_Core::add_hooks
@@ -2155,6 +2179,71 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertIsArray( $providers, 'Returns an array of providers' );
 		$this->assertArrayHasKey( 'Two_Factor_Email', $providers, 'Email provider is supported by default' );
 		$this->assertArrayHasKey( 'Two_Factor_Totp', $providers, 'TOTP provider is supported by default' );
+	}
+
+	/**
+	 * Test user_two_factor_options output when backup codes are available.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options
+	 */
+	public function test_user_two_factor_options_mentions_recovery_codes_when_backup_codes_are_available() {
+		$user = self::factory()->user->create_and_get();
+
+		Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Email' );
+
+		try {
+			$output = $this->render_user_two_factor_options( $user );
+
+			$this->assertStringContainsString(
+				'consider enabling a backup method like Recovery Codes',
+				$output
+			);
+			$this->assertStringContainsString(
+				'Configure a primary two-factor method along with a backup method, such as Recovery Codes',
+				$output
+			);
+			$this->assertStringNotContainsString(
+				'consider enabling an additional two-factor method',
+				$output
+			);
+		} finally {
+			$this->reset_profile_errors();
+		}
+	}
+
+	/**
+	 * Test user_two_factor_options output when backup codes are filtered out.
+	 *
+	 * @covers Two_Factor_Core::user_two_factor_options
+	 */
+	public function test_user_two_factor_options_uses_generic_wording_when_backup_codes_are_filtered_out() {
+		$filter = static function ( $providers ) {
+			unset( $providers['Two_Factor_Backup_Codes'] );
+			return $providers;
+		};
+
+		add_filter( 'two_factor_providers', $filter );
+
+		try {
+			$user = self::factory()->user->create_and_get();
+
+			Two_Factor_Core::enable_provider_for_user( $user->ID, 'Two_Factor_Email' );
+
+			$output = $this->render_user_two_factor_options( $user );
+
+			$this->assertStringContainsString(
+				'consider enabling an additional two-factor method',
+				$output
+			);
+			$this->assertStringContainsString(
+				'Configure a primary two-factor method along with an additional two-factor method',
+				$output
+			);
+			$this->assertStringNotContainsString( 'Recovery Codes', $output );
+		} finally {
+			remove_filter( 'two_factor_providers', $filter );
+			$this->reset_profile_errors();
+		}
 	}
 
 	/**

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -178,9 +178,21 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	private function render_user_two_factor_options( WP_User $user ) {
 		$this->reset_profile_errors();
 
+		$ob_level = ob_get_level();
 		ob_start();
-		Two_Factor_Core::user_two_factor_options( $user );
-		return ob_get_clean();
+
+		try {
+			Two_Factor_Core::user_two_factor_options( $user );
+			return ob_get_clean();
+		} finally {
+			// If user_two_factor_options() aborted early, close only the buffer
+			// this helper opened and clear the static profile errors, so a leaked
+			// buffer or stale error state can't bleed into later tests.
+			while ( ob_get_level() > $ob_level ) {
+				ob_end_clean();
+			}
+			$this->reset_profile_errors();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Follow-up tests for [PR #858](https://github.com/WordPress/two-factor/pull/858), which landed without test coverage.

## What

Two tests for the conditional notice logic introduced in #858:

- `test_user_two_factor_options_mentions_recovery_codes_when_backup_codes_are_available` — when `Two_Factor_Backup_Codes` is registered, the profile UI should name "Recovery Codes" specifically
- `test_user_two_factor_options_uses_generic_wording_when_backup_codes_are_filtered_out` — when `Two_Factor_Backup_Codes` is removed via the `two_factor_providers` filter, the UI should use the generic fallback wording instead

Also adds two private helpers used by these tests (and available for future notice-related tests):

- `reset_profile_errors()` — clears the static `$profile_errors` array between tests via reflection
- `render_user_two_factor_options()` — captures `user_two_factor_options()` output to a string

## Why

The fix in #858 is a conditional: one branch names "Recovery Codes" explicitly, the other uses generic wording. Without tests, either branch could silently regress. These tests pin both sides of the condition.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22pr-858-tests%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->