### PR TITLE
Fix TOTP verify button after resetting authenticator app

### DIFF
--- a/providers/js/totp-admin.js
+++ b/providers/js/totp-admin.js
@@ -38,7 +38,7 @@
 		} );
 	}
 
-	$( '.totp-submit' ).click( function( e ) {
+	$( '#two-factor-totp-options' ).on( 'click', '.totp-submit', function( e ) {
 		var key = $( '#two-factor-totp-key' ).val(),
 			code = $( '#two-factor-totp-authcode' ).val();
 
@@ -71,7 +71,7 @@
 		} );
 	} );
 
-	$( '.button.reset-totp-key' ).click( function( e ) {
+	$( '#two-factor-totp-options' ).on( 'click', '.button.reset-totp-key', function( e ) {
 		e.preventDefault();
 
 		wp.apiRequest( {


### PR DESCRIPTION
## What?
Clicking "Reset authenticator app" replaces the contents of #two-factor-totp-options via AJAX, but the click handlers for .totp-submit and .button.reset-totp-key were bound directly to elements present at page load. The new "Verify" button never got those handlers, so clicking it fell back to a native form submit instead of the AJAX request, triggering the browser's unsaved changes prompt.

Fixes #978

## Why?
Making sure users can easily switch authenticator app.

## How?
Delegate both handlers off the persistent #two-factor-totp-options container so they keep working after its contents are replaced.

## Use of AI Tools
AI assistance: Yes
Tool: Claude code
Model: Sonnet 5
Used for: Initial finding of what code triggered the bug, wording on issue.

## Testing Instructions
1. Go to your user profile screen with TOTP already enabled.
2. Click "Reset authenticator app" (this AJAX-resets the key and re-renders a fresh QR code + form via wp.apiRequest).
3. Enter a valid code from your authenticator app in the new "Authentication Code" field.
4. Click "Verify" immediately (no page reload in between).

Before this PR it wouldn't work, with this PR it works.

## Changelog Entry
Fixed – Clicking TOTP verify button after resetting authenticator app

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.2%22%2C%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22git%3Adirectory%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Ftwo-factor.git%22%2C%22ref%22%3A%22fix-978%22%2C%22path%22%3A%22%2F%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->