### PR TITLE
Fix empty backup code when appending codes for a user with none

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -317,7 +317,8 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 
 		// Append or replace (default).
 		if ( isset( $args['method'] ) && 'append' === $args['method'] ) {
-			$codes_hashed = (array) get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+			$existing     = get_user_meta( $user->ID, self::BACKUP_CODES_META_KEY, true );
+			$codes_hashed = is_array( $existing ) ? $existing : array();
 		}
 
 		$code_length = $this->get_backup_code_length( $user );

--- a/tests/providers/class-two-factor-backup-codes.php
+++ b/tests/providers/class-two-factor-backup-codes.php
@@ -202,6 +202,33 @@ class Tests_Two_Factor_Backup_Codes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify appending codes for a user with no existing codes does not store an empty entry.
+	 *
+	 * @covers Two_Factor_Backup_Codes::generate_codes
+	 * @covers Two_Factor_Backup_Codes::codes_remaining_for_user
+	 */
+	public function test_generate_codes_append_with_no_existing_codes() {
+		$user = new WP_User( self::factory()->user->create() );
+
+		$codes = $this->provider->generate_codes(
+			$user,
+			array(
+				'number' => Two_Factor_Backup_Codes::NUMBER_OF_CODES,
+				'method' => 'append',
+			)
+		);
+
+		$this->assertCount( Two_Factor_Backup_Codes::NUMBER_OF_CODES, $codes );
+
+		$backup_codes = get_user_meta( $user->ID, Two_Factor_Backup_Codes::BACKUP_CODES_META_KEY, true );
+
+		$this->assertIsArray( $backup_codes );
+		$this->assertCount( Two_Factor_Backup_Codes::NUMBER_OF_CODES, $backup_codes );
+		$this->assertNotContains( '', $backup_codes );
+		$this->assertEquals( Two_Factor_Backup_Codes::NUMBER_OF_CODES, $this->provider->codes_remaining_for_user( $user ) );
+	}
+
+	/**
 	 * Test backup code length filter.
 	 */
 	public function test_backup_code_length_filter() {


### PR DESCRIPTION
## What?
Generating backup codes with `'method' => 'append'` for a user who has no existing codes no longer stores an extra, empty code that can never be validated or removed.

Fixes #956

## Why?
`generate_codes()` cast `get_user_meta( ..., true )` directly to an array. For a user with no stored codes that meta value is `''`, and `(array) ''` evaluates to `array( '' )` rather than an empty array, so an empty string was permanently appended ahead of the real hashes. `codes_remaining_for_user()` then reports one more code than the user actually holds, causing two problems:

- A user with zero usable codes is still offered recovery codes at login.
- The low-codes warning reports one code too many.

## How?
Replaced the bare `(array)` cast with an `is_array()` guard before assigning the existing hashes, matching the pattern already used by `codes_remaining_for_user()` and `validate_code()`. Added a regression test for the append-with-no-existing-codes case.

## Use of AI Tools
AI assistance: Yes
Tool(s): OpenCode
Model(s): deepseek-v4-pro
Used for: Root-cause analysis, fix implementation, and test authoring; the final diff and validation were reviewed by the contributor.

## Testing Instructions
1. `npm run composer -- test -- --filter Tests_Two_Factor_Backup_Codes`
2. `npm test` (full suite)
3. Manual reproduction from the issue:

```php
$user  = get_user_by( 'login', 'someone' ); // no backup codes yet
$codes = Two_Factor_Backup_Codes::get_instance()->generate_codes( $user, array( 'method' => 'append' ) );

count( $codes );                                              // 10
count( get_user_meta( $user->ID, '_two_factor_backup_codes', true ) ); // 10 (was 11)
Two_Factor_Backup_Codes::codes_remaining_for_user( $user );   // 10 (was 11)
```

## Screenshots or screencast
Not applicable (no UI changes).

## Changelog Entry
> Fixed - Generating backup codes with the `append` method no longer stores an empty entry for users with no existing codes.
