### PR TITLE
Fix #644: Expose existing 2FA revalidation flow to third-party plugins via action hook

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -147,6 +147,8 @@ class Two_Factor_Core {
 		add_action( 'admin_init', array( __CLASS__, 'trigger_user_settings_action' ) );
 		add_filter( 'two_factor_providers', array( __CLASS__, 'enable_dummy_method_for_debug' ) );
 
+		add_action( 'two_factor_revalidate_session', array( __CLASS__, 'action_revalidate_session' ), 10, 2 );
+
 		// Add Settings link to plugin action links.
 		add_filter( 'plugin_action_links_' . plugin_basename( TWO_FACTOR_DIR . 'two-factor.php' ), array( __CLASS__, 'add_settings_action_link' ) );
 
@@ -600,6 +602,40 @@ class Two_Factor_Core {
 			 * @param string $action Settings action.
 			 */
 			do_action( 'two_factor_user_settings_action', $user_id, $action );
+		}
+	}
+
+	/**
+	 * Require a recent Two Factor session.
+	 *
+	 * Triggers a redirect to the two-factor revalidation screen if the current session
+	 * hasn't been validated within the specified time window.
+	 *
+	 * @since NEXT
+	 *
+	 * @param int    $time_window The grace period in seconds. Default 300 (5 minutes).
+	 * @param string $redirect_to The URL to redirect back to after revalidation. Defaults to the current request URI.
+	 *
+	 * @return void
+	 */
+	public static function action_revalidate_session( $time_window = 300, $redirect_to = '' ) {
+		if ( ! is_user_logged_in() || ! self::is_user_using_two_factor() ) {
+			return;
+		}
+
+		$last_2fa  = self::is_current_user_session_two_factor();
+		$is_recent = $last_2fa && ( time() - $last_2fa < (int) $time_window );
+
+		if ( ! $is_recent ) {
+			if ( empty( $redirect_to ) && isset( $_SERVER['REQUEST_URI'] ) ) {
+				$redirect_to = wp_unslash( $_SERVER['REQUEST_URI'] );
+			}
+
+			$reauth_url = self::get_user_two_factor_revalidate_url();
+			$reauth_url = add_query_arg( 'redirect_to', urlencode( $redirect_to ), $reauth_url );
+
+			wp_safe_redirect( $reauth_url );
+			exit;
 		}
 	}
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2707,4 +2707,66 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Settings', $first );
 		$this->assertStringContainsString( 'options-general.php', $first );
 	}
+
+	/**
+	 * @covers Two_Factor_Core::action_revalidate_session
+	 */
+	public function test_action_revalidate_session_redirects_when_not_recent() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Dummy' ) );
+		update_user_meta( $user_id, Two_Factor_Core::PROVIDER_USER_META_KEY, 'Two_Factor_Dummy' );
+
+		// Simulate an old session (20 minutes ago)
+		$old_time = time() - ( 20 * MINUTE_IN_SECONDS );
+		Two_Factor_Core::update_current_user_session(
+			array(
+				'two-factor-provider' => 'Two_Factor_Dummy',
+				'two-factor-login'    => $old_time,
+			)
+		);
+
+		$_SERVER['REQUEST_URI'] = '/wp-admin/post.php?post=1&action=edit';
+
+		// Catch the redirect exception
+		$redirected = false;
+		try {
+			Two_Factor_Core::action_revalidate_session( 300, '/custom-redirect/' );
+		} catch ( Two_Factor_Redirect_Exception $e ) {
+			$redirected = true;
+			$location   = $e->getMessage();
+			$this->assertStringContainsString( 'action=revalidate_2fa', $location );
+			$this->assertStringContainsString( 'redirect_to=%2Fcustom-redirect%2F', $location );
+		}
+
+		$this->assertTrue( $redirected, 'Expected wp_safe_redirect to throw Two_Factor_Redirect_Exception.' );
+	}
+
+	/**
+	 * @covers Two_Factor_Core::action_revalidate_session
+	 */
+	public function test_action_revalidate_session_bypasses_when_recent() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+		update_user_meta( $user_id, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Dummy' ) );
+
+		// Simulate a recent session (1 minute ago)
+		$recent_time = time() - MINUTE_IN_SECONDS;
+		Two_Factor_Core::update_current_user_session(
+			array(
+				'two-factor-provider' => 'Two_Factor_Dummy',
+				'two-factor-login'    => $recent_time,
+			)
+		);
+
+		// Should not throw an exception (no redirect)
+		$exception = false;
+		try {
+			Two_Factor_Core::action_revalidate_session( 300 );
+		} catch ( Two_Factor_Redirect_Exception $e ) {
+			$exception = true;
+		}
+
+		$this->assertFalse( $exception, 'Expected no redirect for a recent session.' );
+	}
 }


### PR DESCRIPTION
## What?
Introduces the two_factor_revalidate_session action hook which allows developers to programmatically trigger a 2FA re-authentication check.

Fixes #644

## Why?
There are cases where other plugins or custom site logic need to verify that an authenticated user has recently passed a 2FA check before allowing them to perform a sensitive action (such as accessing a billing portal or publishing a high-profile post). This PR exposes the core plugin's existing re-authentication flow through a standardized, easy-to-use action hook.

## How?
1. Added the action_revalidate_session( $time_window, $redirect_to ) method to Two_Factor_Core.
2. Hooked the method into a new two_factor_revalidate_session action hook.
3. The method checks is_current_user_session_two_factor() against the provided time window (defaulting to 5 minutes).
4. If the last 2FA verification is missing or older than the time window, the user is safely redirected to the plugin's revalidate_2fa screen.
5. Added PHPUnit tests to cover both the recent-session bypass and the old-session redirect flows.

## Use of AI Tools
AI Assistance: No

## Testing Instructions

1. Ensure your user account has a 2FA method properly configured and enabled in your profile.
2. Add a temporary testing script to your site (e.g., in mu-plugins or functions.php) to intercept the post editor:
`
add_action( 'admin_init', function() {
    global $pagenow;
    if ( $pagenow === 'post.php' || $pagenow === 'post-new.php' ) {
        // Force re-auth if the 2FA session is older than 60 seconds
        do_action( 'two_factor_revalidate_session', 60 );
    }
} );
`
3. Log into the site via 2FA.
4. Immediately navigate to Posts > Add New. You should be granted access normally.
5. Wait for 60 seconds.
6. Refresh the "Add New Post" page or attempt to edit an existing post.
7. You should be intercepted and prompted with the 2FA re-authentication screen.
8. Validate your 2FA credential. Upon success, you should be safely redirected back to the post editor.


## Changelog Entry
Added - two_factor_revalidate_session action hook to allow third-party code to trigger a 2FA revalidation flow for an existing user session.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22issue-644-revalidate-session%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->