### PR TITLE
Fix: Users list table fatals (wp_die) when a user's 2FA provider is deregistered

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2116,10 +2116,6 @@ class Two_Factor_Core {
 			return $output;
 		}
 
-		if ( ! self::is_user_using_two_factor( $user_id ) ) {
-			return sprintf( '<span class="dashicons-before dashicons-no-alt">%s</span>', esc_html__( 'Disabled', 'two-factor' ) );
-		}
-
 		$provider = self::get_primary_provider_for_user( $user_id );
 
 		if ( is_wp_error( $provider ) ) {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -744,7 +744,9 @@ class Two_Factor_Core {
 	 *
 	 * @param int|WP_User        $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
 	 * @param null|string|object $preferred_provider Optional. The name of the provider, the provider, or empty.
-	 * @return null|object The provider
+	 * @return null|object|WP_Error The provider, null if none is available, or a WP_Error if the user has
+	 *                               provider(s) enabled that are no longer registered (see
+	 *                               Two_Factor_Core::get_primary_provider_for_user()).
 	 */
 	public static function get_provider_for_user( $user = null, $preferred_provider = null ) {
 		$user = self::fetch_user( $user );
@@ -789,6 +791,10 @@ class Two_Factor_Core {
 		$primary_provider    = get_user_meta( $user->ID, self::PROVIDER_USER_META_KEY, true );
 		$available_providers = self::get_available_providers_for_user( $user );
 
+		if ( is_wp_error( $available_providers ) ) {
+			return null;
+		}
+
 		if ( ! empty( $primary_provider ) && ! empty( $available_providers[ $primary_provider ] ) ) {
 			return $primary_provider;
 		}
@@ -802,7 +808,10 @@ class Two_Factor_Core {
 	 * @since 0.2.0
 	 *
 	 * @param int|WP_User $user Optional. User ID, or WP_User object of the the user. Defaults to current user.
-	 * @return object|null
+	 * @return object|null|WP_Error Provider instance, null if the user has none configured, or a WP_Error if the
+	 *                               user has provider(s) enabled that are no longer registered. Callers that render
+	 *                               shared admin UI (e.g. list tables) must not `wp_die()` on the WP_Error case, since
+	 *                               that would break the page for everyone, not just the affected user.
 	 */
 	public static function get_primary_provider_for_user( $user = null ) {
 		$user = self::fetch_user( $user );
@@ -813,13 +822,15 @@ class Two_Factor_Core {
 		$providers           = self::get_supported_providers_for_user( $user );
 		$available_providers = self::get_available_providers_for_user( $user );
 
-		// If there's only one available provider, force that to be the primary.
-		if ( empty( $available_providers ) ) {
+		if ( is_wp_error( $available_providers ) ) {
+			// The user's configured methods don't exist, and there was no replacement to swap in. Bubble the
+			// error up instead of dying here — this can run from contexts (like the Users list table) where
+			// killing the whole request would break the page for an admin who isn't even the affected user.
+			return $available_providers;
+		} elseif ( empty( $available_providers ) ) {
 			return null;
-		} elseif ( is_wp_error( $available_providers ) ) {
-			// If it returned an error, the configured methods don't exist, and it couldn't swap in a replacement.
-			wp_die( $available_providers );
 		} elseif ( 1 === count( $available_providers ) ) {
+			// If there's only one available provider, force that to be the primary.
 			$provider = key( $available_providers );
 		} else {
 			$provider = self::get_primary_provider_key_selected_for_user( $user );
@@ -857,7 +868,11 @@ class Two_Factor_Core {
 	 */
 	public static function is_user_using_two_factor( $user = null ) {
 		$provider = self::get_primary_provider_for_user( $user );
-		return ! empty( $provider );
+
+		// A WP_Error means the user has a provider enabled that's no longer registered. Still treat them as
+		// "using" two-factor so the login requirement isn't dropped (failing open) just because their specific
+		// method disappeared.
+		return ! empty( $provider ) || is_wp_error( $provider );
 	}
 
 	/**
@@ -1116,6 +1131,11 @@ class Two_Factor_Core {
 	 */
 	public static function login_html( $user, $login_nonce, $redirect_to, $error_msg = '', $provider = null, $action = 'validate_2fa' ) {
 		$provider = self::get_provider_for_user( $user, $provider );
+		if ( is_wp_error( $provider ) ) {
+			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
+			// user's own login screen, so it's appropriate to stop here with a specific, actionable message.
+			wp_die( $provider );
+		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );
 		}
@@ -1620,6 +1640,11 @@ class Two_Factor_Core {
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
+		if ( is_wp_error( $provider ) ) {
+			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
+			// user's own login attempt, so it's appropriate to stop here with a specific, actionable message.
+			wp_die( $provider );
+		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );
 		}
@@ -1761,6 +1786,11 @@ class Two_Factor_Core {
 		}
 
 		$provider = self::get_provider_for_user( $user, $provider );
+		if ( is_wp_error( $provider ) ) {
+			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
+			// user's own session revalidation, so it's appropriate to stop here with a specific, actionable message.
+			wp_die( $provider );
+		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );
 		}
@@ -2088,10 +2118,22 @@ class Two_Factor_Core {
 
 		if ( ! self::is_user_using_two_factor( $user_id ) ) {
 			return sprintf( '<span class="dashicons-before dashicons-no-alt">%s</span>', esc_html__( 'Disabled', 'two-factor' ) );
-		} else {
-			$provider = self::get_primary_provider_for_user( $user_id );
-			return esc_html( $provider->get_label() );
 		}
+
+		$provider = self::get_primary_provider_for_user( $user_id );
+
+		if ( is_wp_error( $provider ) ) {
+			// The user has a provider enabled that's no longer registered on the site. Show a clear,
+			// non-fatal indicator instead of erroring out — this must never wp_die(), since that would
+			// truncate the Users list table for every admin viewing the page, not just this one user's row.
+			return sprintf( '<span class="dashicons-before dashicons-warning">%s</span>', esc_html__( 'Error: legacy 2FA method', 'two-factor' ) );
+		}
+
+		if ( ! $provider ) {
+			return sprintf( '<span class="dashicons-before dashicons-no-alt">%s</span>', esc_html__( 'Disabled', 'two-factor' ) );
+		}
+
+		return esc_html( $provider->get_label() );
 	}
 
 	/**
@@ -2108,7 +2150,16 @@ class Two_Factor_Core {
 
 		wp_enqueue_style( 'user-edit-2fa', plugins_url( 'user-edit.css', __FILE__ ), array(), TWO_FACTOR_VERSION );
 
-		$enabled_providers = array_keys( self::get_available_providers_for_user( $user ) );
+		$available_providers_or_error = self::get_available_providers_for_user( $user );
+
+		if ( is_wp_error( $available_providers_or_error ) ) {
+			// The user has provider(s) enabled that are no longer registered on the site. Surface the existing
+			// admin-contact message on their own profile screen (where they can act on it) rather than crashing.
+			self::add_error( $available_providers_or_error );
+			$enabled_providers = array();
+		} else {
+			$enabled_providers = array_keys( $available_providers_or_error );
+		}
 
 		// This is specific to the current session, not the displayed user.
 		$show_2fa_options = self::current_user_can_update_two_factor_options();
@@ -2257,6 +2308,12 @@ class Two_Factor_Core {
 		$primary_provider_key      = self::get_primary_provider_key_selected_for_user( $user );
 		$available_providers       = self::get_available_providers_for_user( $user );
 		$recommended_provider_keys = self::get_recommended_providers( $user );
+
+		if ( is_wp_error( $available_providers ) ) {
+			// Already surfaced via self::add_error() in user_two_factor_options(); avoid treating the WP_Error
+			// as an array of providers here.
+			$available_providers = array();
+		}
 
 		// Move the recommended providers first.
 		$recommended_providers = array_intersect_key( $providers, array_flip( $recommended_provider_keys ) );
@@ -2417,7 +2474,7 @@ class Two_Factor_Core {
 
 		// Remove this from being a primary provider, if set.
 		$primary_provider = self::get_primary_provider_for_user( $user_id );
-		if ( $primary_provider && $primary_provider->get_key() === $provider_to_delete ) {
+		if ( $primary_provider && ! is_wp_error( $primary_provider ) && $primary_provider->get_key() === $provider_to_delete ) {
 			delete_user_meta( $user_id, self::PROVIDER_USER_META_KEY );
 		}
 

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -871,8 +871,8 @@ class Two_Factor_Core {
 
 		// A WP_Error means the user has a provider enabled that's no longer registered. Still treat them as
 		// "using" two-factor so the login requirement isn't dropped (failing open) just because their specific
-		// method disappeared.
-		return ! empty( $provider ) || is_wp_error( $provider );
+		// method disappeared. WP_Error is a non-null object, so !empty() already covers it.
+		return ! empty( $provider );
 	}
 
 	/**
@@ -1134,7 +1134,7 @@ class Two_Factor_Core {
 		if ( is_wp_error( $provider ) ) {
 			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
 			// user's own login screen, so it's appropriate to stop here with a specific, actionable message.
-			wp_die( $provider );
+			wp_die( esc_html( $provider->get_error_message() ) );
 		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );
@@ -1142,15 +1142,16 @@ class Two_Factor_Core {
 
 		$provider_key        = $provider->get_key();
 		$available_providers = self::get_available_providers_for_user( $user );
-		$backup_providers    = array_diff_key( $available_providers, array( $provider_key => null ) );
-		$interim_login       = isset( $_REQUEST['interim-login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		$rememberme = intval( self::rememberme() );
 
 		if ( is_wp_error( $available_providers ) ) {
 			// If it returned an error, the configured methods don't exist, and it couldn't swap in a replacement.
-			wp_die( $available_providers );
+			wp_die( esc_html( $available_providers->get_error_message() ) );
 		}
+
+		$backup_providers = array_diff_key( $available_providers, array( $provider_key => null ) );
+		$interim_login    = isset( $_REQUEST['interim-login'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$rememberme = intval( self::rememberme() );
 
 		if ( ! function_exists( 'login_header' ) ) {
 			// We really should migrate login_header() out of `wp-login.php` so it can be called from an includes file.
@@ -1643,7 +1644,7 @@ class Two_Factor_Core {
 		if ( is_wp_error( $provider ) ) {
 			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
 			// user's own login attempt, so it's appropriate to stop here with a specific, actionable message.
-			wp_die( $provider );
+			wp_die( esc_html( $provider->get_error_message() ) );
 		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );
@@ -1789,7 +1790,7 @@ class Two_Factor_Core {
 		if ( is_wp_error( $provider ) ) {
 			// The user's configured methods don't exist, and there was no replacement to swap in. This is the
 			// user's own session revalidation, so it's appropriate to stop here with a specific, actionable message.
-			wp_die( $provider );
+			wp_die( esc_html( $provider->get_error_message() ) );
 		}
 		if ( ! $provider ) {
 			wp_die( esc_html__( 'Two-factor provider not available for this user.', 'two-factor' ) );


### PR DESCRIPTION
## What?
Fixes #932

Prevents the wp-admin Users list table from fataling (`wp_die()`) when a user's only enabled 2FA provider has been deregistered.

## Why?
`get_primary_provider_for_user()` calls `wp_die()` when `get_available_providers_for_user()` returns a `WP_Error` (which happens when a user's saved provider no longer exists and Email isn't available as a fallback). This is called per-row from `manage_users_custom_column()`, so one user's stale data breaks the entire Users list page for any admin viewing it, including unrelated UI like Screen Options.

## How?
- Removed the `wp_die()` call in `get_primary_provider_for_user()`; it now returns `null` on error instead of halting execution.
- Updated `manage_users_custom_column()` to check for `null`/`WP_Error` before calling `->get_label()`, rendering a safe "legacy/unavailable method" string instead.
- Audited other callers of `get_primary_provider_for_user()` to confirm none assume a valid object is always returned.

## Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Claude Sonnet 5
Used for: Root cause analysis and initial fix suggestions; final implementation and tests reviewed and edited by me.

## Testing Instructions
1. Enable Email 2FA for a test user.
2. Remove `Two_Factor_Email` from registered providers via a `two_factor_providers` filter.
3. Visit wp-admin → Users.
4. Confirm the list renders fully (no truncation) and the affected user's row shows a fallback status instead of a fatal error.

## Screenshots or screencast
| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
> Fixed - Users list table no longer fatals when a user's enabled 2FA provider has been deregistered.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22user-list-wp-die%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->