### PR TITLE
Unbreak CI: PHPStan false positive and matrix fail-fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,20 +79,30 @@ jobs:
         permissions:
           contents: read # Required to clone the repo.
         strategy:
-            # One broken leg should not cancel the other 27. Notably, the PHP 7.4/8.0/8.1
-            # images are Debian bullseye based, and bullseye's security suite is now past
-            # its Release file expiry, so `apt-get update` exits 100 while building those
-            # containers. Without this, that single failure hides every other result.
+            # One broken leg should not cancel the rest of the matrix and hide every
+            # other result.
             fail-fast: false
             matrix:
+                # PHP 7.4 and 8.0 cannot be run here any more. wp-env builds from
+                # `wordpress:php<version>`, and those two tags were last rebuilt in 2022
+                # and 2023 respectively, permanently pinned to Debian bullseye. Bullseye
+                # LTS ended 2026-08-31, so its security Release file is now expired and
+                # the `apt-get -qy update` in wp-env's generated Dockerfile exits 100
+                # before a single test runs. No bookworm image exists for either version,
+                # and wp-env hardcodes both the base image and that apt call, so there is
+                # nothing to configure our way out of.
+                #
+                # NOTE: PHP 7.4 is still this plugin's declared minimum ("Requires PHP" in
+                # two-factor.php, `>=7.4` in composer.json). It remains covered statically
+                # by PHPCompatibilityWP via `testVersion 7.4-` in phpcs.xml.dist, but it
+                # is no longer exercised at runtime. 8.1 is now the lowest version we
+                # actually run the suite against.
                 php:
                   - '8.5'
                   - '8.4'
                   - '8.3'
                   - '8.2'
                   - '8.1'
-                  - '8.0'
-                  - '7.4'
                 wp:
                   - latest
                   - wordpress/wordpress

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,11 @@ jobs:
         permissions:
           contents: read # Required to clone the repo.
         strategy:
+            # One broken leg should not cancel the other 27. Notably, the PHP 7.4/8.0/8.1
+            # images are Debian bullseye based, and bullseye's security suite is now past
+            # its Release file expiry, so `apt-get update` exits 100 while building those
+            # containers. Without this, that single failure hides every other result.
+            fail-fast: false
             matrix:
                 php:
                   - '8.5'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 name: Test
 
-on: [push, pull_request]
+# Pushing to a branch that has an open PR previously triggered this workflow twice: once
+# for `push` and once for `pull_request`. The concurrency group below cannot collapse the
+# pair, because it deliberately keys pull requests on the branch name and everything else
+# on the commit hash, putting the two runs in different groups. Limiting `push` to the
+# default branch leaves pull requests covered by the `pull_request` event alone, while
+# still running the suite on merges to master.
+on:
+    push:
+        branches:
+            - master
+    pull_request:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:


### PR DESCRIPTION
## Why

Every pull request currently looks broken, and for reasons that have nothing to do with the code being proposed. This fixes the workflow itself.

PHPStan was the fourth cause, but #972 handles that one properly — by upgrading PHPStan and dropping `includes/` from the analysed paths, matching the `*/includes/*` exclusion that already exists in `phpcs.xml.dist`. That's a better fix than the scoped ignore this PR originally carried, so it has been removed here. **This PR is now purely workflow changes**; #972 keeps the PHPStan fix.

The two are complementary. #972 can't go green on its own — its only failing leg is `Test PHP 7.4`, with the other 27 cancelled, which is exactly what's fixed below. Landing this first should unblock it.

## What

### 1. One failing leg no longer cancels the other 27

The matrix ran with the default `fail-fast: true`. A single failure cancelled every other job, so 28 jobs reported as 1 failure + 27 cancelled and nothing usable came back. Now `fail-fast: false`.

### 2. PHP 7.4 and 8.0 removed from the matrix

These cannot be run any more, and it isn't a transient breakage.

`wp-env` builds its container from `wordpress:php<version>`, and:

| Tag | Last rebuilt | Base |
| --- | --- | --- |
| `wordpress:php7.4-fpm` | 2022-11-16 | bullseye |
| `wordpress:php8.0-fpm` | 2023-11-22 | bullseye |
| `wordpress:php8.1-fpm` | 2026-01-01 | bookworm |
| `wordpress:php8.4-fpm` | 2026-08-31 | bookworm |

Debian bullseye LTS ended **2026-08-31**. Its security `Release` file is now expired, so the `apt-get -qy update` in wp-env's generated Dockerfile exits 100 before a single test runs. No bookworm image exists for 7.4 or 8.0 — both reached EOL before bookworm shipped — and wp-env hardcodes both the base image (`lib/runtime/docker/docker-config.js:83`) and that apt call (line 167), with no configuration hook for either. Verified against wp-env 11.14.0; this repo pins `^10.30.0`.

8.1 is bookworm and passes, so it becomes the lowest version actually exercised.

**Note:** PHP 7.4 is still the declared minimum (`Requires PHP` in `two-factor.php`, `>=7.4` in `composer.json`). It stays covered statically by PHPCompatibilityWP via `testVersion 7.4-`, but it is no longer exercised at runtime. Whether to raise the floor to 8.1 is a support-policy decision and deliberately isn't made here.

### 3. The suite ran twice for every pull request

`on: [push, pull_request]` fired both events for any push to a branch with an open PR. The concurrency group can't collapse them:

```yaml
group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
```

Pull requests key on branch name, everything else on commit SHA — so the two runs land in different groups and neither cancels the other, and the push key is unique per push so it never matches anything at all. The result was two full 20-job matrices per push.

`push` is now scoped to `master`, leaving pull requests covered by `pull_request` alone while still running the suite on merges. Manual re-runs are unaffected.

It demonstrated itself on its own commit:

| Commit | Events fired |
| --- | --- |
| `0b87b39` (matrix change) | `push` **+** `pull_request` |
| `b835d49` (trigger fix) | `pull_request` only |

## Testing

Full matrix green before the PHPStan commit was dropped: 23/23 jobs passing — 20 test legs (PHP 8.1–8.5 × 4 WordPress versions), Lint PHP & PHP Compatibility, Lint JS & CSS, Build.

This revision only removes a `phpstan.dist.neon` hunk; `git diff origin/master..HEAD` now touches `.github/workflows/test.yml` and nothing else.
