### PR TITLE
Phpcs reduce ignores

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -533,6 +533,7 @@ class Two_Factor_Core {
 	 * Check if a user action is valid.
 	 *
 	 * @since 0.5.2
+	 * @deprecated x.x.x Use two_factor_is_valid_user_action() instead.
 	 *
 	 * @param integer $user_id User ID.
 	 * @param string  $action User action ID.
@@ -540,21 +541,8 @@ class Two_Factor_Core {
 	 * @return boolean
 	 */
 	public static function is_valid_user_action( $user_id, $action ) {
-		$request_nonce_raw = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) ? wp_unslash( $_REQUEST[ self::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value sanitized and then only passed to wp_verify_nonce().
-		if ( ! is_scalar( $request_nonce_raw ) ) {
-			$request_nonce = '';
-		} else {
-			$request_nonce = sanitize_text_field( (string) $request_nonce_raw );
-		}
-
-		if ( ! $user_id || ! $action || ! $request_nonce ) {
-			return false;
-		}
-
-		return wp_verify_nonce(
-			$request_nonce,
-			sprintf( '%d-%s', $user_id, $action )
-		);
+		_deprecated_function( __FUNCTION__, 'x.x.x', 'two_factor_is_valid_user_action' );
+		return two_factor_is_valid_user_action( $user_id, $action );
 	}
 
 	/**
@@ -586,11 +574,12 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function trigger_user_settings_action() {
-		$action_raw = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) ? wp_unslash( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value sanitized below; nonce verified in is_valid_user_action() before do_action.
-		$action     = ( is_scalar( $action_raw ) && '' !== (string) $action_raw ) ? sanitize_key( (string) $action_raw ) : '';
-		$user_id    = self::current_user_being_edited();
+		$action  = isset( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) && is_scalar( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] )
+			? sanitize_key( wp_unslash( $_REQUEST[ self::USER_SETTINGS_ACTION_QUERY_VAR ] ) )
+			: '';
+		$user_id = self::current_user_being_edited();
 
-		if ( self::is_valid_user_action( $user_id, $action ) ) {
+		if ( two_factor_is_valid_user_action( $user_id, $action ) ) {
 			/**
 			 * This action is triggered when a valid Two Factor settings
 			 * action is detected and it passes the nonce validation.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2500,11 +2500,10 @@ class Two_Factor_Core {
 				return;
 			}
 
-			$user                    = self::fetch_user( $user_id );
-			$providers               = self::get_supported_providers_for_user( $user_id );
-			$enabled_providers_input = wp_unslash( $_POST[ self::ENABLED_PROVIDERS_USER_META_KEY ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Array values are sanitized below.
-			$enabled_providers       = array_map( 'sanitize_text_field', $enabled_providers_input );
-			$existing_providers      = self::get_enabled_providers_for_user( $user_id );
+			$user               = self::fetch_user( $user_id );
+			$providers          = self::get_supported_providers_for_user( $user_id );
+			$enabled_providers  = array_map( 'sanitize_text_field', wp_unslash( $_POST[ self::ENABLED_PROVIDERS_USER_META_KEY ] ) );
+			$existing_providers = self::get_enabled_providers_for_user( $user_id );
 
 			// Enable only the available providers.
 			$enabled_providers = array_intersect_key( $providers, array_flip( $enabled_providers ) );

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -2532,7 +2532,7 @@ class Two_Factor_Core {
 			update_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, array_keys( $enabled_providers ) );
 
 			// Primary provider must be enabled.
-			$new_provider = isset( $_POST[ self::PROVIDER_USER_META_KEY ] ) ? sanitize_text_field( wp_unslash( $_POST[ self::PROVIDER_USER_META_KEY ] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Value sanitized inline.
+			$new_provider = isset( $_POST[ self::PROVIDER_USER_META_KEY ] ) ? sanitize_text_field( wp_unslash( $_POST[ self::PROVIDER_USER_META_KEY ] ) ) : '';
 			if ( ! empty( $new_provider ) && isset( $enabled_providers[ $new_provider ] ) ) {
 				update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, $new_provider );
 			} else {

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -1743,10 +1743,24 @@ class Two_Factor_Core {
 	 * @since 0.9.0
 	 */
 	public static function login_form_revalidate_2fa() {
-		$nonce           = ( isset( $_REQUEST['wp-auth-nonce'] ) && is_scalar( $_REQUEST['wp-auth-nonce'] ) ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['wp-auth-nonce'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in revalidate_login_form_2fa() for POST before processing.
-		$provider        = ! empty( $_REQUEST['provider'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in revalidate_login_form_2fa() for POST before processing.
-		$redirect_to     = ! empty( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : admin_url(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in revalidate_login_form_2fa() for POST before processing.
-		$is_post_request = isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( $_SERVER['REQUEST_METHOD'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- REQUEST_METHOD is not user input.
+		$nonce       = ( isset( $_REQUEST['wp-auth-nonce'] ) && is_scalar( $_REQUEST['wp-auth-nonce'] ) ) ? sanitize_text_field( wp_unslash( (string) $_REQUEST['wp-auth-nonce'] ) ) : '';
+		$provider    = ! empty( $_REQUEST['provider'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : false;
+		$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : admin_url();
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- false report due to strtoupper.
+		$is_post_request = isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'];
+
+		if ( ! is_user_logged_in() ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
+
+		$user = wp_get_current_user();
+
+		// Validate the nonce for POST requests. GET requests do not perform actions, and such do not require the nonce (such as the initial request).
+		if ( $is_post_request && ! wp_verify_nonce( $nonce, 'two_factor_revalidate_' . $user->ID ) ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
 
 		self::revalidate_login_form_2fa( $nonce, $provider, $redirect_to, $is_post_request );
 		exit;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -40,6 +40,15 @@
 		<exclude-pattern>tests/providers/*.php</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.Security.NonceVerification">
+		<properties>
+			<property name="customNonceVerificationFunctions" type="array">
+				<element value="two_factor_is_valid_user_action"/>
+			</property>
+		</properties>
+	</rule>
+
+
 	<exclude-pattern>*/wordpress/*</exclude-pattern>
 	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/includes/*</exclude-pattern>

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -32,10 +32,10 @@ class Two_Factor_Settings {
 		if ( isset( $_POST['two_factor_settings_submit'] ) ) {
 			check_admin_referer( 'two_factor_save_settings', 'two_factor_settings_nonce' );
 
-			$posted = isset( $_POST['two_factor_enabled_providers'] ) && is_array( $_POST['two_factor_enabled_providers'] ) ? wp_unslash( $_POST['two_factor_enabled_providers'] ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verified above; array values sanitized immediately below.
+			$posted = isset( $_POST['two_factor_enabled_providers'] ) && is_array( $_POST['two_factor_enabled_providers'] )
+				? array_map( 'sanitize_text_field', wp_unslash( $_POST['two_factor_enabled_providers'] ) )
+				: array();
 
-			// Sanitize posted values immediately.
-			$posted = array_map( 'sanitize_text_field', (array) $posted );
 			// Remove empty values.
 			$enabled = array_values( array_filter( $posted, 'strlen' ) );
 

--- a/tests/class-two-factor-core.php
+++ b/tests/class-two-factor-core.php
@@ -2033,29 +2033,29 @@ class Test_ClassTwoFactorCore extends WP_UnitTestCase {
 	/**
 	 * Test is_valid_user_action validates actions correctly.
 	 *
-	 * @covers Two_Factor_Core::is_valid_user_action
+	 * @covers two_factor_is_valid_user_action
 	 */
 	public function test_is_valid_user_action() {
 		$user_id = self::factory()->user->create();
 		$action  = 'test_action';
 
 		// Test without nonce.
-		$this->assertFalse( Two_Factor_Core::is_valid_user_action( $user_id, $action ), 'Action is invalid without nonce' );
+		$this->assertFalse( two_factor_is_valid_user_action( $user_id, $action ), 'Action is invalid without nonce' );
 
 		// Test with invalid nonce.
 		$_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] = 'invalid_nonce';
-		$this->assertFalse( Two_Factor_Core::is_valid_user_action( $user_id, $action ), 'Action is invalid with wrong nonce' );
+		$this->assertFalse( two_factor_is_valid_user_action( $user_id, $action ), 'Action is invalid with wrong nonce' );
 
 		// Test with valid nonce.
 		$nonce = wp_create_nonce( sprintf( '%d-%s', $user_id, $action ) );
 		$_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] = $nonce;
-		$this->assertNotFalse( Two_Factor_Core::is_valid_user_action( $user_id, $action ), 'Action is valid with correct nonce' );
+		$this->assertNotFalse( two_factor_is_valid_user_action( $user_id, $action ), 'Action is valid with correct nonce' );
 
 		// Test with missing user_id.
-		$this->assertFalse( Two_Factor_Core::is_valid_user_action( 0, $action ), 'Action is invalid without user ID' );
+		$this->assertFalse( two_factor_is_valid_user_action( 0, $action ), 'Action is invalid without user ID' );
 
 		// Test with missing action.
-		$this->assertFalse( Two_Factor_Core::is_valid_user_action( $user_id, '' ), 'Action is invalid without action name' );
+		$this->assertFalse( two_factor_is_valid_user_action( $user_id, '' ), 'Action is invalid without action name' );
 
 		// Cleanup.
 		unset( $_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] );

--- a/two-factor.php
+++ b/two-factor.php
@@ -187,3 +187,28 @@ function two_factor_filter_enabled_providers_for_user( $enabled, $user_id ) { //
 
 	return array_values( array_intersect( (array) $enabled, $site_enabled ) );
 }
+
+/**
+ * Check if a user action is valid.
+ *
+ * @since 0.5.2
+ *
+ * @param integer $user_id User ID.
+ * @param string  $action User action ID.
+ *
+ * @return boolean
+ */
+function two_factor_is_valid_user_action( $user_id, $action ) {
+	$request_nonce = isset( $_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) && is_scalar( $_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] )
+		? sanitize_text_field( wp_unslash( $_REQUEST[ Two_Factor_Core::USER_SETTINGS_ACTION_NONCE_QUERY_ARG ] ) )
+		: '';
+
+	if ( ! $user_id || ! $action || ! $request_nonce ) {
+		return false;
+	}
+
+	return wp_verify_nonce(
+		$request_nonce,
+		sprintf( '%d-%s', $user_id, $action )
+	);
+}

--- a/two-factor.php
+++ b/two-factor.php
@@ -140,7 +140,7 @@ function two_factor_get_enabled_providers_option() {
  * This filter receives providers in core format: classname => path.
  *
  * @since 0.16
- * 
+ *
  * @param array $providers Registered providers in classname => path format.
  * @return array Filtered list of enabled providers.
  */
@@ -153,8 +153,8 @@ function two_factor_filter_enabled_providers( $providers ) {
 	}
 
 	// On the settings page itself, show all providers so admins can change the selection.
-	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the current admin page slug only; no state change occurs here.
-	if ( is_admin() && 'two-factor-settings' === $page ) {
+	$current_screen = is_admin() ? get_current_screen() : false;
+	if ( $current_screen && 'settings_page_two-factor-settings' === $current_screen->base ) {
 		return $providers;
 	}
 


### PR DESCRIPTION
## What?

Reducing `phpcs:ignore` and `phpcs:disable` instances.

<!-- Please reference the issue this PR fixes -->
Fixes #

## Why?

It's not unknown that these come back cause problems later as code is removed.

## How?

Modifies code to remove the need where possible.

Commonly:

* moves sanitization to run early
* moves nonce checks to run alongside form input. They're cheap so can be duplicated if needs be.



## Use of AI Tools

N/A

## Testing Instructions

TBA once this comes out of draft.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
> Development Update - Improve compliance with WordPress Coding Standards.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22phpcs-reduce-ignores%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->