### PR TITLE
PHPSTAN: validate against version 3,4 & 5

### DIFF
--- a/class-two-factor-compat.php
+++ b/class-two-factor-compat.php
@@ -58,6 +58,12 @@ class Two_Factor_Compat {
 	 * @return boolean
 	 */
 	public function jetpack_is_sso_active() {
-		return ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'sso' ) );
+		if ( ! class_exists( 'Jetpack' ) ) {
+			return false;
+		}
+
+		$jetpack_is_module_active = array( 'Jetpack', 'is_module_active' );
+
+		return is_callable( $jetpack_is_module_active ) && (bool) call_user_func( $jetpack_is_module_active, 'sso' );
 	}
 }

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -244,7 +244,7 @@ class Two_Factor_Core {
 		}
 
 		foreach ( $user_meta_keys as $meta_key ) {
-			delete_metadata( 'user', null, $meta_key, null, true );
+			delete_metadata( 'user', 0, $meta_key, '', true );
 		}
 	}
 
@@ -1152,14 +1152,14 @@ class Two_Factor_Core {
 
 		<form name="validate_2fa_form" id="loginform" action="<?php echo esc_url( self::login_url( array( 'action' => $action ), 'login_post' ) ); ?>" method="post" autocomplete="off">
 				<input type="hidden" name="provider"      id="provider"      value="<?php echo esc_attr( $provider_key ); ?>" />
-				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( $user->ID ); ?>" />
+				<input type="hidden" name="wp-auth-id"    id="wp-auth-id"    value="<?php echo esc_attr( (string) $user->ID ); ?>" />
 				<input type="hidden" name="wp-auth-nonce" id="wp-auth-nonce" value="<?php echo esc_attr( $login_nonce ); ?>" />
 				<?php if ( $interim_login ) { ?>
 					<input type="hidden" name="interim-login" value="1" />
 				<?php } else { ?>
 					<input type="hidden" name="redirect_to" value="<?php echo esc_attr( $redirect_to ); ?>" />
 				<?php } ?>
-				<input type="hidden" name="rememberme"    id="rememberme"    value="<?php echo esc_attr( $rememberme ); ?>" />
+				<input type="hidden" name="rememberme"    id="rememberme"    value="<?php echo esc_attr( (string) $rememberme ); ?>" />
 
 				<?php $provider->authentication_page( $user ); ?>
 		</form>

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,7 +1,7 @@
 includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	level: 3
+	level: 4
 	paths:
 		- includes
 		- providers

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,7 +1,7 @@
 includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	level: 2
+	level: 3
 	paths:
 		- includes
 		- providers

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,7 +1,7 @@
 includes:
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	level: 4
+	level: 5
 	paths:
 		- includes
 		- providers

--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -441,7 +441,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		?>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Recovery Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php echo esc_attr( $code_length ); ?>" />
+			<input type="text" inputmode="numeric" name="two-factor-backup-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="<?php echo esc_attr( $code_placeholder ); ?>" data-digits="<?php echo esc_attr( (string) $code_length ); ?>" />
 		</p>
 		<?php
 		/**
@@ -484,7 +484,7 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 	 * @since 0.1-dev
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
-	 * @param int     $code The backup code.
+	 * @param string  $code The backup code.
 	 * @return boolean
 	 */
 	public function validate_code( $user, $code ) {

--- a/providers/class-two-factor-email.php
+++ b/providers/class-two-factor-email.php
@@ -364,7 +364,7 @@ class Two_Factor_Email extends Two_Factor_Provider {
 		?>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Verification Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="two-factor-email-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" autocomplete="one-time-code" placeholder="<?php echo esc_attr( $token_placeholder ); ?>" data-digits="<?php echo esc_attr( $token_length ); ?>" />
+			<input type="text" inputmode="numeric" name="two-factor-email-code" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" autocomplete="one-time-code" placeholder="<?php echo esc_attr( $token_placeholder ); ?>" data-digits="<?php echo esc_attr( (string) $token_length ); ?>" />
 		</p>
 		<?php
 		/** This action is documented in providers/class-two-factor-backup-codes.php */

--- a/providers/class-two-factor-totp.php
+++ b/providers/class-two-factor-totp.php
@@ -532,7 +532,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 * @since 0.8.0
 	 *
 	 * @param WP_User $user WP_User object of the logged-in user.
-	 * @param int     $code The TOTP token to validate.
+	 * @param string  $code The TOTP token to validate.
 	 *
 	 * @return bool Whether the code is valid for the user and a newer code has not been used.
 	 */
@@ -643,7 +643,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 	 */
 	public static function generate_key( $bitsize = self::DEFAULT_KEY_BIT_SIZE ) {
 		$bytes  = ceil( $bitsize / 8 );
-		$secret = wp_generate_password( $bytes, true, true );
+		$secret = wp_generate_password( (int) $bytes, true, true );
 
 		return self::base32_encode( $secret );
 	}
@@ -745,7 +745,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 				( ord( $hash[ $offset + 3 ] ) & 0xff )
 			) % pow( 10, $digits );
 
-		return str_pad( $code, $digits, '0', STR_PAD_LEFT );
+		return str_pad( (string) $code, $digits, '0', STR_PAD_LEFT );
 	}
 
 	/**
@@ -789,7 +789,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		?>
 		<p>
 			<label for="authcode"><?php esc_html_e( 'Authentication Code:', 'two-factor' ); ?></label>
-			<input type="text" inputmode="numeric" name="authcode" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="123 456" autocomplete="one-time-code" data-digits="<?php echo esc_attr( self::DEFAULT_DIGIT_COUNT ); ?>" />
+			<input type="text" inputmode="numeric" name="authcode" id="authcode" class="input authcode" value="" size="20" pattern="[0-9 ]*" placeholder="123 456" autocomplete="one-time-code" data-digits="<?php echo esc_attr( (string) self::DEFAULT_DIGIT_COUNT ); ?>" />
 		</p>
 		<?php
 		/** This action is documented in providers/class-two-factor-backup-codes.php */
@@ -818,7 +818,7 @@ class Two_Factor_Totp extends Two_Factor_Provider {
 		$binary_string = '';
 
 		foreach ( str_split( $input ) as $character ) {
-			$binary_string .= str_pad( base_convert( ord( $character ), 10, 2 ), 8, '0', STR_PAD_LEFT );
+			$binary_string .= str_pad( base_convert( (string) ord( $character ), 10, 2 ), 8, '0', STR_PAD_LEFT );
 		}
 
 		$five_bit_sections = str_split( $binary_string, 5 );

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -37,7 +37,14 @@ class Two_Factor_Settings {
 			// Sanitize posted values immediately.
 			$posted = array_map( 'sanitize_text_field', (array) $posted );
 			// Remove empty values.
-			$enabled = array_values( array_filter( $posted, 'strlen' ) );
+			$enabled = array_values(
+				array_filter(
+					$posted,
+					static function ( $value ) {
+						return '' !== $value;
+					}
+				)
+			);
 
 			update_option( Two_Factor_Core::ENABLED_PROVIDERS_OPTION_KEY, array_values( array_unique( $enabled ) ) );
 

--- a/two-factor.php
+++ b/two-factor.php
@@ -106,7 +106,7 @@ function two_factor_render_settings_page() {
 	}
 
 	// Prefer new settings class (keeps main file small).
-	if ( class_exists( 'Two_Factor_Settings' ) && is_callable( array( 'Two_Factor_Settings', 'render_settings_page' ) ) ) {
+	if ( class_exists( 'Two_Factor_Settings' ) ) {
 		Two_Factor_Settings::render_settings_page();
 		return;
 	}


### PR DESCRIPTION
## What?
Raise PHPStan baseline in this branch from level 4 to level 5 and fix all resulting level 5 findings so the full repository passes static analysis and lint checks.

## Why?
The plugin already passed at level 2, but level 3,4 & 5 surfaced stricter type-safety issues (mostly scalar typing around escaping and auth-code handling). Fixing these now improves type correctness, keeps CI healthier as rules tighten, and reduces future refactor risk.

## How?
This PR updates the PHPStan level and applies targeted, behavior-preserving type fixes

## Use of AI Tools
AI assistance: Yes  
Tool(s): GitHub Copilot  
Model(s): GPT-5.3-Codex  
Used for: Static analysis triage, proposing and applying type-safety fixes, and drafting PR documentation.  
Human review: All generated changes were reviewed and validated through local lint/static-analysis runs.

## Testing Instructions
1. Install dependencies:
npm install

2. Run full lint suite:
npm run lint

3. Run PHPStan directly with repo config:
vendor/bin/phpstan analyse -c phpstan.dist.neon --memory-limit=1G

4. Optional explicit level check:
vendor/bin/phpstan analyse -c phpstan.dist.neon --level=5 --memory-limit=1G

Expected result:
- All commands complete successfully.
- PHPStan reports OK with no errors.

## Screenshots or screencast
Not applicable (no UI behavior change).

| Before | After |
| ------ | ----- |
| PHPStan level 5 reported 14 errors across core/providers/settings | PHPStan level 5 reports no errors |

## Changelog Entry
> Development Update - Raise PHPStan to level 5 and resolve level 5 type-safety findings across core and providers.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22phpstan-v3%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->