### PR TITLE
rework fail-safe

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -687,26 +687,32 @@ class Two_Factor_Core {
 		$user_providers_raw   = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
 
 		/**
-		 * If the user had enabled providers, but none of them exist currently,
-		 * if emailed codes is available force it to be on, so that deprecated
-		 * or removed providers don't result in the two-factor requirement being
+		 * If the user had enabled providers in user meta, but none of those
+		 * providers are still registered, force emailed codes on when available
+		 * so deprecated or removed providers don't result in two-factor being
 		 * removed and 'failing open'.
 		 *
-		 * Possible enhancement: add a filter to change the fallback method?
+		 * If the configured providers are still registered, an empty enabled list
+		 * may have been returned intentionally by two_factor_enabled_providers_for_user
+		 * and must be respected.
 		 */
 		if ( empty( $enabled_providers ) && $user_providers_raw ) {
-			if ( isset( $providers['Two_Factor_Email'] ) ) {
-				// Force Emailed codes to 'on'.
-				$enabled_providers[] = 'Two_Factor_Email';
-			} else {
-				return new WP_Error(
-					'no_available_2fa_methods',
-					__( 'Error: You have Two Factor method(s) enabled, but the provider(s) no longer exist. Please contact a site administrator for assistance.', 'two-factor' ),
-					array(
-						'user_providers_raw'  => $user_providers_raw,
-						'available_providers' => array_keys( $providers ),
-					)
-				);
+			$still_registered = array_intersect( (array) $user_providers_raw, array_keys( $providers ) );
+
+			if ( empty( $still_registered ) ) {
+				if ( isset( $providers['Two_Factor_Email'] ) ) {
+					// Force Emailed codes to 'on'.
+					$enabled_providers[] = 'Two_Factor_Email';
+				} else {
+					return new WP_Error(
+						'no_available_2fa_methods',
+						__( 'Error: You have Two Factor method(s) enabled, but the provider(s) no longer exist. Please contact a site administrator for assistance.', 'two-factor' ),
+						array(
+							'user_providers_raw'  => $user_providers_raw,
+							'available_providers' => array_keys( $providers ),
+						)
+					);
+				}
 			}
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -645,6 +645,29 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Get the provider keys stored in user meta, normalised.
+	 *
+	 * Returns the raw stored list without intersecting against registered providers and
+	 * without applying `two_factor_enabled_providers_for_user`, so callers can distinguish
+	 * "this user has no registered providers left" from "a filter intentionally cleared the list".
+	 *
+	 * @since 0.17.0
+	 *
+	 * @param WP_User $user User object.
+	 *
+	 * @return string[] Provider keys stored for the user. May include keys that are no longer registered.
+	 */
+	private static function get_stored_provider_keys_for_user( $user ) {
+		$stored = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
+
+		if ( ! is_array( $stored ) ) {
+			$stored = array();
+		}
+
+		return array_values( array_filter( $stored, 'is_string' ) );
+	}
+
+	/**
 	 * Get two-factor providers that are enabled for the specified (or current) user
 	 * but might not be configured, yet.
 	 *
@@ -664,11 +687,10 @@ class Two_Factor_Core {
 		}
 
 		$providers         = self::get_supported_providers_for_user( $user );
-		$enabled_providers = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
-		if ( empty( $enabled_providers ) ) {
-			$enabled_providers = array();
-		}
-		$enabled_providers = array_intersect( $enabled_providers, array_keys( $providers ) );
+		$enabled_providers = array_intersect(
+			self::get_stored_provider_keys_for_user( $user ),
+			array_keys( $providers )
+		);
 
 		/**
 		 * Filter the enabled two-factor authentication providers for this user.
@@ -691,7 +713,8 @@ class Two_Factor_Core {
 	 * @see Two_Factor_Core::get_enabled_providers_for_user()
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
-	 * @return Two_Factor_Provider[]|WP_Error List of provider instances, or a WP_Error if all configured providers are unavailable.
+	 * @return Two_Factor_Provider[]|WP_Error List of provider instances, or a WP_Error if the user's stored
+	 *                                        providers are no longer registered and email isn't registered either.
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
 		$user = self::fetch_user( $user );
@@ -702,32 +725,71 @@ class Two_Factor_Core {
 		$providers            = self::get_supported_providers_for_user( $user ); // Returns full objects.
 		$enabled_providers    = self::get_enabled_providers_for_user( $user ); // Returns just the keys.
 		$configured_providers = array();
-		$user_providers_raw   = get_user_meta( $user->ID, self::ENABLED_PROVIDERS_USER_META_KEY, true );
+		$stored_providers     = self::get_stored_provider_keys_for_user( $user );
 
 		/**
-		 * If the user had enabled providers in user meta, but none of those
-		 * providers are still registered, force emailed codes on when available
-		 * so deprecated or removed providers don't result in two-factor being
-		 * removed and 'failing open'.
+		 * If the user has providers stored in meta but none of them are still registered, force
+		 * emailed codes on where available so removed or deprecated providers can't drop the user
+		 * to single-factor auth ('failing open').
 		 *
-		 * If the configured providers are still registered, an empty enabled list
-		 * may have been returned intentionally by two_factor_enabled_providers_for_user
-		 * and must be respected.
+		 * "No longer registered" is deliberately cause-agnostic: a provider dropped by plugin
+		 * deactivation, by the site-wide settings, or by `two_factor_providers_for_user` is treated
+		 * identically, because the outcome for the user is identical.
+		 *
+		 * If any stored provider IS still registered, an empty enabled list means
+		 * `two_factor_enabled_providers_for_user` cleared it on purpose, and that must be respected.
 		 */
-		if ( empty( $enabled_providers ) && $user_providers_raw ) {
-			$still_registered = array_intersect( (array) $user_providers_raw, array_keys( $providers ) );
+		if ( empty( $enabled_providers ) && ! empty( $stored_providers ) ) {
+			$still_registered = array_intersect( $stored_providers, array_keys( $providers ) );
 
 			if ( empty( $still_registered ) ) {
-				if ( isset( $providers['Two_Factor_Email'] ) ) {
-					// Force Emailed codes to 'on'.
-					$enabled_providers[] = 'Two_Factor_Email';
+				/**
+				 * Filter the provider forced on when none of a user's stored providers are still registered.
+				 *
+				 * Returning a key that is not registered, or that the provider itself reports as unavailable
+				 * for this user, is treated as "no fallback": the method returns a `no_available_2fa_methods`
+				 * WP_Error rather than allowing the user through with one factor.
+				 *
+				 * The returned provider must be usable without any prior per-user setup (like the email
+				 * provider is), since the user has no working provider left to configure it through:
+				 *
+				 *     add_filter( 'two_factor_fallback_provider_for_user', function() {
+				 *         return 'Two_Factor_Backup_Codes'; // Wrong: requires codes to already be generated.
+				 *     } );
+				 *
+				 * A fallback that is not already available for the user resolves to the WP_Error branch,
+				 * not to a silent single-factor login.
+				 *
+				 * @since 0.17.0
+				 *
+				 * @param string   $fallback_provider Provider key to force on. Default 'Two_Factor_Email'.
+				 * @param int      $user_id           The user ID.
+				 * @param string[] $stored_providers  Provider keys stored for the user, none of which are registered.
+				 */
+				$fallback_provider = apply_filters(
+					'two_factor_fallback_provider_for_user',
+					'Two_Factor_Email',
+					$user->ID,
+					$stored_providers
+				);
+
+				if (
+					is_string( $fallback_provider )
+					&& isset( $providers[ $fallback_provider ] )
+					&& $providers[ $fallback_provider ]->is_available_for_user( $user )
+				) {
+					// Force the fallback provider to 'on'.
+					$enabled_providers[] = $fallback_provider;
 				} else {
+					// Fail closed: an invalid, unregistered, or unavailable fallback locks the user
+					// out pending admin intervention, rather than letting them through with one factor.
 					return new WP_Error(
 						'no_available_2fa_methods',
 						__( 'Error: You have Two Factor method(s) enabled, but the provider(s) no longer exist. Please contact a site administrator for assistance.', 'two-factor' ),
 						array(
-							'user_providers_raw'  => $user_providers_raw,
+							'user_providers_raw'  => $stored_providers,
 							'available_providers' => array_keys( $providers ),
+							'fallback_provider'   => $fallback_provider,
 						)
 					);
 				}

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -714,7 +714,9 @@ class Two_Factor_Core {
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @return Two_Factor_Provider[]|WP_Error List of provider instances, or a WP_Error if the user's stored
-	 *                                        providers are no longer registered and email isn't registered either.
+	 *                                        providers are no longer registered and the fallback provider
+	 *                                        (`Two_Factor_Email` by default, see `two_factor_fallback_provider_for_user`)
+	 *                                        doesn't resolve to a registered, available provider.
 	 */
 	public static function get_available_providers_for_user( $user = null ) {
 		$user = self::fetch_user( $user );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, kasparsd, masteradhoc, valendesigns, stevenkword, jeffpaul, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 7.0
-Stable tag:   0.16.0
+Stable tag:   0.17.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -92,6 +92,7 @@ Here is a list of action and filter hooks provided by the plugin:
 - `two_factor_providers` filter overrides the available two-factor providers such as email and time-based one-time passwords. Array values are PHP classnames of the two-factor providers.
 - `two_factor_providers_for_user` filter overrides the available two-factor providers for a specific user. Array values are instances of provider classes and the user object `WP_User` is available as the second argument.
 - `two_factor_enabled_providers_for_user` filter overrides the list of two-factor providers enabled for a user. First argument is an array of enabled provider classnames as values, the second argument is the user ID.
+- `two_factor_fallback_provider_for_user` filter overrides the provider forced on when none of a user's stored two-factor providers are still registered (e.g. after a provider plugin is deactivated). Defaults to `Two_Factor_Email`. First argument is the provider classname, the second is the user ID, the third is the array of provider classnames that were stored for the user but are no longer registered. The returned provider must be registered and available to the user (`is_available_for_user()`), or the user is shown an error instead of being let through with a fallback.
 - `two_factor_user_authenticated` action which receives the logged in `WP_User` object as the first argument for determining the logged in user right after the authentication workflow.
 - `two_factor_user_api_login_enable` filter restricts authentication for REST API and XML-RPC to application passwords only. Provides the user ID as the second argument.
 - `two_factor_email_token_ttl` filter overrides the time interval in seconds that an email token is considered after generation. Accepts the time in seconds as the first argument and the ID of the `WP_User` object being authenticated.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: georgestephanis, kasparsd, masteradhoc, valendesigns, stevenkword, jeffpaul, extendwings, sgrant, aaroncampbell, johnbillion, stevegrunwell, netweb, alihusnainarshad, passoniate
 Tags:         2fa, mfa, totp, authentication, security
 Tested up to: 7.0
-Stable tag:   0.17.0
+Stable tag:   0.16.0
 License:      GPL-2.0-or-later
 License URI:  https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2268,6 +2268,49 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure an intentionally emptied provider list is respected.
+	 *
+	 * @covers Two_Factor_Core::get_available_providers_for_user
+	 */
+	public function test_get_available_providers_for_user_respects_filter_cleared_list() {
+		$user = self::factory()->user->create_and_get();
+
+		update_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Email' ) );
+
+		$filter = function ( $enabled_providers, $user_id ) use ( $user ) {
+			$this->assertSame( $user->ID, $user_id, 'Filter received expected user ID' );
+			return array();
+		};
+
+		add_filter( 'two_factor_enabled_providers_for_user', $filter, 10, 2 );
+
+		try {
+			$this->assertEmpty(
+				Two_Factor_Core::get_available_providers_for_user( $user->ID ),
+				'No fallback provider is forced when the filter intentionally returns an empty list'
+			);
+		} finally {
+			remove_filter( 'two_factor_enabled_providers_for_user', $filter, 10 );
+		}
+	}
+
+	/**
+	 * Ensure fallback still applies when configured providers are no longer registered.
+	 *
+	 * @covers Two_Factor_Core::get_available_providers_for_user
+	 */
+	public function test_get_available_providers_for_user_falls_back_when_configured_providers_are_missing() {
+		$user = self::factory()->user->create_and_get();
+
+		update_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Missing' ) );
+
+		$available = Two_Factor_Core::get_available_providers_for_user( $user->ID );
+
+		$this->assertCount( 1, $available, 'Email fallback remains active when configured providers are missing' );
+		$this->assertArrayHasKey( 'Two_Factor_Email', $available, 'Emailed codes are forced on for missing configured providers' );
+	}
+
+	/**
 	 * Verify process_provider() returns WP_Error when no provider is given.
 	 *
 	 * @covers Two_Factor_Core::process_provider

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2470,6 +2470,34 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure an unregistered `two_factor_fallback_provider_for_user` return value fails closed
+	 * instead of silently letting the user through with no second factor.
+	 *
+	 * @covers Two_Factor_Core::get_available_providers_for_user
+	 */
+	public function test_get_available_providers_for_user_fails_closed_on_invalid_fallback_provider() {
+		$user = self::factory()->user->create_and_get();
+
+		update_user_meta( $user->ID, Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY, array( 'Two_Factor_Missing' ) );
+
+		$filter = function () {
+			return 'Two_Factor_Nonexistent';
+		};
+
+		add_filter( 'two_factor_fallback_provider_for_user', $filter );
+
+		try {
+			$result = Two_Factor_Core::get_available_providers_for_user( $user->ID );
+
+			$this->assertInstanceOf( WP_Error::class, $result, 'An unregistered fallback provider results in a WP_Error' );
+			$this->assertSame( 'no_available_2fa_methods', $result->get_error_code() );
+			$this->assertSame( 'Two_Factor_Nonexistent', $result->get_error_data()['fallback_provider'], 'Error data records the rejected fallback provider' );
+		} finally {
+			remove_filter( 'two_factor_fallback_provider_for_user', $filter );
+		}
+	}
+
+	/**
 	 * Verify process_provider() returns WP_Error when no provider is given.
 	 *
 	 * @covers Two_Factor_Core::process_provider

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -1113,7 +1113,7 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		$totp_disabled     = Two_Factor_Core::disable_provider_for_user( $user->ID, 'Two_Factor_Totp' );
 		$enabled_providers = Two_Factor_Core::get_enabled_providers_for_user( $user->ID );
 		$this->assertTrue( $totp_disabled, 'Can disable a provider that is enabled' );
-		$this->assertSame( array( 1 => 'Two_Factor_Dummy' ), $enabled_providers, 'The other providers are kept enabled' );
+		$this->assertSame( array( 'Two_Factor_Dummy' ), $enabled_providers, 'The other providers are kept enabled' );
 		$this->assertSame( 'Two_Factor_Dummy', Two_Factor_Core::get_primary_provider_for_user( $user->ID )->get_key(), 'Primary is updated to the first available' );
 	}
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, email, and backup verification codes.
  * Requires at least: 6.9
- * Version:           0.16.0
+ * Version:           0.17.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
@@ -27,7 +27,7 @@ if ( ! defined( 'TWO_FACTOR_DIR' ) ) {
 }
 
 if ( ! defined( 'TWO_FACTOR_VERSION' ) ) {
-	define( 'TWO_FACTOR_VERSION', '0.16.0' );
+	define( 'TWO_FACTOR_VERSION', '0.17.0' );
 }
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/two-factor.php
+++ b/two-factor.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/two-factor/
  * Description:       Enable Two-Factor Authentication using time-based one-time passwords, email, and backup verification codes.
  * Requires at least: 6.9
- * Version:           0.17.0
+ * Version:           0.16.0
  * Requires PHP:      7.2
  * Author:            WordPress.org Contributors
  * Author URI:        https://github.com/wordpress/two-factor/graphs/contributors
@@ -27,7 +27,7 @@ if ( ! defined( 'TWO_FACTOR_DIR' ) ) {
 }
 
 if ( ! defined( 'TWO_FACTOR_VERSION' ) ) {
-	define( 'TWO_FACTOR_VERSION', '0.17.0' );
+	define( 'TWO_FACTOR_VERSION', '0.16.0' );
 }
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## What?
 
Partially resolves #871 (see https://github.com/WordPress/two-factor/pull/882#pullrequestreview-4594685069)
 
Reworks the `get_available_providers_for_user()` fail-safe so it only forces emailed codes on when a user's stored providers are genuinely no longer registered — instead of every time the enabled provider list comes back empty.
 
## Why?
 
The fail-safe exists so that a deprecated or removed provider can't silently drop a user to single-factor auth. It fires when `_two_factor_enabled_providers` user meta is non-empty but the resolved enabled list is empty, and forces `Two_Factor_Email` on (or returns a `no_available_2fa_methods` `WP_Error` if Email isn't registered either).
 
The problem is that an empty list has two very different causes, and the old check couldn't tell them apart:
 
| Cause | Correct response |
| --- | --- |
| The user's stored providers are no longer registered | Fail-safe — force Email / `WP_Error` |
| `two_factor_enabled_providers_for_user` deliberately returned `array()` | Respect it — no fallback |
 
The second case was being overridden. A site using the documented filter to intentionally exclude a user from 2FA got emailed codes forced back on, and had no way to express "no providers" through the filter at all — the filter was effectively inert for that value.
 
## How?
 
Before forcing the fallback, intersect the user's stored provider keys against the currently registered providers:
 
```php
$still_registered = array_intersect( (array) $user_providers_raw, array_keys( $providers ) );
 
if ( empty( $still_registered ) ) {
    // ...existing force-Email / WP_Error logic, unchanged.
}
```
 
If any stored provider is still registered, an empty enabled list can only have come from the filter, so it's honoured. If none are, the fail-safe behaves exactly as before.
 
Two points worth flagging for review:
 
**"No longer registered" is deliberately cause-agnostic.** A provider dropped by plugin deactivation, by the site-wide settings option, or by `two_factor_providers_for_user` is treated identically, because the outcome for the user is identical — their configured second factor no longer exists. Note that disabling Email site-wide is already respected without special-casing, via the existing `isset( $providers['Two_Factor_Email'] )` guard: that path falls through to the `WP_Error` rather than forcing a provider the admin turned off.
 
**This intentionally widens a fail-open path.** Cases that previously got Email forced on now return an empty array, which flows into `is_user_using_two_factor()`. That's the intended fix and it's opt-in — a site has to actively clear the list via filter to reach it.
 
## Use of AI Tools 
AI assistance: Yes
Tool(s): Claude
Model(s): Claude Opus 5
Used for: Code review of the existing implementation, and drafting the manual test matrix below. Implementation authored and manually verified by me.
 
## Testing Instructions
 
Use a throwaway site and a second admin account for recovery — several cases deliberately lock a user out. Run logins in a private window.
 
**Setup.** While all providers are still registered, create and configure three users:
 
- `t_email` — Email only
- `t_totp` — Authenticator app only
- `t_both` — both
Add `wp-content/mu-plugins/2fa-test.php`, uncommenting one block at a time:
 
```php
<?php
// BLOCK 1 — deregister providers.
// add_filter( 'two_factor_providers', function ( $providers ) {
//     unset( $providers['Two_Factor_Totp'] );
//     // unset( $providers['Two_Factor_Email'] );
//     return $providers;
// }, 99 );
 
// BLOCK 2 — intentionally clear the enabled list.
// add_filter( 'two_factor_enabled_providers_for_user', function ( $enabled, $user_id ) {
//     return array();
// }, 10, 2 );
```
 
**A. No regressions** (no blocks active)
 
1. Log in as each of `t_email`, `t_totp`, `t_both` — each is prompted for their configured method, `t_both` can switch between them.
**B. Fail-safe still fires**
 
2. Block 1, unset Totp only → log in as `t_totp` → prompted for an **emailed** code.
3. Block 1, unset Totp **and** Email → log in as `t_totp` → refused with the "provider(s) no longer exist" message. Must not reach the dashboard.
4. Block 1, unset Totp only → log in as `t_both` → prompted for an emailed code via the normal path.
**C. The fix** — run each against `master` too, to see the difference
 
5. Block 2 only → log in as `t_email` → **no 2FA prompt**, straight to the dashboard. On `master`: emailed codes forced on.
6. Blocks 1 (unset Totp) + 2 → log in as `t_both` → no prompt. On `master`: emailed codes forced on.
7. Blocks 1 (unset both) + 2 → log in as `t_totp` → refused with the error. Unchanged from `master` — this is the boundary and must **not** flip.
**D. Settings screen behaves identically to the filter**
 
8. Settings → Two-Factor, untick Authenticator app → log in as `t_totp` → emailed code. Matches B2.
9. Untick Authenticator app and Email → log in as `t_totp` → refused. Matches B3.
Watch `debug.log` throughout — no notices, warnings, or fatals, in particular no "Array to string conversion" or `TypeError` from `array_intersect()`.
 
**Note on step 9.** Failing closed here is intended, but an admin unticking every provider in the settings UI receives no warning that configured users are about to be locked out, and recovery means deactivating the plugin over SFTP. That's a pre-existing footgun this PR doesn't introduce or worsen — **this should be discussed.**
 
## Screenshots or screencast
 
No UI changes — behaviour is only observable in the login flow, covered by the steps above.
 
## Changelog Entry
 
> Fixed - `two_factor_enabled_providers_for_user` can once again return an empty array without emailed codes being forced back on. The fail-safe now applies only when none of a user's configured providers are still registered.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22871-fix-regression%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->