### PR TITLE
Removes three calls to `ReflectionProperty::setAccessible()` / `ReflectionMethod::setAccessible()` in the test suite above PHP 8.1

### DIFF
--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -165,6 +165,9 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	private function reset_profile_errors() {
 		$reflection = new ReflectionClass( Two_Factor_Core::class );
 		$prop       = $reflection->getProperty( 'profile_errors' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$prop->setValue( null, array() );
 	}
 
@@ -2370,6 +2373,9 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		// but capture the original value so it can be restored afterward.
 		$reflection = new ReflectionClass( Two_Factor_Core::class );
 		$prop       = $reflection->getProperty( 'password_auth_tokens' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
 		$original_tokens = $prop->getValue( null );
 
 		try {

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -165,7 +165,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	private function reset_profile_errors() {
 		$reflection = new ReflectionClass( Two_Factor_Core::class );
 		$prop       = $reflection->getProperty( 'profile_errors' );
-		$prop->setAccessible( true );
 		$prop->setValue( null, array() );
 	}
 
@@ -2371,7 +2370,6 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 		// but capture the original value so it can be restored afterward.
 		$reflection = new ReflectionClass( Two_Factor_Core::class );
 		$prop       = $reflection->getProperty( 'password_auth_tokens' );
-		$prop->setAccessible( true );
 		$original_tokens = $prop->getValue( null );
 
 		try {

--- a/tests/providers/class-two-factor-totp.php
+++ b/tests/providers/class-two-factor-totp.php
@@ -454,6 +454,9 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 */
 	private function call_pad_secret( $secret, $length ) {
 		$method = new ReflectionMethod( 'Two_Factor_Totp', 'pad_secret' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 		return $method->invoke( null, $secret, $length );
 	}
 

--- a/tests/providers/class-two-factor-totp.php
+++ b/tests/providers/class-two-factor-totp.php
@@ -454,7 +454,6 @@ class Tests_Two_Factor_Totp extends WP_UnitTestCase {
 	 */
 	private function call_pad_secret( $secret, $length ) {
 		$method = new ReflectionMethod( 'Two_Factor_Totp', 'pad_secret' );
-		$method->setAccessible( true );
 		return $method->invoke( null, $secret, $length );
 	}
 


### PR DESCRIPTION
## What?
Removes three calls to `ReflectionProperty::setAccessible()` / `ReflectionMethod::setAccessible()` for PHP 8.1+ in the test suite.

Fixes #

## Why?
See: https://www.php.net/manual/de/reflectionmethod.setaccessible.php

Since PHP 8.1, reflection properties and methods are accessible without calling `setAccessible( true )`, making the call a no-op. As of PHP 8.5, calling it is deprecated and emits a `PHP Deprecated` notice, which was showing up as noise in test runs (`tests/class-two-factor-core.php:168`, `:2374`, `tests/providers/class-two-factor-totp.php:457`).

`...............................................................  63 / 232 ( 27%)
[23-Jul-2026 20:30:55 UTC] PHP Deprecated:  Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/class-two-factor-core.php on line 168
.......Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/class-two-factor-core.php on line 168
[23-Jul-2026 20:30:55 UTC] PHP Deprecated:  Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/class-two-factor-core.php on line 2398
Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1.Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1...Received a non-notice error: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/class-two-factor-core.php on line 2398
...................................F................ 126 / 232 ( 54%)
............................................................... 189 / 232 ( 81%)
[23-Jul-2026 20:30:57 UTC] PHP Deprecated:  Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/providers/class-two-factor-totp.php on line 457
......................................
Deprecated: Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/wp-content/plugins/two-factor/tests/providers/class-two-factor-totp.php on line 457`

## How?
Deleted the three now-redundant `setAccessible( true )` lines. No behavior change — the reflection objects were already accessible without it.

## Use of AI Tools
-

## Testing Instructions
1. Run the plugin's PHPUnit suite on PHP 8.5.
2. Confirm the `ReflectionProperty::setAccessible() is deprecated` / `ReflectionMethod::setAccessible() is deprecated` notices no longer appear.

## Changelog Entry
> Fixed - Removed deprecated `setAccessible()` calls in the test suite to prevent PHP 8.5 deprecation notices.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22remove-setAccessible%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->