### PR TITLE
Use site host in backup codes download title

### DIFF
--- a/providers/class-two-factor-backup-codes.php
+++ b/providers/class-two-factor-backup-codes.php
@@ -358,8 +358,18 @@ class Two_Factor_Backup_Codes extends Two_Factor_Provider {
 		$title = sprintf(
 			/* translators: %s: the site's domain */
 			__( 'Two-Factor Recovery Codes for %s', 'two-factor' ),
-			home_url( '/' )
+			wp_parse_url( home_url(), PHP_URL_HOST )
 		);
+
+		/**
+		 * Filters the title in the backup codes download file.
+		 *
+		 * @since 0.17.0
+		 *
+		 * @param string  $title Title for the backup codes download file.
+		 * @param WP_User $user  User for whom the backup codes were generated.
+		 */
+		$title = apply_filters( 'two_factor_backup_codes_download_title', $title, $user );
 
 		// Generate download content.
 		$download_link  = 'data:application/text;charset=utf-8,';

--- a/tests/providers/class-two-factor-backup-codes-rest-api.php
+++ b/tests/providers/class-two-factor-backup-codes-rest-api.php
@@ -88,6 +88,36 @@ class Tests_Two_Factor_Backup_Codes_REST_API extends WP_Test_REST_TestCase {
 		$this->assertCount( 10, $data['codes'] );
 		$this->assertTrue( self::$provider->validate_code( wp_get_current_user(), $data['codes'][0] ) );
 		$this->assertStringContainsString( $data['codes'][0], $data['download_link'] );
+		$this->assertStringContainsString( 'Two-Factor Recovery Codes for example.org', rawurldecode( $data['download_link'] ) );
+		$this->assertStringNotContainsString( home_url(), rawurldecode( $data['download_link'] ) );
+	}
+
+	/**
+	 * Verify that the download title can be filtered.
+	 *
+	 * @covers Two_Factor_Backup_Codes::rest_generate_codes
+	 */
+	public function test_download_file_title_can_be_filtered() {
+		wp_set_current_user( self::$admin_id );
+		$filter = static function () {
+			return 'Custom recovery codes title';
+		};
+		add_filter( 'two_factor_backup_codes_download_title', $filter );
+
+		$request = new WP_REST_Request( 'POST', '/' . Two_Factor_Core::REST_NAMESPACE . '/generate-backup-codes' );
+		$request->set_body_params(
+			array(
+				'user_id' => self::$admin_id,
+			)
+		);
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		remove_filter( 'two_factor_backup_codes_download_title', $filter );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertStringContainsString( 'Custom recovery codes title', rawurldecode( $data['download_link'] ) );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Use the site's host instead of its full URL in the heading of downloaded backup-code files, and make the heading filterable.

Fixes #957

## Why?

The current heading includes the scheme and path from `home_url( '/' )`, which makes the recovery-code file contain a directly usable target URL. The host alone still identifies the site while matching the existing translator comment and avoiding unnecessary URL details.

## How?

- Parse the host from `home_url()` with `wp_parse_url()`.
- Add the `two_factor_backup_codes_download_title` filter, including the generated title and user as arguments.
- Add REST API regression coverage confirming that the download contains the host but not the full home URL and that the title can be filtered.

## Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: Investigating the issue, implementing the change, adding tests, and running validation. The resulting diff was reviewed before submission.

## Testing Instructions

1. Generate backup codes for a user through the REST API or user profile.
2. Download the recovery-code file.
3. Confirm its heading contains only the site's host, without the URL scheme or path.
4. Add a callback to `two_factor_backup_codes_download_title`, generate codes again, and confirm the custom heading appears.

Validation performed:

- PHP syntax checks passed for both changed files.
- PHPCS passed for both changed files.
- PHPStan passed for the changed provider.
- `git diff --check` passed.
- The full PHPUnit suite was not run because the required Docker environment was unavailable.

## Changelog Entry

> Fixed - Use the site host instead of the full URL in backup-code download headings and allow the heading to be filtered.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22fix%2F957-backup-codes-identify-site-by-host%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->