### PR TITLE
Persist third-party plugin $_POST fields across the 2FA login screen (Fixes #705)

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2664,7 +2664,7 @@ class Two_Factor_Core {
 			if ( in_array( $key, $blocklist, true ) ) {
 				continue;
 			}
-			self::print_hidden_inputs( $key, $value );
+			self::print_hidden_inputs( $key, wp_unslash( $value ), $blocklist );
 		}
 	}
 
@@ -2673,13 +2673,17 @@ class Two_Factor_Core {
 	 *
 	 * @since 0.17.0
 	 *
-	 * @param string       $name  Input name.
-	 * @param string|array $value Input value.
+	 * @param string       $name      Input name.
+	 * @param string|array $value     Input value.
+	 * @param array        $blocklist Array of keys to skip.
 	 */
-	private static function print_hidden_inputs( $name, $value ) {
+	private static function print_hidden_inputs( $name, $value, $blocklist = array() ) {
 		if ( is_array( $value ) ) {
 			foreach ( $value as $k => $v ) {
-				self::print_hidden_inputs( $name . '[' . $k . ']', $v );
+				if ( in_array( $k, $blocklist, true ) ) {
+					continue;
+				}
+				self::print_hidden_inputs( $name . '[' . $k . ']', $v, $blocklist );
 			}
 		} else {
 			echo '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" />' . "\n";

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1161,6 +1161,7 @@ class Two_Factor_Core {
 					<input type="hidden" name="redirect_to" value="<?php echo esc_attr( $redirect_to ); ?>" />
 				<?php } ?>
 				<input type="hidden" name="rememberme"    id="rememberme"    value="<?php echo esc_attr( $rememberme ); ?>" />
+				<?php self::print_custom_post_fields(); ?>
 
 				<?php $provider->authentication_page( $user ); ?>
 		</form>
@@ -2623,6 +2624,66 @@ class Two_Factor_Core {
 		}
 
 		return $session;
+	}
+
+	/**
+	 * Output custom $_POST fields as hidden inputs.
+	 *
+	 * Iterates over $_POST and outputs hidden inputs for fields added by third-party plugins,
+	 * ensuring that standard WordPress and Two-Factor fields (especially sensitive ones like `pwd`)
+	 * are explicitly ignored.
+	 *
+	 * @since 0.17.0
+	 */
+	private static function print_custom_post_fields() {
+		$blocklist = array(
+			// Standard WP Login fields.
+			'log',
+			'pwd',
+			'wp-submit',
+			'redirect_to',
+			'rememberme',
+			'interim-login',
+			'testcookie',
+			'_wpnonce',
+			'_wp_http_referer',
+			// Additional common login fields (e.g., WooCommerce, custom forms).
+			'password',
+			'user_pass',
+			'username',
+			'user_login',
+			// Two Factor specific fields.
+			'provider',
+			'wp-auth-id',
+			'wp-auth-nonce',
+			'action',
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		foreach ( $_POST as $key => $value ) {
+			if ( in_array( $key, $blocklist, true ) ) {
+				continue;
+			}
+			self::print_hidden_inputs( $key, $value );
+		}
+	}
+
+	/**
+	 * Recursively output hidden inputs for a given key/value.
+	 *
+	 * @since 0.17.0
+	 *
+	 * @param string       $name  Input name.
+	 * @param string|array $value Input value.
+	 */
+	private static function print_hidden_inputs( $name, $value ) {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $k => $v ) {
+				self::print_hidden_inputs( $name . '[' . $k . ']', $v );
+			}
+		} else {
+			echo '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '" />' . "\n";
+		}
 	}
 }
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2707,4 +2707,65 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Settings', $first );
 		$this->assertStringContainsString( 'options-general.php', $first );
 	}
+
+	/**
+	 * @covers Two_Factor_Core::print_custom_post_fields
+	 */
+	public function test_print_custom_post_fields_includes_custom_fields() {
+		$original_post = $_POST;
+		$_POST         = array(
+			'custom_field_1' => 'value1',
+			'custom_array'   => array(
+				'key1' => 'val1',
+				'key2' => 'val2',
+			),
+		);
+
+		$method = new ReflectionMethod( 'Two_Factor_Core', 'print_custom_post_fields' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( null );
+		$output = ob_get_clean();
+
+		$_POST = $original_post;
+
+		$this->assertStringContainsString( '<input type="hidden" name="custom_field_1" value="value1" />', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="custom_array[key1]" value="val1" />', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="custom_array[key2]" value="val2" />', $output );
+	}
+
+	/**
+	 * @covers Two_Factor_Core::print_custom_post_fields
+	 */
+	public function test_print_custom_post_fields_excludes_blocked_fields() {
+		$original_post = $_POST;
+		$_POST         = array(
+			'pwd'        => 'my_secret_password',
+			'password'   => 'my_other_password',
+			'log'        => 'admin',
+			'user_pass'  => 'secret',
+			'rememberme' => '1',
+			'custom_ok'  => 'allowed',
+		);
+
+		$method = new ReflectionMethod( 'Two_Factor_Core', 'print_custom_post_fields' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( null );
+		$output = ob_get_clean();
+
+		$_POST = $original_post;
+
+		$this->assertStringContainsString( '<input type="hidden" name="custom_ok" value="allowed" />', $output );
+		$this->assertStringNotContainsString( 'my_secret_password', $output );
+		$this->assertStringNotContainsString( 'my_other_password', $output );
+		$this->assertStringNotContainsString( 'secret', $output );
+		$this->assertStringNotContainsString( 'pwd', $output );
+		$this->assertStringNotContainsString( 'password', $output );
+		$this->assertStringNotContainsString( 'log', $output );
+		$this->assertStringNotContainsString( 'user_pass', $output );
+		$this->assertStringNotContainsString( 'rememberme', $output );
+	}
 }

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2747,6 +2747,10 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 			'user_pass'  => 'secret',
 			'rememberme' => '1',
 			'custom_ok'  => 'allowed',
+			'nested'     => array(
+				'pwd' => 'nested_secret_password',
+				'ok'  => 'nested_allowed',
+			),
 		);
 
 		$method = new ReflectionMethod( 'Two_Factor_Core', 'print_custom_post_fields' );
@@ -2759,8 +2763,10 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$_POST = $original_post;
 
 		$this->assertStringContainsString( '<input type="hidden" name="custom_ok" value="allowed" />', $output );
+		$this->assertStringContainsString( '<input type="hidden" name="nested[ok]" value="nested_allowed" />', $output );
 		$this->assertStringNotContainsString( 'my_secret_password', $output );
 		$this->assertStringNotContainsString( 'my_other_password', $output );
+		$this->assertStringNotContainsString( 'nested_secret_password', $output );
 		$this->assertStringNotContainsString( 'secret', $output );
 		$this->assertStringNotContainsString( 'pwd', $output );
 		$this->assertStringNotContainsString( 'password', $output );


### PR DESCRIPTION
## What?
This PR ensures that custom $_POST fields injected by third-party plugins (e.g., JavaScript detection flags, custom checkboxes) into the WordPress login form are preserved when the Two-Factor plugin interrupts the login flow to display its 2FA challenge.

Fixes #705

## Why?
Currently, when a user successfully passes the initial username/password check, Two-Factor renders the login_html() interstitial form. In doing so, it drops any non-standard $_POST variables submitted from the original wp-login.php form. When the user eventually submits their 2FA code, plugins that rely on $_POST (for instance, during the attach_session_information hook) fail to find their data.

## How?
A new recursive method Two_Factor_Core::print_custom_post_fields() has been added.

1. It iterates over $_POST and outputs hidden <input> elements for each field.
2. It uses a rigorous blocklist to prevent echoing standard WordPress core fields (like log, wp-submit, _wpnonce, etc.), Two-Factor specific fields, and most importantly, passwords (pwd, password, user_pass). This ensures absolute security so that plaintext passwords are never inadvertently written to the HTML source code.
3. Unit tests have been added to verify that custom fields (including nested arrays) are properly passed through, and that sensitive fields are rigorously blocked.

## Use of AI Tools
AI assistance: No

## Testing Instructions
1. Install and activate a plugin that adds a custom field to the WP login form (e.g., nocache-bfcache from the issue, or write a simple mu-plugin that adds an <input type="hidden" name="my_custom_field" value="test"> using the login_form hook).
2. Attempt to log in with an account that has Two-Factor enabled.
3. On the 2FA interstitial screen, inspect the HTML source code.
4. Verify that the custom field (my_custom_field) is present as a hidden input.
5. Verify that sensitive fields (like pwd, password, user_pass, log, etc.) are absolutely not present in the hidden inputs.
6. Verify that standard authentication still works normally.

## Changelog Entry
Fixed - Preserve custom third-party $_POST variables during the 2FA login challenge.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22issue-705-persist-post-fields%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->