### PR TITLE
update .md with latest two-factor changes / requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,10 @@ The plugin follows a provider pattern. `Two_Factor_Core` owns the login intercep
 
 ### Core Files
 
-- **`two-factor.php`** — Entry point. Defines `TWO_FACTOR_DIR` and `TWO_FACTOR_VERSION`, loads all core files, instantiates `Two_Factor_Compat`, and calls `Two_Factor_Core::add_hooks()`.
+- **`two-factor.php`** — Entry point. Defines `TWO_FACTOR_DIR` and `TWO_FACTOR_VERSION`, loads all core files (including the settings class), instantiates `Two_Factor_Compat`, and calls `Two_Factor_Core::add_hooks()`. Also registers the wp-admin settings page (Settings → Two-Factor) and the filter callbacks that enforce the site-wide enabled-providers option (`two_factor_filter_enabled_providers`, `two_factor_filter_enabled_providers_for_user`).
 - **`class-two-factor-core.php`** — Central class. Owns the login flow, user meta, nonce management, rate limiting, session tracking, REST API endpoints, and the user profile settings UI.
 - **`class-two-factor-compat.php`** — Compatibility shims for third-party plugins (currently: Jetpack SSO). New integrations go here; the goal is to avoid any plugin-specific logic outside this file.
+- **`settings/class-two-factor-settings.php`** — `Two_Factor_Settings`, renders the site-wide settings screen (Settings → Two-Factor, requires `manage_options`) where admins choose which providers are available on the site. Saving writes the `two_factor_enabled_providers` option; enforcement happens via the filters registered in `two-factor.php`, not in this class.
 - **`providers/class-two-factor-provider.php`** — Abstract base class all providers extend. Defines the required interface: `get_label()`, `is_available_for_user()`, `authentication_page()`, `validate_authentication()`, and optional hooks for REST routes, settings UI, and uninstall cleanup.
 - **`providers/`** — Concrete providers: `class-two-factor-totp.php`, `class-two-factor-email.php`, `class-two-factor-backup-codes.php`, `class-two-factor-dummy.php`.
 - **`includes/`** — Custom `login_header()` and `login_footer()` template functions that replace the WordPress core versions with additional filter hooks. Excluded from PHPCS because they intentionally deviate from core function signatures. Do not modify files in includes/ directly. They are intentionally kept close to WordPress core function signatures to ease future merging into Core. Any functional changes should go through the filter hooks they expose instead.
@@ -97,6 +98,12 @@ New providers should follow this pattern rather than registering hooks from outs
 | `USER_FAILED_LOGIN_ATTEMPTS_KEY` | `_two_factor_failed_login_attempts` | Failed attempt count |
 | `USER_PASSWORD_WAS_RESET_KEY` | `_two_factor_password_was_reset` | Flags compromised-password reset |
 
+### Key Site Options (constants on `Two_Factor_Core`)
+
+| Constant | Option Key | Purpose |
+|---|---|---|
+| `ENABLED_PROVIDERS_OPTION_KEY` | `two_factor_enabled_providers` | Provider class names enabled site-wide via the settings page; never saved means all providers are allowed. |
+
 ### REST API
 
 Namespace: `two-factor/1.0` (constant `Two_Factor_Core::REST_NAMESPACE`). Each provider that exposes REST endpoints registers its own routes in `register_rest_routes()` called from its constructor.
@@ -104,6 +111,7 @@ Namespace: `two-factor/1.0` (constant `Two_Factor_Core::REST_NAMESPACE`). Each p
 ## Code Standards
 
 - PHP 7.2+ compatibility required; enforced by PHPCompatibilityWP.
+- WordPress 6.9+ required.
 - Follows WordPress coding standards (WPCS) and WordPress-VIP-Go rules.
 - `includes/` is excluded from PHPCS — those files intentionally override core functions.
 - The codebase does not fully pass all PHPCS checks (known issue [#437](https://github.com/WordPress/two-factor/issues/437)). Do not treat existing violations as license to introduce new ones.

--- a/TESTS.md
+++ b/TESTS.md
@@ -24,7 +24,7 @@ Pass PHPUnit arguments through the `composer` wrapper:
 
 ```bash
 # Run a single test class
-npm run composer -- test -- --filter Tests_Two_Factor_Core
+npm run composer -- test -- --filter Test_ClassTwoFactorCore
 
 # Run a single test method
 npm run composer -- test -- --filter test_create_login_nonce
@@ -49,7 +49,7 @@ Smoke tests that the plugin loaded correctly: the `TWO_FACTOR_DIR` constant is d
 
 ### Core — `tests/class-two-factor-core.php`
 
-**Class:** `Tests_Two_Factor_Core` · **Group:** `core`
+**Class:** `Test_ClassTwoFactorCore` · **Group:** `core`
 The largest test file. Covers the full authentication lifecycle managed by `Two_Factor_Core`:
 
 - Hook registration (`add_hooks`)
@@ -58,10 +58,11 @@ The largest test file. Covers the full authentication lifecycle managed by `Two_
 - Login nonce creation, verification, and deletion
 - Rate limiting (`get_user_time_delay`, `is_user_rate_limited`)
 - Session management: two-factor factored vs. non-factored sessions, session destruction on 2FA enable/disable, revalidation
-- Password reset flow (compromise detection, email notifications, reset notices)
+- Password reset flow (compromise detection, email notifications, reset notices and their nonce validation)
 - REST API permission callbacks (`rest_api_can_edit_user_and_update_two_factor_options`)
 - User settings actions (`trigger_user_settings_action`, `current_user_can_update_two_factor_options`)
-- Uninstall cleanup
+- Profile settings UI output (`user_two_factor_options`), including recovery-codes wording with and without the Backup Codes provider
+- Uninstall cleanup (user meta and site-wide options)
 - Filter hooks (`two_factor_providers`, `two_factor_primary_provider_for_user`, `two_factor_user_api_login_enable`)
 
 ### Provider Base Class — `tests/providers/class-two-factor-provider.php`
@@ -158,3 +159,4 @@ Tests `Two_Factor_Dummy_Secure` (a fixture that always _fails_ authentication, u
 
 - **`tests/bootstrap.php`** — Locates the WordPress test library (via `WP_TESTS_DIR` env var, relative path, or `/tmp/wordpress-tests-lib`), loads the plugin via `muplugins_loaded`, then boots the WP test environment.
 - **`tests/class-two-factor-dummy-secure.php`** — Defines `Two_Factor_Dummy_Secure`, a test-only provider class that spoofs the key of `Two_Factor_Dummy` but always fails `validate_authentication`. Used by `Tests_Two_Factor_Dummy_Secure` and some core tests.
+- **`Two_Factor_Redirect_Exception`** — Defined in `tests/class-two-factor-core.php`. The core tests' render helper intercepts `wp_redirect` and throws this exception, so code paths that redirect and `exit` can be tested without terminating the test process.


### PR DESCRIPTION
## What?
Updates `AGENTS.md` and `TESTS.md` to reflect recent changes to the plugin so the internal docs stay in sync with the actual codebase.
Fixes #

## Why?
The two docs had drifted out of date:
- `AGENTS.md` didn't mention the new settings class/page (`Settings → Two-Factor`), the `two-factor.php` registration of the site-wide enabled-providers filters, or the `two_factor_enabled_providers` option and its constant.
- `TESTS.md` referenced an outdated test class name (`Tests_Two_Factor_Core`) instead of the current `Test_ClassTwoFactorCore`, and was missing coverage notes for nonce validation on password-reset notices, profile settings UI output, and site-wide option cleanup on uninstall.

Keeping these contributor-facing docs accurate reduces confusion for anyone (human or AI-assisted) onboarding to the codebase or writing new tests.

## How?
- In `AGENTS.md`: expanded the `two-factor.php` bullet to mention it loads the settings class and registers the enabled-providers filter callbacks; added a new `settings/class-two-factor-settings.php` bullet; added a "Key Site Options" table documenting `ENABLED_PROVIDERS_OPTION_KEY` / `two_factor_enabled_providers`.
- In `TESTS.md`: corrected the test class name from `Tests_Two_Factor_Core` to `Test_ClassTwoFactorCore` in both the command example and class description; added bullets covering password-reset nonce validation, profile settings UI output, and uninstall cleanup of site-wide options.

No functional/code changes — documentation only.

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Claude Sonnet 5
Used for: Drafting the documentation updates to AGENTS.md and TESTS.md; reviewed and edited by me before submission.

## Testing Instructions
This is a documentation-only change with no functional impact. Verify by reading through `AGENTS.md` and `TESTS.md` and confirming they accurately describe the current codebase:
1. Check that the settings page, filter hooks, and `two_factor_enabled_providers` option described in `AGENTS.md` match `two-factor.php` and `settings/class-two-factor-settings.php`.
2. Check that the `Test_ClassTwoFactorCore` class name in `TESTS.md` matches `tests/class-two-factor-core.php`.
3. Confirm `npm run composer -- test -- --filter Test_ClassTwoFactorCore` runs the core test suite correctly.

## Screenshots or screencast
Not applicable — documentation-only change, no UI.

## Changelog Entry
> Development Update - Updated AGENTS.md and TESTS.md to reflect the settings page, enabled-providers option, and corrected test class references.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22md-file-update%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->